### PR TITLE
[RFC][SV/HW] Split to `sv.net` and `sv.var` lvalue types from `hw.inout` (Phases 1, 2, 3, 5, 6)

### DIFF
--- a/include/circt/Dialect/HW/HWMiscOps.td
+++ b/include/circt/Dialect/HW/HWMiscOps.td
@@ -118,6 +118,50 @@ def WireOp : HWOp<"wire", [
   }];
 }
 
+def VarOp : HWOp<"var", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+    DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
+  let summary = "A generic, category-neutral addressable storage declaration";
+  let description = [{
+    Declares a piece of generic lvalue storage. Unlike `hw.wire`, which is
+    value-semantic, `hw.var` produces an `!hw.inout<T>` result, an lvalue
+    that downstream dialects (e.g. SV) can resolve into a concrete net or
+    variable. 
+
+    Example:
+    ```mlir
+    %0 = hw.var : !hw.inout<i42>
+    %1 = hw.var sym @mySym : !hw.inout<i42>
+    %2 = hw.var name "myVar" : !hw.inout<i42>
+    ```
+  }];
+
+  let arguments = (ins OptionalAttr<StrAttr>:$name,
+                       OptionalAttr<InnerSymAttr>:$inner_sym);
+  let results = (outs InOutType:$result);
+
+  let hasCanonicalizeMethod = 1; 
+
+  let builders = [
+    OpBuilder<(ins "mlir::Type":$elementType,
+                   CArg<"const StringAttrOrRef &", "{}">:$name,
+                   CArg<"hw::InnerSymAttr", "{}">:$innerSym), [{
+      auto *context = odsBuilder.getContext();
+      if (auto attr = name.get(context))
+        odsState.addAttribute(getNameAttrName(odsState.name), attr);
+      if (innerSym)
+        odsState.addAttribute(getInnerSymAttrName(odsState.name), innerSym);
+      odsState.addTypes(hw::InOutType::get(elementType));
+    }]>
+  ];
+
+  let assemblyFormat = [{
+    (`sym` $inner_sym^)? custom<ImplicitSSAName>($name) attr-dict
+    `:` qualified(type($result))
+  }];
+}
+
+
 def KnownBitWidthType : Type<CPred<[{getBitWidth($_self) != -1}]>,
   "Type wherein the bitwidth in hardware is known">;
 

--- a/include/circt/Dialect/HW/HWTypesImpl.td
+++ b/include/circt/Dialect/HW/HWTypesImpl.td
@@ -118,9 +118,10 @@ def UnpackedArrayTypeImpl : HWType<"UnpackedArray", [
 def InOutTypeImpl : HWType<"InOut"> {
   let summary = "inout type";
   let description = [{
-    InOut type is used for model operations and values that have "connection"
-    semantics, instead of typical dataflow behavior.  This is used for wires
-    and inout ports in Verilog.
+    InOut type is a category-neutral addressable storage carrier with
+    connection/lvalue semantics, as opposed to typical dataflow behavior.
+    HW makes no net-vs-variable distinction here; that classification is
+    decided downstream (e.g. by HWToSV).
   }];
 
   let mnemonic = "inout";

--- a/include/circt/Dialect/SV/SV.td
+++ b/include/circt/Dialect/SV/SV.td
@@ -16,6 +16,7 @@
 include "circt/Dialect/SV/SVDialect.td"
 include "circt/Dialect/SV/SVAttributes.td"
 include "circt/Dialect/SV/SVEnums.td"
+include "circt/Dialect/SV/SVTypesImpl.td"
 include "circt/Dialect/SV/SVTypes.td"
 include "circt/Dialect/SV/SVExpressions.td"
 include "circt/Dialect/SV/SVInOutOps.td"

--- a/include/circt/Dialect/SV/SVEnums.td
+++ b/include/circt/Dialect/SV/SVEnums.td
@@ -30,4 +30,15 @@ def EventControlAttr : I32EnumAttr<"EventControl", "edge control trigger",
   let cppNamespace = "circt::sv";
 }
 
+def SVVarKeywordReg : I32EnumAttrCase<"Reg", 0, "reg">;
+def SVVarKeywordLogic : I32EnumAttrCase<"Logic", 1, "logic">;
+def SVVarKeywordNone : I32EnumAttrCase<"None", 2, "none">;
+
+def SVVarKeywordAttr : I32EnumAttr<"SVVarKeyword",
+                                   "variable declaration keyword",
+                                   [SVVarKeywordReg, SVVarKeywordLogic,
+                                    SVVarKeywordNone]> {
+  let cppNamespace = "circt::sv";
+}
+
 #endif // CIRCT_DIALECT_SV_SVENUMS_TD

--- a/include/circt/Dialect/SV/SVExpressions.td
+++ b/include/circt/Dialect/SV/SVExpressions.td
@@ -21,7 +21,7 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 
-def HWValueOrInOutType : AnyTypeOf<[HWValueType, InOutType]>;
+def HWValueOrSVLvalueType : AnyTypeOf<[HWValueType, SVLvalueType]>;
 
 
 def SystemFunctionOp : SVOp<"system"> {
@@ -57,7 +57,7 @@ def VerbatimExprOp : SVOp<"verbatim.expr", [Pure, HasCustomSSAName,
 
   let arguments = (ins StrAttr:$format_string, Variadic<AnyType>:$substitutions,
                   DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols);
-  let results = (outs HWValueOrInOutType:$result);
+  let results = (outs HWValueOrSVLvalueType:$result);
   let assemblyFormat = [{
     $format_string (`(` $substitutions^ `)`)?
       `:` functional-type($substitutions, $result) attr-dict
@@ -90,7 +90,7 @@ def VerbatimExprSEOp : SVOp<"verbatim.expr.se", [HasCustomSSAName,
 
   let arguments = (ins StrAttr:$format_string, Variadic<AnyType>:$substitutions,
                  DefaultValuedAttr<NameRefArrayAttr,"{}">:$symbols );
-  let results = (outs HWValueOrInOutType:$result);
+  let results = (outs HWValueOrSVLvalueType:$result);
   let assemblyFormat = [{
     $format_string (`(` $substitutions^ `)`)?
       `:` functional-type($substitutions, $result) attr-dict
@@ -116,7 +116,7 @@ def MacroRefExprOp : SVOp<"macro.ref.expr", [Pure, HasCustomSSAName,
     }];
 
   let arguments = (ins FlatSymbolRefAttr:$macroName, Variadic<AnyType>:$inputs);
-  let results = (outs HWValueOrInOutType:$result);
+  let results = (outs HWValueOrSVLvalueType:$result);
 
   let assemblyFormat = "$macroName `(` $inputs `)` attr-dict `:` functional-type($inputs, $result)";
 
@@ -143,7 +143,7 @@ def MacroRefExprSEOp : SVOp<"macro.ref.expr.se", [HasCustomSSAName,
     }];
 
   let arguments = (ins FlatSymbolRefAttr:$macroName, Variadic<AnyType>:$inputs);
-  let results = (outs HWValueOrInOutType:$result);
+  let results = (outs HWValueOrSVLvalueType:$result);
 
   let assemblyFormat = "$macroName `(` $inputs `)` attr-dict `:` functional-type($inputs, $result)";
 

--- a/include/circt/Dialect/SV/SVInOutOps.td
+++ b/include/circt/Dialect/SV/SVInOutOps.td
@@ -18,6 +18,7 @@ include "circt/Dialect/HW/HWAttributesNaming.td"
 include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/SV/SVDialect.td"
+include "circt/Dialect/SV/SVEnums.td"
 include "circt/Dialect/SV/SVTypes.td"
 include "circt/Support/ProceduralRegionTrait.td"
 include "circt/Types.td"
@@ -36,7 +37,7 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
     }];
 
   let arguments = (ins StrAttr:$name, OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs InOutType:$result);
+  let results = (outs SVNetType:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [
@@ -57,31 +58,33 @@ def WireOp : SVOp<"wire", [NonProceduralOp,
 
   let extraClassDeclaration = [{
     Type getElementType() {
-      return llvm::cast<InOutType>(getResult().getType()).getElementType();
+      return llvm::cast<NetType>(getResult().getType()).getElementType();
     }
   }];
 }
 
-def RegOp : SVOp<"reg", [
-          DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-          DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
-  let summary = "Define a new `reg` in SystemVerilog";
-   let description = [{
-     Declare a SystemVerilog Variable Declaration of 'reg' type.
-     See SV Spec 6.8, pp100.
-   }];
+def VarOp : SVOp<"var", [
+      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
+      DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
+  let summary = "Define a new SystemVerilog variable";
+  let description = [{
+    Declare a SystemVerilog variable. The optional keyword controls whether
+    the declaration is emitted as `reg`, `logic`, or without a keyword.
+  }];
   let arguments = (ins
     StrAttr:$name,
     Optional<AnyType>:$init,
+    OptionalAttr<SVVarKeywordAttr>:$keyword,
     OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs InOutType:$result);
+  let results = (outs SVVarType:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins "::mlir::Type":$elementType,
                     CArg<"StringAttr", "StringAttr()">:$name,
                     CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym,
-                    CArg<"mlir::Value", "{}">:$init)>
+                    CArg<"mlir::Value", "{}">:$init,
+                    CArg<"SVVarKeywordAttr", "{}">:$keyword)>
   ];
 
   // We handle the name in a custom way, so we use a customer parser/printer.
@@ -94,7 +97,7 @@ def RegOp : SVOp<"reg", [
 
   let extraClassDeclaration = [{
     Type getElementType() {
-      return llvm::cast<InOutType>(getResult().getType()).getElementType();
+      return llvm::cast<VarType>(getResult().getType()).getElementType();
     }
   }];
 }
@@ -116,7 +119,7 @@ def XMROp : SVOp<"xmr", []> {
     path has public visibility so paths are not invalidated.
   }];
   let arguments = (ins UnitAttr:$isRooted, StrArrayAttr:$path, StrAttr:$terminal);
-  let results = (outs InOutType:$result);
+  let results = (outs SVLvalueType:$result);
   let assemblyFormat = "(`isRooted` $isRooted^)? custom<XMRPath>($path, $terminal) attr-dict `:` qualified(type($result))";
 }
 
@@ -142,7 +145,7 @@ def XMRRefOp : SVOp<"xmr.ref", [
     ins FlatSymbolRefAttr:$ref,
     DefaultValuedAttr<StrAttr, "{}">:$verbatimSuffix
   );
-  let results = (outs InOutType:$result);
+  let results = (outs SVLvalueType:$result);
   let assemblyFormat = [{
     $ref ( $verbatimSuffix^ )? attr-dict `:` qualified(type($result))
   }];
@@ -154,32 +157,52 @@ def XMRRefOp : SVOp<"xmr.ref", [
 
 def ReadInOutOp
  : SVOp<"read_inout",
-        [Pure, InOutElementConstraint<"result", "input">]> {
+        [Pure, SVLvalueElementConstraint<"result", "input">]> {
   let summary = "Get the value of from something of inout type (e.g. a wire or"
                 " inout port) as the value itself.";
-  let arguments = (ins InOutType:$input);
+  let arguments = (ins SVLvalueType:$input);
   let results = (outs HWValueType:$result);
   let assemblyFormat = "$input attr-dict `:` qualified(type($input))";
 }
 
-def InOutArrayType
-  : Type<CPred<"getAnyHWArrayElementType(getInOutElementType($_self)) "
-                        "!= Type()">,
-         "an inout type with array element", "::circt::hw::InOutType">;
+def NetFromInOutOp : SVOp<"net.from_inout", [
+    Pure, HWInOutToSVNetConstraint<"input", "result">]> {
+  let summary = "View an HW inout port as an SV net";
+  let arguments = (ins InOutType:$input);
+  let results = (outs SVNetType:$result);
+  let hasFolder = 1;
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` "
+                       "qualified(type($result))";
+}
 
-class InOutIndexConstraint<string value, string inoutValue>
-  : TypesMatchWith<"type should be element of inout type",
-                   inoutValue, value,
-                   "InOutType::get(getAnyHWArrayElementType("
-                                            "getInOutElementType($_self)))">;
+def InOutFromNetOp : SVOp<"inout.from_net", [
+    Pure, SVNetToHWInOutConstraint<"input", "result">]> {
+  let summary = "View an SV net as an HW inout port";
+  let arguments = (ins SVNetType:$input);
+  let results = (outs InOutType:$result);
+  let hasFolder = 1;
+  let assemblyFormat = "$input attr-dict `:` qualified(type($input)) `->` "
+                       "qualified(type($result))";
+}
+
+def SVLvalueArrayType
+  : Type<CPred<"getAnyHWArrayElementType(sv::getLvalueElementType($_self)) "
+                        "!= Type()">,
+         "an SV lvalue type with array element">;
+
+class SVLvalueIndexConstraint<string input, string result>
+  : TypesMatchWith<"result should preserve SV lvalue category", input, result,
+                   "sv::getLvalueOfSameCategory($_self, "
+                   "getAnyHWArrayElementType("
+                   "sv::getLvalueElementType($_self)))">;
 
 def ArrayIndexInOutOp
  : SVOp<"array_index_inout",
-        [Pure, InOutIndexConstraint<"result", "input">]> {
+        [Pure, SVLvalueIndexConstraint<"input", "result">]> {
   let summary = "Index an inout memory to produce an inout element";
   let description = "See SV Spec 11.5.2.";
-  let arguments = (ins InOutArrayType:$input, HWIntegerType:$index);
-  let results = (outs InOutType:$result);
+  let arguments = (ins SVLvalueArrayType:$input, HWIntegerType:$index);
+  let results = (outs SVLvalueType:$result);
   let assemblyFormat =
     "$input`[`$index`]` attr-dict `:` qualified(type($input)) `,` qualified(type($index))";
 }
@@ -194,9 +217,9 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
                 " then part select decrements starting from $base."
                 "See SV Spec 11.5.1.";
 
-  let arguments = (ins InOutType:$input, HWIntegerType:$base, I32Attr:$width,
+  let arguments = (ins SVLvalueType:$input, HWIntegerType:$base, I32Attr:$width,
                       UnitAttr:$decrement);
-  let results = (outs InOutType:$result);
+  let results = (outs SVLvalueType:$result);
 
   let hasVerifier = 1;
 
@@ -216,17 +239,18 @@ def IndexedPartSelectInOutOp : SVOp<"indexed_part_select_inout",
                         " attr-dict `:` qualified(type($input)) `,` qualified(type($base))";
 }
 
-def InOutStructType
-  : Type<CPred<"circt::hw::type_isa_and_nonnull<hw::StructType>(getInOutElementType($_self))">,
-         "an inout type with struct field", "::circt::hw::InOutType">;
+def SVLvalueStructType
+  : Type<CPred<"circt::hw::type_isa_and_nonnull<hw::StructType>("
+               "sv::getLvalueElementType($_self))">,
+         "an SV lvalue type with struct field">;
 
 def StructFieldInOutOp : SVOp<"struct_field_inout",
                               [Pure, InferTypeOpInterface]> {
   let summary = "Create an subfield inout memory to produce an inout element.";
   let description = "See SV Spec 7.2.";
 
-  let arguments = (ins InOutStructType:$input, StrAttr:$field);
-  let results = (outs InOutType:$result);
+  let arguments = (ins SVLvalueStructType:$input, StrAttr:$field);
+  let results = (outs SVLvalueType:$result);
 
   let assemblyFormat =
     "$input `[` $field `]` attr-dict `:` qualified(type($input))";
@@ -242,41 +266,6 @@ def StructFieldInOutOp : SVOp<"struct_field_inout",
                                           SmallVectorImpl<Type> &results);
   }];
 
-}
-
-def LogicOp : SVOp<"logic", [
-      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>,
-      DeclareOpInterfaceMethods<InnerSymbol, ["getTargetResultIndex"]>]> {
-  let summary = "Define a logic";
-  let description = [{
-    Declare a SystemVerilog Variable Declaration of 'logic' type.
-    See SV Spec 6.8, pp100.
-    }];
-
-  let arguments = (ins StrAttr:$name, OptionalAttr<InnerSymAttr>:$inner_sym);
-  let results = (outs InOutType:$result);
-
-  let skipDefaultBuilders = 1;
-  let builders = [
-    OpBuilder<(ins "::mlir::Type":$elementType,
-                   CArg<"StringAttr", "StringAttr()">:$name,
-                   CArg<"hw::InnerSymAttr", "hw::InnerSymAttr()">:$innerSym)>,
-    OpBuilder<(ins "::mlir::Type":$elementType, CArg<"StringRef">:$name), [{
-      return build($_builder, $_state, elementType,
-                   $_builder.getStringAttr(name));
-    }]>
-  ];
-
-  let assemblyFormat = [{
-    (`sym` $inner_sym^)? `` custom<ImplicitSSAName>($name) attr-dict
-    `:` qualified(type($result))
-  }];
-
-  let extraClassDeclaration = [{
-    Type getElementType() {
-      return llvm::cast<InOutType>(getResult().getType()).getElementType();
-    }
-  }];
 }
 
 #endif // CIRCT_DIALECT_SV_SVINOUTOPS_TD

--- a/include/circt/Dialect/SV/SVStatements.td
+++ b/include/circt/Dialect/SV/SVStatements.td
@@ -411,20 +411,21 @@ def CaseOp : SVOp<"case", [SingleBlock, NoTerminator, NoRegionArguments,
 // Assignment Related Statements
 //===----------------------------------------------------------------------===//
 
-def AssignOp : SVOp<"assign", [InOutTypeConstraint<"src", "dest">,
-                                 NonProceduralOp]> {
+def AssignOp : SVOp<"assign", [NonProceduralOp,
+                               SVLvalueElementConstraint<"src", "dest">]> {
   let summary = "Continuous assignment";
   let description = [{
     A SystemVerilog assignment statement 'x = y;'.
     These occur in module scope.  See SV Spec 10.3.2.
   }];
-  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let arguments = (ins SVNetType:$dest, HWValueType:$src);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src attr-dict `:` qualified(type($src))";
+  let assemblyFormat =
+    "$dest `,` $src attr-dict `:` custom<NetAssignTypes>(type($dest), type($src))";
 }
 
-def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
-                                   ProceduralOp]> {
+def BPAssignOp : SVOp<"bpassign", [ProceduralOp,
+                                   SVLvalueElementConstraint<"src", "dest">]> {
   let summary = "Blocking procedural assignment";
   let description = [{
     A SystemVerilog blocking procedural assignment statement 'x = y;'.  These
@@ -432,14 +433,15 @@ def BPAssignOp : SVOp<"bpassign", [InOutTypeConstraint<"src", "dest">,
     executed before any following statements are. See SV Spec 10.4.1.
   }];
   let hasCanonicalizeMethod = true;
-  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let arguments = (ins SVVarType:$dest, HWValueType:$src);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` custom<VarAssignTypes>(type($dest), type($src))";
   let hasVerifier = 1;
 }
 
-def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
-                                 ProceduralOp]> {
+def PAssignOp : SVOp<"passign", [ProceduralOp,
+                                 SVLvalueElementConstraint<"src", "dest">]> {
   let summary = "Nonblocking procedural assignment";
   let description = [{
     A SystemVerilog nonblocking procedural assignment statement 'x <= y;'.
@@ -447,9 +449,10 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
     can be scheduled without blocking procedural flow.  See SV Spec 10.4.2.
   }];
   let hasCanonicalizeMethod = true;
-  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let arguments = (ins SVVarType:$dest, HWValueType:$src);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` custom<VarAssignTypes>(type($dest), type($src))";
   let hasVerifier = 1;
 }
 
@@ -459,8 +462,8 @@ def PAssignOp : SVOp<"passign", [InOutTypeConstraint<"src", "dest">,
 // Other Statements
 //===----------------------------------------------------------------------===//
 
-def ForceOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
-                                   ProceduralOp]> {
+def ForceOp : SVOp<"force", [ProceduralOp,
+                             SVForceDestElementConstraint<"src", "dest">]> {
   let summary = "Force procedural statement";
   let description = [{
     A SystemVerilog force procedural statement 'force x = y;'.  These
@@ -472,9 +475,10 @@ def ForceOp : SVOp<"force", [InOutTypeConstraint<"src", "dest">,
     net or a concatenation. It cannot be a memory word or a bit-select
     or part-select of a vector variable. See SV Spec 10.6.2.
   }];
-  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let arguments = (ins SVForceDestType:$dest, HWValueType:$src);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
+  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($dest))";
+  let hasVerifier = 1;
 }
 
 def ReleaseOp : SVOp<"release", [ProceduralOp]> {
@@ -489,9 +493,10 @@ def ReleaseOp : SVOp<"release", [ProceduralOp]> {
     active assign procedural continuous assignment shall immediately
     reestablish that assignment. See SV Spec 10.6.2.
   }];
-  let arguments = (ins InOutType:$dest);
+  let arguments = (ins SVLvalueType:$dest);
   let results = (outs);
   let assemblyFormat = "$dest attr-dict `:` qualified(type($dest))";
+  let hasVerifier = 1;
 }
 
 def AliasOp : SVOp<"alias"> {
@@ -501,7 +506,7 @@ def AliasOp : SVOp<"alias"> {
     bits within a net.  Aliases always have at least two operands.
   }];
 
-  let arguments = (ins Variadic<InOutType>:$aliases);
+  let arguments = (ins Variadic<SVNetType>:$aliases);
   let results = (outs);
 
   let assemblyFormat = "$aliases attr-dict `:` qualified(type($aliases))";
@@ -824,15 +829,16 @@ foreach severity = ["Error", "Warning", "Info"] in {
 }
 
 def DepositOp : SVOp<"nonstandard.deposit",
-    [ProceduralOp, VendorExtension, InOutTypeConstraint<"src", "dest">]> {
+    [ProceduralOp, VendorExtension, SVLvalueElementConstraint<"src", "dest">]> {
   let summary = "`$deposit` system task";
   let description = [{
     This system task sets the value of a net or variable, but doesn't hold it.
     This is a common simulation vendor extension.
   }];
-  let arguments = (ins InOutType:$dest, InOutElementType:$src);
+  let arguments = (ins SVLvalueType:$dest, HWValueType:$src);
   let results = (outs);
-  let assemblyFormat = "$dest `,` $src  attr-dict `:` qualified(type($src))";
+  let assemblyFormat =
+    "$dest `,` $src  attr-dict `:` custom<VarAssignTypes>(type($dest), type($src))";
 }
 
 
@@ -855,7 +861,7 @@ def ReadMemOp : SVOp<"readmem", [ProceduralOp]> {
     See Section 21.4 of IEEE 1800-2017 for more information.
   }];
   let arguments =
-    (ins InOutType:$dest, StrAttr:$filename, MemBaseTypeAttr:$base);
+    (ins SVVarType:$dest, StrAttr:$filename, MemBaseTypeAttr:$base);
   let results = (outs);
   let assemblyFormat =
     "$dest `,` $filename `,` $base attr-dict `:` qualified(type($dest))";

--- a/include/circt/Dialect/SV/SVTypeDecl.td
+++ b/include/circt/Dialect/SV/SVTypeDecl.td
@@ -18,6 +18,7 @@ include "circt/Dialect/HW/HWOpInterfaces.td"
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/SV/SVDialect.td"
 include "circt/Dialect/SV/SVTypes.td"
+include "circt/Dialect/SV/SVTypesImpl.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/SymbolInterfaces.td"
@@ -280,6 +281,8 @@ def SVVerbatimModuleOp
       for (const auto &port : ports) {
         Type portType = port.type;
         hw::ModulePort::Direction portDir = port.dir;
+        // This is HW module-port handling. HW inout ports remain
+        // category-neutral; SV operations use sv.net.from_inout instead.
         if (auto inoutType = dyn_cast<hw::InOutType>(port.type)) {
           portType = inoutType.getElementType();
           portDir = hw::ModulePort::Direction::InOut;

--- a/include/circt/Dialect/SV/SVTypes.h
+++ b/include/circt/Dialect/SV/SVTypes.h
@@ -28,6 +28,21 @@ using InOutType = circt::hw::InOutType;
 /// InOut type.
 mlir::Type getInOutElementType(mlir::Type type);
 
+/// Return the element type of an SV lvalue type or null if the operand is not
+/// an SV lvalue.
+mlir::Type getLvalueElementType(mlir::Type type);
+
+/// Return the element type of a force destination type or null if the operand is
+/// not a valid force destination.
+mlir::Type getForceDestElementType(mlir::Type type);
+
+bool isSVNet(mlir::Type type);
+bool isSVVar(mlir::Type type);
+
+/// Form an SV lvalue with `newElement`, preserving the category of `lvalue`.
+/// Return null if `lvalue` is not an SV lvalue.
+mlir::Type getLvalueOfSameCategory(mlir::Type lvalue, mlir::Type newElement);
+
 /// Return the element type of an ArrayType or UnpackedArrayType, or null if the
 /// operand isn't an array.
 mlir::Type getAnyHWArrayElementType(mlir::Type type);

--- a/include/circt/Dialect/SV/SVTypes.td
+++ b/include/circt/Dialect/SV/SVTypes.td
@@ -15,12 +15,6 @@
 
 include "circt/Dialect/HW/HWTypes.td"
 include "circt/Dialect/SV/SVDialect.td"
-include "mlir/IR/AttrTypeBase.td"
-
-// TODO: The following should go into a `SVTypesImpl.td` if we ever actually
-// define any SV-specific types. Doing so will keep this `SVTypes.td` file
-// includable for other dialects, without polluting their output with SV types.
-class SVType<string name> : TypeDef<SVDialect, name> { }
 
 //===----------------------------------------------------------------------===//
 // InOut type and related helpers.
@@ -53,31 +47,40 @@ class InOutElementConstraint<string value, string inoutValue>
   : TypesMatchWith<"type should be element of inout type",
                    inoutValue, value, "sv::getInOutElementType($_self)">;
 
-def UnpackedOpenArrayTypeImpl : SVType<"UnpackedOpenArray"> {
-  let summary = "SystemVerilog unpacked 'open' array";
-  let description = [{
-    This type represents unpacked 'open' array. Open array is a special type that can be
-    used as formal arguments of DPI import statements.
-
-    See SystemVerilog Spec 35.5.6.1.
-  }];
-
-  let mnemonic = "open_uarray";
-  let parameters = (ins "::mlir::Type":$elementType);
-
-  let builders = [
-    TypeBuilderWithInferredContext<(ins "Type":$elementType), [{
-      auto *ctx = elementType.getContext();
-      return $_get(ctx, elementType);
-    }]>
-  ];
-
-  let assemblyFormat = "`<` $elementType `>`";
-}
-
 def UnpackedOpenArrayType : DialectType<SVDialect,
     CPred<"::circt::hw::type_isa<circt::sv::UnpackedOpenArrayType>($_self)">,
           "an Unpacked Open ArrayType",
           "::circt::hw::TypeAliasOr<circt::sv::UnpackedOpenArrayType>">;
+
+def SVNetType : DialectType<SVDialect,
+    CPred<"::circt::hw::type_isa<circt::sv::NetType>($_self)">,
+    "an SV net type", "::circt::sv::NetType">;
+
+def SVVarType : DialectType<SVDialect,
+    CPred<"::circt::hw::type_isa<circt::sv::VarType>($_self)">,
+    "an SV variable type", "::circt::sv::VarType">;
+
+def SVLvalueType : AnyTypeOf<[SVNetType, SVVarType]>;
+
+class SVLvalueElementConstraint<string value, string lvalue>
+  : TypesMatchWith<"type should be element of SV lvalue type",
+                   lvalue, value, "sv::getLvalueElementType($_self)">;
+
+def SVForceDestType : AnyTypeOf<[SVNetType, SVVarType, InOutType]>;
+
+class SVForceDestElementConstraint<string value, string lvalue>
+  : TypesMatchWith<"type should be element of SV force destination type",
+                   lvalue, value, "sv::getForceDestElementType($_self)">;
+
+class HWInOutToSVNetConstraint<string input, string result>
+  : TypesMatchWith<"result should be an SV net of the inout element type",
+                   input, result,
+                   "sv::NetType::get(sv::getInOutElementType($_self))">;
+
+class SVNetToHWInOutConstraint<string input, string result>
+  : TypesMatchWith<"result should be an InOut of an SV net element type",
+                   input, result,
+                   "hw::InOutType::get($_self.getContext(), "
+                   "cast<sv::NetType>($_self).getElementType())">;
 
 #endif // CIRCT_DIALECT_SV_SVTYPES

--- a/include/circt/Dialect/SV/SVTypesImpl.td
+++ b/include/circt/Dialect/SV/SVTypesImpl.td
@@ -1,0 +1,69 @@
+//===- SVTypesImpl.td - SV type definitions ----------------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CIRCT_DIALECT_SV_SVTYPESIMPL
+#define CIRCT_DIALECT_SV_SVTYPESIMPL
+
+include "circt/Dialect/SV/SVDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class SVType<string name> : TypeDef<SVDialect, name> { }
+
+def UnpackedOpenArrayTypeImpl : SVType<"UnpackedOpenArray"> {
+  let summary = "SystemVerilog unpacked 'open' array";
+  let description = [{
+    This type represents unpacked 'open' array. Open array is a special type
+    that can be used as formal arguments of DPI import statements.
+
+    See SystemVerilog Spec 35.5.6.1.
+  }];
+
+  let mnemonic = "open_uarray";
+  let parameters = (ins "::mlir::Type":$elementType);
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$elementType), [{
+      auto *ctx = elementType.getContext();
+      return $_get(ctx, elementType);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` $elementType `>`";
+}
+
+def NetTypeImpl : SVType<"Net"> {
+  let summary = "SystemVerilog net lvalue";
+  let mnemonic = "net";
+  let parameters = (ins "::mlir::Type":$elementType);
+  let genVerifyDecl = 1;
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$elementType), [{
+      return $_get(elementType.getContext(), elementType);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` $elementType `>`";
+}
+
+def VarTypeImpl : SVType<"Var"> {
+  let summary = "SystemVerilog variable lvalue";
+  let mnemonic = "var";
+  let parameters = (ins "::mlir::Type":$elementType);
+  let genVerifyDecl = 1;
+
+  let builders = [
+    TypeBuilderWithInferredContext<(ins "Type":$elementType), [{
+      return $_get(elementType.getContext(), elementType);
+    }]>
+  ];
+
+  let assemblyFormat = "`<` $elementType `>`";
+}
+
+#endif // CIRCT_DIALECT_SV_SVTYPESIMPL

--- a/include/circt/Dialect/SV/SVVisitors.h
+++ b/include/circt/Dialect/SV/SVVisitors.h
@@ -28,13 +28,13 @@ public:
     return TypeSwitch<Operation *, ResultType>(op)
         .template Case<
             // Expressions
-            ReadInOutOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
+            ReadInOutOp, NetFromInOutOp, InOutFromNetOp, ArrayIndexInOutOp, VerbatimExprOp, VerbatimExprSEOp,
             IndexedPartSelectInOutOp, IndexedPartSelectOp, StructFieldInOutOp,
             ConstantXOp, ConstantZOp, ConstantStrOp, MacroRefExprOp,
             MacroRefExprSEOp, UnpackedArrayCreateOp, UnpackedOpenArrayCastOp,
             SFormatFOp, ConcatStrOp,
             // Declarations.
-            RegOp, WireOp, LogicOp, LocalParamOp, XMROp, XMRRefOp,
+            VarOp, WireOp, LocalParamOp, XMROp, XMRRefOp,
             // Control flow.
             OrderedOutputOp, IfDefOp, IfDefProceduralOp, IfOp, AlwaysOp,
             AlwaysCombOp, AlwaysFFOp, InitialOp, CaseOp,
@@ -94,15 +94,16 @@ public:
   }
 
   // Declarations
-  HANDLE(RegOp, Unhandled);
+  HANDLE(VarOp, Unhandled);
   HANDLE(WireOp, Unhandled);
-  HANDLE(LogicOp, Unhandled);
   HANDLE(LocalParamOp, Unhandled);
   HANDLE(XMROp, Unhandled);
   HANDLE(XMRRefOp, Unhandled);
 
   // Expressions
   HANDLE(ReadInOutOp, Unhandled);
+  HANDLE(NetFromInOutOp, Unhandled);
+  HANDLE(InOutFromNetOp, Unhandled);
   HANDLE(ArrayIndexInOutOp, Unhandled);
   HANDLE(VerbatimExprOp, Unhandled);
   HANDLE(VerbatimExprSEOp, Unhandled);

--- a/lib/Bindings/Python/dialects/sv.py
+++ b/lib/Bindings/Python/dialects/sv.py
@@ -61,13 +61,13 @@ class WireOp(WireOp):
 
   @staticmethod
   def create(data_type, name=None, sym_name=None):
-    if not isinstance(data_type, hw.InOutType):
-      data_type = hw.InOutType.get(data_type)
+    if not isinstance(data_type, NetType):
+      data_type = NetType.get(data_type)
     return sv.WireOp(data_type, name, sym_name=sym_name)
 
 
 @_ods_cext.register_operation(_Dialect, replace=True)
-class RegOp(RegOp):
+class VarOp(VarOp):
 
   def __init__(self,
                data_type,

--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -177,8 +177,9 @@ static bool isDuplicatableExpression(Operation *op) {
       return true;
     if (auto read = dyn_cast<ReadInOutOp>(indexOp)) {
       auto *readSrc = read.getInput().getDefiningOp();
-      // A port or wire is ok to duplicate reads.
-      return !readSrc || isa<sv::WireOp, LogicOp>(readSrc);
+      // A port or wire or net-conversion from inout is ok to duplicate reads.
+      return !readSrc ||
+             isa<sv::WireOp, sv::VarOp, sv::NetFromInOutOp>(readSrc);
     }
 
     return false;
@@ -255,7 +256,8 @@ bool ExportVerilog::isVerilogExpression(Operation *op) {
           IndexedPartSelectInOutOp, StructFieldInOutOp, IndexedPartSelectOp,
           ParamValueOp, XMROp, XMRRefOp, SampledOp, EnumConstantOp, SFormatFOp,
           SystemFunctionOp, STimeOp, TimeOp, UnpackedArrayCreateOp,
-          UnpackedOpenArrayCastOp, ConcatStrOp>(op))
+          UnpackedOpenArrayCastOp, ConcatStrOp, NetFromInOutOp, InOutFromNetOp>(
+          op))
     return true;
 
   // These are Verif dialect expressions.
@@ -290,6 +292,10 @@ static void getTypeDims(
 
   if (auto inout = hw::type_dyn_cast<InOutType>(type))
     return getTypeDims(dims, inout.getElementType(), loc, errorHandler);
+  if (auto lvalue = hw::type_dyn_cast<sv::NetType>(type))
+    return getTypeDims(dims, lvalue.getElementType(), loc, errorHandler);
+  if (auto lvalue = hw::type_dyn_cast<sv::VarType>(type))
+    return getTypeDims(dims, lvalue.getElementType(), loc, errorHandler);
   if (auto uarray = hw::type_dyn_cast<hw::UnpackedArrayType>(type))
     return getTypeDims(dims, uarray.getElementType(), loc, errorHandler);
   if (auto uarray = hw::type_dyn_cast<sv::UnpackedOpenArrayType>(type))
@@ -321,6 +327,10 @@ bool ExportVerilog::isZeroBitType(Type type) {
     return intType.getWidth() == 0;
   if (auto inout = dyn_cast<hw::InOutType>(type))
     return isZeroBitType(inout.getElementType());
+  if (auto lvalue = dyn_cast<sv::NetType>(type))
+    return isZeroBitType(lvalue.getElementType());
+  if (auto lvalue = dyn_cast<sv::VarType>(type))
+    return isZeroBitType(lvalue.getElementType());
   if (auto uarray = dyn_cast<hw::UnpackedArrayType>(type))
     return uarray.getNumElements() == 0 ||
            isZeroBitType(uarray.getElementType());
@@ -348,6 +358,9 @@ static Type stripUnpackedTypes(Type type) {
       .Case<InOutType>([](InOutType inoutType) {
         return stripUnpackedTypes(inoutType.getElementType());
       })
+      .Case<sv::NetType, sv::VarType>([](auto lvalueType) {
+        return stripUnpackedTypes(lvalueType.getElementType());
+      })
       .Case<UnpackedArrayType, sv::UnpackedOpenArrayType>([](auto arrayType) {
         return stripUnpackedTypes(arrayType.getElementType());
       })
@@ -356,17 +369,22 @@ static Type stripUnpackedTypes(Type type) {
 
 /// Return true if the type has a leading unpacked type.
 static bool hasLeadingUnpackedType(Type type) {
-  assert(isa<hw::InOutType>(type) && "inout type is expected");
-  auto elementType = cast<hw::InOutType>(type).getElementType();
+  Type elementType;
+  if (auto inoutType = dyn_cast<hw::InOutType>(type))
+    elementType = inoutType.getElementType();
+  else
+    elementType = sv::getLvalueElementType(type);
+  assert(elementType && "lvalue type is expected");
   return stripUnpackedTypes(elementType) != elementType;
 }
 
 /// Return true if type has a struct type as a subtype.
 static bool hasStructType(Type type) {
   return TypeSwitch<Type, bool>(type)
-      .Case<InOutType, UnpackedArrayType, ArrayType>([](auto parentType) {
-        return hasStructType(parentType.getElementType());
-      })
+      .Case<InOutType, sv::NetType, sv::VarType, UnpackedArrayType, ArrayType>(
+          [](auto parentType) {
+            return hasStructType(parentType.getElementType());
+          })
       .Case<StructType>([](auto) { return true; })
       .Default([](auto) { return false; });
 }
@@ -820,7 +838,8 @@ static bool isExpressionUnableToInline(Operation *op,
       auto read = dyn_cast<ReadInOutOp>(op);
       if (!read)
         return true;
-      if (!isa_and_nonnull<sv::WireOp, RegOp>(read.getInput().getDefiningOp()))
+      if (!isa_and_nonnull<sv::WireOp, sv::VarOp>(
+              read.getInput().getDefiningOp()))
         return true;
     }
   }
@@ -1393,7 +1412,7 @@ StringAttr ExportVerilog::inferStructuralNameForTemporary(Value expr) {
 
   } else if (auto *op = expr.getDefiningOp()) {
     // Uses of a wire, register or logic can be done inline.
-    if (isa<sv::WireOp, RegOp, LogicOp>(op)) {
+    if (isa<sv::WireOp, sv::VarOp>(op)) {
       StringRef name = getSymOpName(op);
       result = StringAttr::get(expr.getContext(), name);
 
@@ -1553,12 +1572,19 @@ public:
 /// in a non-procedural region.
 static StringRef getVerilogDeclWord(Operation *op,
                                     const ModuleEmitter &emitter) {
-  if (isa<RegOp>(op)) {
+  // If 'op' is in a module, output 'wire'. If 'op' is in a procedural block,
+  // fall through to default.
+  bool isProcedural = op->getParentOp()->hasTrait<ProceduralRegion>();
+
+  // If this decl is within a function, "automatic" is not needed because
+  // "automatic" is added to its definition.
+  bool stripAutomatic = isa_and_nonnull<FuncOp>(emitter.currentModuleOp);
+
+  if (auto var = dyn_cast<sv::VarOp>(op)) {
     // Check if the type stored in this register is a struct or array of
     // structs. In this case, according to spec section 6.8, the "reg" prefix
     // should be left off.
-    auto elementType =
-        cast<InOutType>(op->getResult(0).getType()).getElementType();
+    auto elementType = var.getElementType();
     // Unwrap arrays. Since packed arrays cannot contain unpacked arrays, we can
     // unpack unpacked arrays first.
     while (auto arrayType = hw::type_dyn_cast<UnpackedArrayType>(elementType))
@@ -1566,10 +1592,33 @@ static StringRef getVerilogDeclWord(Operation *op,
     while (auto arrayType = hw::type_dyn_cast<ArrayType>(elementType))
       elementType = arrayType.getElementType();
 
-    if (isa<StructType, UnionType, EnumType, TypeAliasType>(elementType))
-      return "";
+    bool hasStruct =
+        isa<StructType, UnionType, EnumType, TypeAliasType>(elementType);
 
-    return "reg";
+    // If the variable op is defined in a procedural region, add 'automatic'
+    // keyword. If the op has a struct type, 'logic' keyword is already emitted
+    // within a struct type definition (e.g. struct packed {logic foo;}). So we
+    // should not emit extra 'logic'.
+    if (hasStruct) {
+      if (isProcedural && !stripAutomatic)
+        return "automatic";
+      return "";
+    }
+
+    if (auto keyword = var.getKeyword()) {
+      switch (keyword.value()) {
+      case SVVarKeyword::Reg:
+        return "reg";
+      case SVVarKeyword::Logic:
+        return "logic";
+      case SVVarKeyword::None:
+        return "";
+      }
+    }
+
+    if (isProcedural && !stripAutomatic)
+      return "automatic logic";
+    return "logic";
   }
   if (isa<sv::WireOp>(op))
     return "wire";
@@ -1579,25 +1628,6 @@ static StringRef getVerilogDeclWord(Operation *op,
   // Interfaces instances use the name of the declared interface.
   if (auto interface = dyn_cast<InterfaceInstanceOp>(op))
     return interface.getInterfaceType().getInterface().getValue();
-
-  // If 'op' is in a module, output 'wire'. If 'op' is in a procedural block,
-  // fall through to default.
-  bool isProcedural = op->getParentOp()->hasTrait<ProceduralRegion>();
-
-  // If this decl is within a function, "automatic" is not needed because
-  // "automatic" is added to its definition.
-  bool stripAutomatic = isa_and_nonnull<FuncOp>(emitter.currentModuleOp);
-
-  if (isa<LogicOp>(op)) {
-    // If the logic op is defined in a procedural region, add 'automatic'
-    // keyword. If the op has a struct type, 'logic' keyword is already emitted
-    // within a struct type definition (e.g. struct packed {logic foo;}). So we
-    // should not emit extra 'logic'.
-    bool hasStruct = hasStructType(op->getResult(0).getType());
-    if (isProcedural && !stripAutomatic)
-      return hasStruct ? "automatic" : "automatic logic";
-    return hasStruct ? "" : "logic";
-  }
 
   if (!isProcedural)
     return "wire";
@@ -1750,6 +1780,12 @@ static bool printPackedTypeImpl(Type type, raw_ostream &os, Location loc,
       })
       .Case<InOutType>([&](InOutType inoutType) {
         return printPackedTypeImpl(inoutType.getElementType(), os, loc, dims,
+                                   implicitIntType, singleBitDefaultType,
+                                   emitter, /*optionalAliasType=*/{},
+                                   emitAsTwoStateType);
+      })
+      .Case<sv::NetType, sv::VarType>([&](auto lvalueType) {
+        return printPackedTypeImpl(lvalueType.getElementType(), os, loc, dims,
                                    implicitIntType, singleBitDefaultType,
                                    emitter, /*optionalAliasType=*/{},
                                    emitAsTwoStateType);
@@ -1911,6 +1947,9 @@ void ModuleEmitter::printUnpackedTypePostfix(Type type, raw_ostream &os) {
   TypeSwitch<Type, void>(type)
       .Case<InOutType>([&](InOutType inoutType) {
         printUnpackedTypePostfix(inoutType.getElementType(), os);
+      })
+      .Case<sv::NetType, sv::VarType>([&](auto lvalueType) {
+        printUnpackedTypePostfix(lvalueType.getElementType(), os);
       })
       .Case<UnpackedArrayType>([&](UnpackedArrayType arrayType) {
         auto loc = currentModuleOp ? currentModuleOp->getLoc()
@@ -2320,8 +2359,7 @@ private:
 
   /// Emit braced list of values surrounded by `{` and `}`.
   void emitBracedList(ValueRange ops) {
-    return emitBracedList(
-        ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
+    return emitBracedList(ops, [&]() { ps << "{"; }, [&]() { ps << "}"; });
   }
 
   /// Print an APInt constant.
@@ -2373,6 +2411,10 @@ private:
     emitSVAttributes(op);
     return result;
   }
+  SubExprInfo visitSV(NetFromInOutOp op) {
+    return emitSubExpr(op.getInput(), LowestPrecedence);
+  }
+  SubExprInfo visitSV(InOutFromNetOp op);
   SubExprInfo visitSV(ArrayIndexInOutOp op);
   SubExprInfo visitSV(IndexedPartSelectInOutOp op);
   SubExprInfo visitSV(IndexedPartSelectOp op);
@@ -2915,6 +2957,16 @@ SubExprInfo ExprEmitter::visitSV(XMRRefOp op) {
   if (leaf && leaf.size())
     ps << PPExtString(leaf);
   return {Selection, IsUnsigned};
+}
+
+SubExprInfo ExprEmitter::visitSV(InOutFromNetOp op) {
+  // The input is an SV net (typically a WireOp result). WireOp has no
+  // expression-emission case of its own. It is only handled as a
+  // declaration (see visitSV(sv::WireOp) in the statement visitor). Reference
+  // it by its declared Verilog name directly, the same way XMR references
+  // print a name rather than recursing into a sub-expression.
+  ps << PPExtString(getVerilogValueName(op.getInput()));
+  return {Symbol, IsUnsigned};
 }
 
 SubExprInfo ExprEmitter::visitVerbatimExprOp(Operation *op, ArrayAttr symbols) {
@@ -4136,8 +4188,9 @@ private:
   LogicalResult visitInvalidVerif(Operation *op) { return failure(); }
 
   LogicalResult visitSV(sv::WireOp op) { return emitDeclaration(op); }
-  LogicalResult visitSV(RegOp op) { return emitDeclaration(op); }
-  LogicalResult visitSV(LogicOp op) { return emitDeclaration(op); }
+  LogicalResult visitSV(sv::VarOp op) { return emitDeclaration(op); }
+  LogicalResult visitSV(NetFromInOutOp op) { return success(); }
+  LogicalResult visitSV(InOutFromNetOp op) { return success(); }
   LogicalResult visitSV(LocalParamOp op) { return emitDeclaration(op); }
   template <typename Op>
   LogicalResult
@@ -6092,13 +6145,13 @@ isExpressionEmittedInlineIntoProceduralDeclaration(Operation *op,
 
       // Reject struct_field_inout/array_index_inout for now because it's
       // necessary to consider aliasing inout operations.
-      if (!isa<RegOp, LogicOp>(defOp))
+      if (!isa<sv::VarOp>(defOp))
         return false;
 
       // It's safe to inline if all users are read op, passign or assign.
       // If the op is a logic op whose single assignment is inlined into
       // declaration, we can inline the read.
-      if (isa<LogicOp>(defOp) &&
+      if (isa<sv::VarOp>(defOp) &&
           stmtEmitter.emitter.expressionsEmittedIntoDecl.count(defOp))
         continue;
 
@@ -6252,7 +6305,7 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
       });
     }
 
-    if (auto regOp = dyn_cast<RegOp>(op)) {
+    if (auto regOp = dyn_cast<sv::VarOp>(op)) {
       if (auto initValue = regOp.getInit()) {
         ps << PP::space << "=" << PP::space;
         ps.scopedBox(PP::ibox0, [&]() {
@@ -6265,7 +6318,8 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     // Try inlining an assignment into declarations.
     // FIXME: Unpacked array is not inlined since several tools doesn't support
     // that syntax. See Issue 6363.
-    if (!state.options.disallowDeclAssignments && isa<sv::WireOp>(op) &&
+    if (!state.options.disallowDeclAssignments &&
+        sv::isSVNet(op->getResult(0).getType()) &&
         !op->getParentOp()->hasTrait<ProceduralRegion>() &&
         !hasLeadingUnpackedType(op->getResult(0).getType())) {
       // Get a single assignments if any.
@@ -6290,7 +6344,8 @@ LogicalResult StmtEmitter::emitDeclaration(Operation *op) {
     // Try inlining a blocking assignment to logic op declaration.
     // FIXME: Unpacked array is not inlined since several tools doesn't support
     // that syntax. See Issue 6363.
-    if (!state.options.disallowDeclAssignments && isa<LogicOp>(op) &&
+    if (!state.options.disallowDeclAssignments &&
+        sv::isSVVar(op->getResult(0).getType()) &&
         op->getParentOp()->hasTrait<ProceduralRegion>() &&
         !hasLeadingUnpackedType(op->getResult(0).getType())) {
       // Get a single assignment which might be possible to inline.

--- a/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
+++ b/lib/Conversion/ExportVerilog/ExportVerilogInternals.h
@@ -409,6 +409,11 @@ static inline bool isExpressionAlwaysInline(Operation *op) {
   if (isa<sv::ArrayIndexInOutOp>(op) || isa<sv::StructFieldInOutOp>(op) ||
       isa<sv::IndexedPartSelectInOutOp>(op) || isa<sv::ReadInOutOp>(op))
     return true;
+  
+  // An SV net-conversion from inout must inline too.
+  if (isa<sv::NetFromInOutOp>(op)){
+    return true;
+  }
 
   // An SV interface modport is a symbolic name that is always inlined.
   if (isa<sv::GetModportOp>(op) || isa<sv::ReadInterfaceSignalOp>(op))

--- a/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeAnonEnums.cpp
@@ -114,6 +114,18 @@ struct LegalizeAnonEnums
       return {};
     }
 
+    if (auto netType = dyn_cast<sv::NetType>(type)) {
+      if (auto newType = processType(netType.getElementType()))
+        return sv::NetType::get(newType);
+      return {};
+    }
+
+    if (auto varType = dyn_cast<sv::VarType>(type)) {
+      if (auto newType = processType(varType.getElementType()))
+        return sv::VarType::get(newType);
+      return {};
+    }
+
     // EnumTypes must be changed into TypeAlias.
     if (auto enumType = dyn_cast<EnumType>(type))
       return getEnumTypeDecl(enumType);

--- a/lib/Conversion/ExportVerilog/LegalizeNames.cpp
+++ b/lib/Conversion/ExportVerilog/LegalizeNames.cpp
@@ -198,7 +198,7 @@ static void legalizeModuleLocalNames(HWEmittableModuleLike module,
       if (auto name = op->getAttrOfType<StringAttr>(verilogNameAttr)) {
         nameResolver.insertUsedName(
             op->getAttrOfType<StringAttr>(verilogNameAttr));
-      } else if (isa<sv::WireOp, hw::WireOp, RegOp, LogicOp, LocalParamOp,
+      } else if (isa<sv::WireOp, hw::WireOp, sv::VarOp, LocalParamOp,
                      hw::InstanceOp, sv::InterfaceInstanceOp, sv::GenerateOp>(
                      op)) {
         // Otherwise, get a verilog name via `getSymOpName`.

--- a/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
+++ b/lib/Conversion/ExportVerilog/PrepareForEmission.cpp
@@ -51,10 +51,12 @@ using namespace ExportVerilog;
 bool ExportVerilog::isSimpleReadOrPort(Value v) {
   if (isa<BlockArgument>(v))
     return true;
+  if (isa<hw::InOutType>(v.getType()))
+    return true;
   auto vOp = v.getDefiningOp();
   if (!vOp)
     return false;
-  if (isa<sv::InOutType>(v.getType()) && isa<sv::WireOp>(vOp))
+  if (sv::isSVNet(v.getType()) && isa<sv::WireOp, sv::NetFromInOutOp>(vOp))
     return true;
   auto read = dyn_cast<ReadInOutOp>(vOp);
   if (!read)
@@ -62,7 +64,8 @@ bool ExportVerilog::isSimpleReadOrPort(Value v) {
   auto readSrc = read.getInput().getDefiningOp();
   if (!readSrc)
     return false;
-  return isa<sv::WireOp, RegOp, LogicOp, XMROp, XMRRefOp>(readSrc);
+  return isa<sv::WireOp, sv::VarOp, XMROp, XMRRefOp, sv::NetFromInOutOp>(
+      readSrc);
 }
 
 // Check if the value is deemed worth spilling into a wire.
@@ -119,8 +122,8 @@ static void replacePortWithWire(ImplicitLocOpBuilder &builder, Operation *op,
 
   Value newTarget;
   if (isProcedural) {
-    newTarget = sv::LogicOp::create(builder, result.getType(),
-                                    builder.getStringAttr(name));
+    newTarget = sv::VarOp::create(builder, result.getType(),
+                                  builder.getStringAttr(name));
   } else {
     newTarget = sv::WireOp::create(builder, result.getType(), name);
   }
@@ -237,24 +240,28 @@ static void lowerUsersToTemporaryWire(Operation &op,
   auto createWireForResult = [&](Value result, StringAttr name) {
     Value newWire;
     Type wireElementType = result.getType();
-    bool isResultInOut = false;
+    bool isResultLvalue = false;
 
     // If the result already is an InOut, make sure to not wrap it again
     if (auto inoutType = hw::type_dyn_cast<hw::InOutType>(result.getType())) {
       wireElementType = inoutType.getElementType();
-      isResultInOut = true;
+      isResultLvalue = true;
+    } else if (auto lvalueElementType =
+                   sv::getLvalueElementType(result.getType())) {
+      wireElementType = lvalueElementType;
+      isResultLvalue = true;
     }
 
     // If the op is in a procedural region, use logic op.
     if (isProceduralRegion)
-      newWire = LogicOp::create(builder, wireElementType, name);
+      newWire = sv::VarOp::create(builder, wireElementType, name);
     else
       newWire = sv::WireOp::create(builder, wireElementType, name);
 
     // Replace all uses with newWire. Wrap in ReadInOutOp if required.
     while (!result.use_empty()) {
       OpOperand &use = *result.getUses().begin();
-      if (isResultInOut) {
+      if (isResultLvalue) {
         use.set(newWire);
       } else {
         auto newWireRead = ReadInOutOp::create(builder, newWire);
@@ -267,15 +274,15 @@ static void lowerUsersToTemporaryWire(Operation &op,
     Operation *connect;
     ReadInOutOp resultRead;
 
-    if (isResultInOut)
+    if (isResultLvalue)
       resultRead = ReadInOutOp::create(builder, result);
 
     if (isProceduralRegion)
       connect = BPAssignOp::create(
-          builder, newWire, isResultInOut ? resultRead.getResult() : result);
+          builder, newWire, isResultLvalue ? resultRead.getResult() : result);
     else
       connect = AssignOp::create(
-          builder, newWire, isResultInOut ? resultRead.getResult() : result);
+          builder, newWire, isResultLvalue ? resultRead.getResult() : result);
 
     connect->moveAfter(&op);
     if (resultRead)
@@ -374,10 +381,10 @@ static void lowerAlwaysInlineOperation(Operation *op,
 // Logic ops are emitted as "automatic logic" in procedural regions, but
 // they must be declared at beginning of blocks.
 static std::pair<Block *, Block::iterator>
-findLogicOpInsertionPoint(Operation *op) {
+findVarOpInsertionPoint(Operation *op) {
   // We have to skip `ifdef.procedural` because it is a just macro.
   if (isa<IfDefProceduralOp>(op->getParentOp()))
-    return findLogicOpInsertionPoint(op->getParentOp());
+    return findVarOpInsertionPoint(op->getParentOp());
   return {op->getBlock(), op->getBlock()->begin()};
 }
 
@@ -473,7 +480,7 @@ static Operation *findParentInNonProceduralRegion(Operation *op) {
 /// This function is invoked on side effecting Verilog expressions when we're in
 /// 'disallowLocalVariables' mode for old Verilog clients.  This ensures that
 /// any side effecting expressions are only used by a single BPAssign to a
-/// sv.reg or sv.logic operation.  This ensures that the verilog emitter doesn't
+/// sv.var operation.  This ensures that the verilog emitter doesn't
 /// have to worry about spilling them.
 ///
 /// This returns true if the op was rewritten, false otherwise.
@@ -494,7 +501,7 @@ static bool rewriteSideEffectingExpr(Operation *op) {
   // Scan to the top of the region tree to find out where to insert the reg.
   Operation *parentOp = findParentInNonProceduralRegion(op);
   OpBuilder builder(parentOp);
-  auto reg = RegOp::create(builder, op->getLoc(), opValue.getType());
+  auto reg = sv::VarOp::create(builder, op->getLoc(), opValue.getType());
 
   // Everything using the expr now uses a read_inout of the reg.
   auto value = ReadInOutOp::create(builder, op->getLoc(), reg);
@@ -516,7 +523,7 @@ static bool hoistNonSideEffectExpr(Operation *op) {
   // never generate a temporary and in fact must always be emitted inline.
   if (isExpressionAlwaysInline(op) &&
       !(isa<sv::ReadInOutOp>(op) ||
-        isa<hw::InOutType>(op->getResult(0).getType())))
+        sv::getLvalueElementType(op->getResult(0).getType())))
     return false;
 
   // Scan to the top of the region tree to find out where to move the op.
@@ -566,7 +573,8 @@ static bool hoistNonSideEffectExpr(Operation *op) {
 /// Check whether an op is a declaration that can be moved.
 static bool isMovableDeclaration(Operation *op) {
   if (op->getNumResults() != 1 ||
-      !isa<InOutType, sv::InterfaceType>(op->getResult(0).getType()))
+      !(sv::getLvalueElementType(op->getResult(0).getType()) ||
+        isa<sv::InterfaceType>(op->getResult(0).getType())))
     return false;
 
   // If all operands (e.g. init value) are constant, it is safe to move
@@ -598,7 +606,7 @@ class EmittedExpressionStateManager
                          EmittedExpressionState> {
 public:
   EmittedExpressionStateManager(const LoweringOptions &options)
-      : options(options){};
+      : options(options) {};
 
   // Get or caluculate an emitted expression state.
   EmittedExpressionState getExpressionState(Value value);
@@ -749,8 +757,8 @@ bool EmittedExpressionStateManager::shouldSpillWireBasedOnState(Operation &op) {
   // Don't spill wires for inout operations and simple expressions such as read
   // or constant.
   if (op.getNumResults() == 0 ||
-      isa<hw::InOutType>(op.getResult(0).getType()) ||
-      isa<ReadInOutOp, ConstantOp>(op))
+      sv::getLvalueElementType(op.getResult(0).getType()) ||
+      isa<ReadInOutOp, ConstantOp, NetFromInOutOp>(op))
     return false;
 
   // If the operation is only used by an assignment, the op is already spilled
@@ -866,8 +874,8 @@ static void applyWireLowerings(Block &block,
     Value decl;
     if (isProceduralRegion) {
       decl =
-          LogicOp::create(builder, hwWireOp.getType(), hwWireOp.getNameAttr(),
-                          hwWireOp.getInnerSymAttr());
+          sv::VarOp::create(builder, hwWireOp.getType(), hwWireOp.getNameAttr(),
+                            hwWireOp.getInnerSymAttr());
     } else {
       decl = sv::WireOp::create(builder, hwWireOp.getType(),
                                 hwWireOp.getNameAttr(),
@@ -987,7 +995,7 @@ static LogicalResult legalizeHWModule(Block &block,
 
     // If a reg or logic is located in a procedural region, we have to move the
     // op declaration to a valid program point.
-    if (isProceduralRegion && isa<LogicOp, RegOp>(op)) {
+    if (isProceduralRegion && isa<sv::VarOp>(op)) {
       if (options.disallowLocalVariables) {
         // When `disallowLocalVariables` is enabled, "automatic logic" is
         // prohibited so hoist the op to a non-procedural region.
@@ -1001,7 +1009,7 @@ static LogicalResult legalizeHWModule(Block &block,
     if (options.disallowLocalVariables && isVerilogExpression(&op) &&
         isProceduralRegion) {
 
-      // Force any side-effecting expressions in nested regions into a sv.reg
+      // Force any side-effecting expressions in nested regions into a sv.var
       // if we aren't allowing local variable declarations.  The Verilog emitter
       // doesn't want to have to have to know how to synthesize a reg in the
       // case they have to be spilled for whatever reason.
@@ -1077,7 +1085,7 @@ static LogicalResult legalizeHWModule(Block &block,
           cast<hw::StructType>(structCreateOp.getResult().getType());
       bool procedural = op.getParentOp()->hasTrait<ProceduralRegion>();
       if (procedural)
-        wireOp = LogicOp::create(builder, structType);
+        wireOp = sv::VarOp::create(builder, structType);
       else
         wireOp = sv::WireOp::create(builder, structType);
 
@@ -1106,9 +1114,9 @@ static LogicalResult legalizeHWModule(Block &block,
       ImplicitLocOpBuilder builder(op.getLoc(), &op);
       Value decl;
       if (procedural)
-        decl = LogicOp::create(builder, arrayInjectOp.getType());
+        decl = sv::VarOp::create(builder, arrayInjectOp.getType());
       else
-        decl = sv::RegOp::create(builder, arrayInjectOp.getType());
+        decl = sv::VarOp::create(builder, arrayInjectOp.getType());
       for (auto &use : llvm::make_early_inc_range(arrayInjectOp->getUses()))
         use.set(ReadInOutOp::create(builder, decl));
 
@@ -1142,7 +1150,7 @@ static LogicalResult legalizeHWModule(Block &block,
       Value readOp;
       if (auto maybeReadOp =
               op.getOperand(1).getDefiningOp<sv::ReadInOutOp>()) {
-        if (isa_and_nonnull<sv::WireOp, LogicOp>(
+        if (isa_and_nonnull<sv::WireOp, sv::VarOp>(
                 maybeReadOp.getInput().getDefiningOp())) {
           wireOp = maybeReadOp.getInput();
           readOp = maybeReadOp;
@@ -1155,7 +1163,8 @@ static LogicalResult legalizeHWModule(Block &block,
         auto type = op.getOperand(1).getType();
         const auto *name = "_GEN_ARRAY_IDX";
         if (op.getParentOp()->hasTrait<ProceduralRegion>()) {
-          wireOp = LogicOp::create(builder, type, name);
+          wireOp =
+              sv::VarOp::create(builder, type, builder.getStringAttr(name));
           BPAssignOp::create(builder, wireOp, op.getOperand(1));
         } else {
           wireOp = sv::WireOp::create(builder, type, name);
@@ -1276,9 +1285,9 @@ static LogicalResult legalizeHWModule(Block &block,
 
     // This keeps tracks of an insertion point of logic op.
     std::pair<Block *, Block::iterator> logicOpInsertionPoint =
-        findLogicOpInsertionPoint(&block.front());
+        findVarOpInsertionPoint(&block.front());
     for (auto &op : llvm::make_early_inc_range(block)) {
-      if (auto logic = dyn_cast<LogicOp>(&op)) {
+      if (auto logic = dyn_cast<sv::VarOp>(&op)) {
         // If the logic op is already located at the given point, increment the
         // iterator to keep the order of logic operations in the block.
         if (logicOpInsertionPoint.second == logic->getIterator()) {
@@ -1377,12 +1386,37 @@ static void fixUpEmptyModules(hw::HWEmittableModuleLike module) {
   sv::AssignOp::create(builder, module.getLoc(), wire, constant);
 }
 
+static void bridgeInOutPorts(hw::HWEmittableModuleLike module) {
+  Block *body = module.getBodyBlock();
+  if (!body)
+    return;
+
+  ImplicitLocOpBuilder builder(module.getLoc(), body, body->begin());
+
+  for (BlockArgument argument : body->getArguments()) {
+    auto inoutType = dyn_cast<hw::InOutType>(argument.getType());
+    if (!inoutType)
+      continue;
+
+    bool hasBridge = llvm::any_of(argument.getUsers(), [](Operation *user) {
+      return isa<sv::NetFromInOutOp>(user);
+    });
+    if (hasBridge)
+      continue;
+
+    sv::NetFromInOutOp::create(
+        builder, sv::NetType::get(inoutType.getElementType()), argument);
+  }
+}
+
 // NOLINTNEXTLINE(misc-no-recursion)
 LogicalResult ExportVerilog::prepareHWModule(hw::HWEmittableModuleLike module,
                                              const LoweringOptions &options) {
   // If the module body is empty, just skip it.
   if (!module.getBodyBlock())
     return success();
+
+  bridgeInOutPorts(module);
 
   // Zero-valued logic pruning.
   pruneZeroValuedLogic(module);

--- a/lib/Conversion/ExportVerilog/PruneZeroValuedLogic.cpp
+++ b/lib/Conversion/ExportVerilog/PruneZeroValuedLogic.cpp
@@ -281,7 +281,7 @@ void ExportVerilog::pruneZeroValuedLogic(HWEmittableModuleLike module) {
 
   addNoI0ResultPruningPattern<
       // SV ops
-      sv::WireOp, sv::RegOp, sv::ReadInOutOp,
+      sv::WireOp, sv::VarOp, sv::ReadInOutOp,
       // Prune all zero-width combinational logic.
       comb::AddOp, comb::AndOp, comb::DivSOp, comb::DivUOp, comb::ExtractOp,
       comb::ModSOp, comb::ModUOp, comb::MulOp, comb::MuxOp, comb::OrOp,

--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -881,8 +881,7 @@ void FIRRTLModuleLowering::lowerFileHeader(CircuitOp op,
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    sv::IfDefOp::create(
-        b, guard, [] {}, body);
+    sv::IfDefOp::create(b, guard, [] {}, body);
   };
 
   if (state.usedFileDescriptorLib)
@@ -2499,9 +2498,10 @@ Value FIRRTLLowering::getLoweredValue(Value value) {
   if (!result)
     return result;
 
-  // If we got an inout value, implicitly read it.  FIRRTL allows direct use
-  // of wires and other things that lower to inout type.
-  if (isa<hw::InOutType>(result.getType()))
+  // If we got an lvalue, implicitly read it. FIRRTL allows direct use of
+  // wires and other addressable values.
+  if (isa<hw::InOutType>(result.getType()) ||
+      sv::getLvalueElementType(result.getType()))
     return getReadValue(result);
 
   return result;
@@ -3227,8 +3227,13 @@ Value FIRRTLLowering::getReadValue(Value v) {
     result = builder.createOrFold<hw::ArrayGetOp>(result,
                                                   arrayIndexInout.getIndex());
   } else {
+    Value readOperand = v;
+    if (auto inoutType = dyn_cast<hw::InOutType>(v.getType()))
+      readOperand = sv::NetFromInOutOp::create(
+          builder, sv::NetType::get(inoutType.getElementType()), v);
+
     // Otherwise, create a read inout operation.
-    result = builder.createOrFold<sv::ReadInOutOp>(v);
+    result = builder.createOrFold<sv::ReadInOutOp>(readOperand);
   }
   builder.restoreInsertionPoint(oldIP);
   readInOutCreated.insert({v, result});
@@ -3274,8 +3279,7 @@ void FIRRTLLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = sv::IfOp::create(
-            builder, reset, [] {}, [] {});
+        insideIfOp = sv::IfOp::create(builder, reset, [] {}, [] {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};
@@ -3467,10 +3471,10 @@ FailureOr<Value> FIRRTLLowering::lowerSubindex(SubindexOp op, Value input) {
               .getNumElements()),
       op.getIndex());
 
-  // If the input has an inout type, we need to lower to ArrayIndexInOutOp;
+  // If the input is an SV lvalue, we need to lower to ArrayIndexInOutOp;
   // otherwise hw::ArrayGetOp.
   Value result;
-  if (isa<sv::InOutType>(input.getType()))
+  if (sv::getLvalueElementType(input.getType()))
     result = builder.createOrFold<sv::ArrayIndexInOutOp>(input, iIdx);
   else
     result = builder.createOrFold<hw::ArrayGetOp>(input, iIdx);
@@ -3491,10 +3495,10 @@ FailureOr<Value> FIRRTLLowering::lowerSubaccess(SubaccessOp op, Value input) {
     return failure();
   }
 
-  // If the input has an inout type, we need to lower to ArrayIndexInOutOp;
+  // If the input is an SV lvalue, we need to lower to ArrayIndexInOutOp;
   // otherwise, lower the op to array indexing.
   Value result;
-  if (isa<sv::InOutType>(input.getType()))
+  if (sv::getLvalueElementType(input.getType()))
     result = builder.createOrFold<sv::ArrayIndexInOutOp>(input, valueIdx);
   else
     result = createArrayIndexing(input, valueIdx);
@@ -3510,12 +3514,12 @@ FailureOr<Value> FIRRTLLowering::lowerSubfield(SubfieldOp op, Value input) {
     return failure();
   }
 
-  // If the input has an inout type, we need to lower to StructFieldInOutOp;
+  // If the input is an SV lvalue, we need to lower to StructFieldInOutOp;
   // otherwise, StructExtractOp.
   auto field = firrtl::type_cast<BundleType>(op.getInput().getType())
                    .getElementName(op.getFieldIndex());
   Value result;
-  if (isa<sv::InOutType>(input.getType()))
+  if (sv::getLvalueElementType(input.getType()))
     result = builder.createOrFold<sv::StructFieldInOutOp>(input, field);
   else
     result = builder.createOrFold<hw::StructExtractOp>(input, field);
@@ -3746,7 +3750,7 @@ LogicalResult FIRRTLLowering::visitDecl(VerbatimWireOp op) {
   auto resultTy = lowerType(op.getType());
   if (!resultTy)
     return failure();
-  resultTy = sv::InOutType::get(op.getContext(), resultTy);
+  resultTy = sv::NetType::get(op.getContext(), resultTy);
 
   SmallVector<Value, 4> operands;
   operands.reserve(op.getSubstitutions().size());
@@ -4049,8 +4053,11 @@ FIRRTLLowering::prepareInstanceOperands(ArrayRef<PortInfo> portInfo,
 
     // Create a wire for each inout operand, so there is something to connect
     // to. The instance becomes the sole driver of this wire.
-    auto wire = sv::WireOp::create(builder, portType,
-                                   "." + port.getName().str() + ".wire");
+    auto wire = hw::VarOp::create(
+        builder, portType,
+        builder.getStringAttr("." + port.getName().str() + ".wire"));
+    // auto wire = sv::WireOp::create(builder, portType,
+    //                                "." + port.getName().str() + ".wire");
 
     // Know that the argument FIRRTL value is equal to this wire, allowing
     // connects to it to be lowered.
@@ -4906,7 +4913,8 @@ LogicalResult FIRRTLLowering::visitExpr(InvalidValueOp op) {
   if (type_isa<AnalogType>(op.getType()))
     // This is a locally visible, private wire created by the compiler, so do
     // not attach a symbol name.
-    return setLoweringTo<sv::WireOp>(op, resultTy, ".invalid_analog");
+    // return setLoweringTo<sv::WireOp>(op, resultTy, ".invalid_analog");
+    return setLoweringTo<hw::VarOp>(op, resultTy, ".invalid_analog");
 
   // We don't allow aggregate values which contain values of analog types.
   if (type_cast<FIRRTLBaseType>(op.getType()).containsAnalog())
@@ -5161,8 +5169,8 @@ LogicalResult FIRRTLLowering::visitExpr(XMRRefOp op) {
   else
     xmrType = lowerType(baseType);
 
-  return setLoweringTo<sv::XMRRefOp>(op, sv::InOutType::get(xmrType),
-                                     op.getRef(), op.getVerbatimSuffixAttr());
+  return setLoweringTo<sv::XMRRefOp>(op, sv::VarType::get(xmrType), op.getRef(),
+                                     op.getVerbatimSuffixAttr());
 }
 
 LogicalResult FIRRTLLowering::visitExpr(XMRDerefOp op) {
@@ -5174,7 +5182,7 @@ LogicalResult FIRRTLLowering::visitExpr(XMRDerefOp op) {
   else
     xmrType = lowerType(op.getType());
 
-  auto xmr = sv::XMRRefOp::create(builder, sv::InOutType::get(xmrType),
+  auto xmr = sv::XMRRefOp::create(builder, sv::NetType::get(xmrType),
                                   op.getRef(), op.getVerbatimSuffixAttr());
   auto readXmr = getReadValue(xmr);
   if (!isa<ClockType>(op.getType()))
@@ -5255,11 +5263,18 @@ LogicalResult FIRRTLLowering::visitStmt(ConnectOp op) {
   if (updateIfBackedge(destVal, srcVal))
     return success();
 
-  if (!isa<hw::InOutType>(destVal.getType()))
-    return op.emitError("destination isn't an inout type");
-
-  sv::AssignOp::create(builder, destVal, srcVal);
-  return success();
+  return llvm::TypeSwitch<Type, LogicalResult>(destVal.getType())
+      .Case<sv::NetType>([&](auto) {
+        sv::AssignOp::create(builder, destVal, srcVal);
+        return success();
+      })
+      .Case<sv::VarType>([&](auto) {
+        sv::BPAssignOp::create(builder, destVal, srcVal);
+        return success();
+      })
+      .Default([&](auto) {
+        return op.emitError("destination isn't an SV lvalue type");
+      });
 }
 
 LogicalResult FIRRTLLowering::visitStmt(MatchingConnectOp op) {
@@ -5283,11 +5298,18 @@ LogicalResult FIRRTLLowering::visitStmt(MatchingConnectOp op) {
   if (updateIfBackedge(destVal, srcVal))
     return success();
 
-  if (!isa<hw::InOutType>(destVal.getType()))
-    return op.emitError("destination isn't an inout type");
-
-  sv::AssignOp::create(builder, destVal, srcVal);
-  return success();
+  return llvm::TypeSwitch<Type, LogicalResult>(destVal.getType())
+      .Case<sv::NetType>([&](auto) {
+        sv::AssignOp::create(builder, destVal, srcVal);
+        return success();
+      })
+      .Case<sv::VarType>([&](auto) {
+        sv::BPAssignOp::create(builder, destVal, srcVal);
+        return success();
+      })
+      .Default([&](auto) {
+        return op.emitError("destination isn't an SV lvalue type");
+      });
 }
 
 LogicalResult FIRRTLLowering::visitStmt(ForceOp op) {
@@ -5302,8 +5324,8 @@ LogicalResult FIRRTLLowering::visitStmt(ForceOp op) {
   if (!destVal)
     return failure();
 
-  if (!isa<hw::InOutType>(destVal.getType()))
-    return op.emitError("destination isn't an inout type");
+  if (!sv::getLvalueElementType(destVal.getType()))
+    return op.emitError("destination isn't an SV lvalue type");
 
   // #ifndef SYNTHESIS
   circuitState.addMacroDecl(builder.getStringAttr("SYNTHESIS"));
@@ -6035,7 +6057,15 @@ LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {
   }
 
   // If the attach operands contain a port, then we can't do anything to
-  // simplify the attach operation.
+  // simplify the attach operation. Convert to SV net types now, right before
+  // we actually need to emit SV ops.
+  SmallVector<Value, 4> netValues;
+  for (auto v : inoutValues) {
+    auto inoutType = cast<hw::InOutType>(v.getType());
+    netValues.push_back(sv::NetFromInOutOp::create(
+        builder, sv::NetType::get(inoutType.getElementType()), v));
+  }
+
   circuitState.addMacroDecl(builder.getStringAttr("SYNTHESIS"));
   circuitState.addMacroDecl(builder.getStringAttr("VERILATOR"));
   addToIfDefBlock(
@@ -6043,13 +6073,13 @@ LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {
       // If we're doing synthesis, we emit an all-pairs assign complex.
       [&]() {
         SmallVector<Value, 4> values;
-        for (auto inoutValue : inoutValues)
-          values.push_back(getReadValue(inoutValue));
+        for (auto netValue : netValues)
+          values.push_back(getReadValue(netValue));
 
-        for (size_t i1 = 0, e = inoutValues.size(); i1 != e; ++i1) {
+        for (size_t i1 = 0, e = netValues.size(); i1 != e; ++i1) {
           for (size_t i2 = 0; i2 != e; ++i2)
             if (i1 != i2)
-              sv::AssignOp::create(builder, inoutValues[i1], values[i2]);
+              sv::AssignOp::create(builder, netValues[i1], values[i2]);
         }
       },
       // In the non-synthesis case, we emit a SystemVerilog alias
@@ -6064,7 +6094,7 @@ LogicalResult FIRRTLLowering::visitStmt(AttachOp op) {
                   "cannot "
                   "arbitrarily connect bidirectional wires and ports\"");
             },
-            [&]() { sv::AliasOp::create(builder, inoutValues); });
+            [&]() { sv::AliasOp::create(builder, netValues); });
       });
 
   return success();

--- a/lib/Conversion/FSMToSV/FSMToSV.cpp
+++ b/lib/Conversion/FSMToSV/FSMToSV.cpp
@@ -203,7 +203,7 @@ void StateEncoding::setEncoding(StateOp state, Value v, bool wire) {
   if (wire) {
     auto loc = machine.getLoc();
     auto stateType = getStateType();
-    auto stateEncodingWire = sv::RegOp::create(
+    auto stateEncodingWire = sv::WireOp::create(
         b, loc, stateType, b.getStringAttr("to_" + state.getName()),
         hw::InnerSymAttr::get(state.getNameAttr()));
     sv::AssignOp::create(b, loc, stateEncodingWire, v);
@@ -277,7 +277,7 @@ private:
                           std::variant<Value, std::shared_ptr<CaseMuxItem>>>;
   struct CaseMuxItem {
     // The target wire to be assigned.
-    sv::RegOp wire;
+    sv::VarOp wire;
 
     // The case select signal to be used.
     Value select;
@@ -442,14 +442,14 @@ LogicalResult MachineOpConverter::dispatch() {
   auto stateType = encoding->getStateType();
 
   auto nextStateWire =
-      sv::RegOp::create(b, loc, stateType, b.getStringAttr("state_next"));
+      sv::VarOp::create(b, loc, stateType, b.getStringAttr("state_next"));
   auto nextStateWireRead = sv::ReadInOutOp::create(b, loc, nextStateWire);
   stateReg = seq::CompRegOp::create(
       b, loc, nextStateWireRead, clock, reset,
       /*reset value=*/encoding->encode(machineOp.getInitialStateOp()),
       "state_reg");
 
-  llvm::DenseMap<VariableOp, sv::RegOp> variableNextStateWires;
+  llvm::DenseMap<VariableOp, sv::VarOp> variableNextStateWires;
   for (auto variableOp : machineOp.front().getOps<fsm::VariableOp>()) {
     auto initValueAttr = dyn_cast<IntegerAttr>(variableOp.getInitValueAttr());
     if (!initValueAttr)
@@ -457,7 +457,7 @@ LogicalResult MachineOpConverter::dispatch() {
                                          "for the initial value.";
     Type varType = variableOp.getType();
     auto varLoc = variableOp.getLoc();
-    auto varNextState = sv::RegOp::create(
+    auto varNextState = sv::VarOp::create(
         b, varLoc, varType, b.getStringAttr(variableOp.getName() + "_next"));
     auto varResetVal = hw::ConstantOp::create(b, varLoc, initValueAttr);
     auto variableReg = seq::CompRegOp::create(
@@ -499,7 +499,7 @@ LogicalResult MachineOpConverter::dispatch() {
       continue;
     auto outputPortType = port.type;
     CaseMuxItem outputAssignment;
-    outputAssignment.wire = sv::RegOp::create(
+    outputAssignment.wire = sv::VarOp::create(
         b, machineOp.getLoc(), outputPortType,
         b.getStringAttr("output_" + std::to_string(portIndex)));
     outputAssignment.select = stateReg;

--- a/lib/Conversion/HWArithToHW/HWArithToHW.cpp
+++ b/lib/Conversion/HWArithToHW/HWArithToHW.cpp
@@ -126,6 +126,10 @@ static bool isSignednessType(Type type) {
           })
           .Case<hw::InOutType>(
               [](auto type) { return isSignednessType(type.getElementType()); })
+          .Case<sv::NetType, sv::VarType>([](auto type) {
+            Type elem = sv::getLvalueElementType(type);
+            return elem && isSignednessType(elem);
+          })
           .Case<hw::TypeAliasType>(
               [](auto type) { return isSignednessType(type.getInnerType()); })
           .Default([](auto type) { return false; });
@@ -399,6 +403,12 @@ Type HWArithToHWTypeConverter::removeSignedness(Type type) {
           })
           .Case<hw::InOutType>([this](auto type) {
             return hw::InOutType::get(removeSignedness(type.getElementType()));
+          })
+          .Case<sv::NetType>([this](auto type) {
+            return sv::NetType::get(removeSignedness(type.getElementType()));
+          })
+          .Case<sv::VarType>([this](auto type) {
+            return sv::VarType::get(removeSignedness(type.getElementType()));
           })
           .Case<hw::TypeAliasType>([this](auto type) {
             return hw::TypeAliasType::get(

--- a/lib/Conversion/SeqToSV/FirRegLowering.cpp
+++ b/lib/Conversion/SeqToSV/FirRegLowering.cpp
@@ -303,10 +303,10 @@ SmallVector<Value> FirRegLowering::createRandomizationVector(OpBuilder &builder,
   // Create randomization vector
   SmallVector<Value> randValues;
   auto numRandomCalls = (maxBit + 31) / 32;
-  auto logic = sv::LogicOp::create(
+  auto logic = sv::VarOp::create(
       builder, loc,
       hw::UnpackedArrayType::get(builder.getIntegerType(32), numRandomCalls),
-      "_RANDOM");
+      builder.getStringAttr("_RANDOM"));
   // Indvar's width must be equal to `ceil(log2(numRandomCalls +
   // 1))` to avoid overflow.
   auto inducionVariableWidth = llvm::Log2_64_Ceil(numRandomCalls + 1);
@@ -697,7 +697,7 @@ void FirRegLowering::lowerReg(FirRegOp reg) {
   ImplicitLocOpBuilder builder(reg.getLoc(), reg);
   RegLowerInfo svReg{nullptr, path, reg.getPresetAttr(), nullptr, nullptr,
                      -1,      0};
-  svReg.reg = sv::RegOp::create(builder, loc, regTy, reg.getNameAttr());
+  svReg.reg = sv::VarOp::create(builder, loc, regTy, reg.getNameAttr());
   svReg.width = hw::getBitWidth(regTy);
 
   if (auto attr = reg->getAttrOfType<IntegerAttr>("firrtl.random_init_start"))
@@ -757,7 +757,7 @@ void FirRegLowering::lowerReg(FirRegOp reg) {
   if (!conditions.empty())
     regConditionTable.emplace_or_assign(svReg.reg, conditions);
 
-  // For clock-typed registers the lowered sv.reg holds i1, but any remaining
+  // For clock-typed registers the lowered sv.var holds i1, but any remaining
   // users of the original !seq.clock result (e.g. seq.from_clock, hw.wire)
   // still expect that type.  Bridge the gap with a seq.to_clock so that those
   // users stay type-correct until applyPartialConversion resolves them via
@@ -777,7 +777,7 @@ void FirRegLowering::initializeRegisterElements(Location loc,
                                                 OpBuilder &builder, Value reg,
                                                 Value randomSource,
                                                 unsigned &pos) {
-  auto type = cast<sv::InOutType>(reg.getType()).getElementType();
+  auto type = sv::getLvalueElementType(reg.getType());
   if (auto intTy = hw::type_dyn_cast<IntegerType>(type)) {
     // Use randomSource[pos-1:pos-width] as a random value.
     pos -= intTy.getWidth();
@@ -803,7 +803,7 @@ void FirRegLowering::initializeRegisterElements(Location loc,
 }
 // NOLINTEND(misc-no-recursion)
 
-void FirRegLowering::buildRegConditions(OpBuilder &b, sv::RegOp reg) {
+void FirRegLowering::buildRegConditions(OpBuilder &b, sv::VarOp reg) {
   // If there are no conditions, just return the current insertion point.
   auto lookup = regConditionTable.find(reg);
   if (lookup == regConditionTable.end())
@@ -904,8 +904,7 @@ void FirRegLowering::addToAlwaysBlock(
       auto createIfOp = [&]() {
         // It is weird but intended. Here we want to create an empty sv.if
         // with an else block.
-        insideIfOp = sv::IfOp::create(
-            builder, reset, []() {}, []() {});
+        insideIfOp = sv::IfOp::create(builder, reset, []() {}, []() {});
       };
       if (resetStyle == sv::ResetType::AsyncReset) {
         sv::EventControl events[] = {clockEdge, resetEdge};

--- a/lib/Conversion/SeqToSV/FirRegLowering.h
+++ b/lib/Conversion/SeqToSV/FirRegLowering.h
@@ -74,7 +74,7 @@ private:
   bool unvisited = true;
 };
 
-/// Lower FirRegOp to `sv.reg` and `sv.always`.
+/// Lower FirRegOp to `sv.var` and `sv.always`.
 class FirRegLowering {
 public:
   /// A map sending registers to their paths.
@@ -117,7 +117,7 @@ private:
   };
 
   struct RegLowerInfo {
-    sv::RegOp reg;
+    sv::VarOp reg;
     hw::HierPathOp path;
     IntegerAttr preset;
     Value asyncResetSignal;
@@ -170,7 +170,7 @@ private:
 
   /// Recreate the ifdefs under which `reg` was defined. Leave the builder with
   /// its insertion point inside the created ifdef guards.
-  void buildRegConditions(OpBuilder &b, sv::RegOp reg);
+  void buildRegConditions(OpBuilder &b, sv::VarOp reg);
 
   using AlwaysKeyType = std::tuple<Block *, sv::EventControl, Value,
                                    sv::ResetType, sv::EventControl, Value>;
@@ -191,7 +191,7 @@ private:
 
   /// A map from RegOps to the ifdef conditions under which they are defined.
   /// We only bother recording a list of conditions if there is at least one.
-  DenseMap<sv::RegOp, std::vector<RegCondition>> regConditionTable;
+  DenseMap<sv::VarOp, std::vector<RegCondition>> regConditionTable;
 
   /// A map from async reset signal to the registers that use it.
   llvm::MapVector<Value, SmallVector<RegLowerInfo>> asyncResets;

--- a/lib/Conversion/SeqToSV/SeqToSV.cpp
+++ b/lib/Conversion/SeqToSV/SeqToSV.cpp
@@ -132,7 +132,7 @@ ModuleLoweringState::ImmutableValueLowering::lower(seq::InitialOp initialOp) {
   return success();
 }
 
-/// Lower CompRegOp to `sv.reg` and `sv.alwaysff`. Use a posedge clock and
+/// Lower CompRegOp to `sv.var` and `sv.alwaysff`. Use a posedge clock and
 /// synchronous reset.
 template <typename OpTy>
 class CompRegLower : public OpConversionPattern<OpTy> {
@@ -153,7 +153,7 @@ public:
 
     auto regTy =
         ConversionPattern::getTypeConverter()->convertType(reg.getType());
-    auto svReg = sv::RegOp::create(rewriter, loc, regTy, reg.getNameAttr(),
+    auto svReg = sv::VarOp::create(rewriter, loc, regTy, reg.getNameAttr(),
                                    reg.getInnerSymAttr());
 
     svReg->setDialectAttrs(reg->getDialectAttrs());
@@ -225,7 +225,7 @@ public:
 
   // Helper to create an assignment based on the register type.
   void createAssign(ConversionPatternRewriter &rewriter, Location loc,
-                    sv::RegOp svReg, OpAdaptor reg) const;
+                    sv::VarOp svReg, OpAdaptor reg) const;
 
 private:
   bool lowerToAlwaysFF;
@@ -235,21 +235,21 @@ private:
 /// Create the assign.
 template <>
 void CompRegLower<CompRegOp>::createAssign(ConversionPatternRewriter &rewriter,
-                                           Location loc, sv::RegOp svReg,
+                                           Location loc, sv::VarOp svReg,
                                            OpAdaptor reg) const {
   sv::PAssignOp::create(rewriter, loc, svReg, reg.getInput());
 }
 /// Create the assign inside of an if block.
 template <>
 void CompRegLower<CompRegClockEnabledOp>::createAssign(
-    ConversionPatternRewriter &rewriter, Location loc, sv::RegOp svReg,
+    ConversionPatternRewriter &rewriter, Location loc, sv::VarOp svReg,
     OpAdaptor reg) const {
   sv::IfOp::create(rewriter, loc, reg.getClockEnable(), [&]() {
     sv::PAssignOp::create(rewriter, loc, svReg, reg.getInput());
   });
 }
 
-/// Lower FromImmutable to `sv.reg` and `sv.initial`.
+/// Lower FromImmutable to `sv.var` and `sv.initial`.
 class FromImmutableLowering : public OpConversionPattern<FromImmutableOp> {
 public:
   FromImmutableLowering(
@@ -267,7 +267,7 @@ public:
 
     auto regTy = ConversionPattern::getTypeConverter()->convertType(
         fromImmutableOp.getType());
-    auto svReg = sv::RegOp::create(rewriter, loc, regTy);
+    auto svReg = sv::VarOp::create(rewriter, loc, regTy);
 
     auto regVal = sv::ReadInOutOp::create(rewriter, loc, svReg);
 
@@ -311,7 +311,7 @@ public:
 
     // Enable latch.
     Value enableLatch =
-        sv::RegOp::create(rewriter, loc, rewriter.getI1Type(),
+        sv::VarOp::create(rewriter, loc, rewriter.getI1Type(),
                           rewriter.getStringAttr("cg_en_latch"));
 
     // Latch the enable signal using an always @* block.
@@ -505,7 +505,7 @@ public:
 
     SmallVector<Value> regs;
     for (unsigned i = 0; i < clockDiv.getPow2(); ++i) {
-      Value reg = sv::RegOp::create(
+      Value reg = sv::VarOp::create(
           rewriter, loc, rewriter.getI1Type(),
           rewriter.getStringAttr("clock_out_" + std::to_string(i)));
       regs.push_back(reg);
@@ -782,8 +782,7 @@ void SeqToSVPass::runOnOperation() {
 
   // Helper function to emit #ifndef guard.
   auto emitGuard = [&](const char *guard, llvm::function_ref<void(void)> body) {
-    sv::IfDefOp::create(
-        b, guard, []() {}, body);
+    sv::IfDefOp::create(b, guard, []() {}, body);
   };
 
   emit::FragmentOp::create(b, randomInitFragmentName.getAttr(), [&] {

--- a/lib/Conversion/SimToSV/SimToSV.cpp
+++ b/lib/Conversion/SimToSV/SimToSV.cpp
@@ -127,7 +127,7 @@ public:
     auto loc = op.getLoc();
     auto resultType = rewriter.getIntegerType(1);
     auto str = sv::ConstantStrOp::create(rewriter, loc, op.getFormatString());
-    auto reg = sv::RegOp::create(rewriter, loc, resultType,
+    auto reg = sv::VarOp::create(rewriter, loc, resultType,
                                  rewriter.getStringAttr("_pargs"));
     sv::InitialOp::create(rewriter, loc, [&] {
       auto call = sv::SystemFunctionOp::create(
@@ -177,9 +177,9 @@ public:
         },
         [&]() {
           auto i32ty = rewriter.getIntegerType(32);
-          auto regf = sv::RegOp::create(rewriter, loc, i32ty,
+          auto regf = sv::VarOp::create(rewriter, loc, i32ty,
                                         rewriter.getStringAttr("_found"));
-          auto regv = sv::RegOp::create(rewriter, loc, type,
+          auto regv = sv::VarOp::create(rewriter, loc, type,
                                         rewriter.getStringAttr("_value"));
           sv::InitialOp::create(rewriter, loc, [&] {
             auto str =
@@ -337,11 +337,11 @@ public:
     bool isClockedCall = !!op.getClock();
     bool hasEnable = !!op.getEnable();
 
-    SmallVector<sv::RegOp> temporaries;
+    SmallVector<sv::VarOp> temporaries;
     SmallVector<Value> reads;
     for (auto [type, result] :
          llvm::zip(op.getResultTypes(), op.getResults())) {
-      temporaries.push_back(sv::RegOp::create(rewriter, op.getLoc(), type));
+      temporaries.push_back(sv::VarOp::create(rewriter, op.getLoc(), type));
       reads.push_back(
           sv::ReadInOutOp::create(rewriter, op.getLoc(), temporaries.back()));
     }

--- a/lib/Conversion/VerifToSV/VerifToSV.cpp
+++ b/lib/Conversion/VerifToSV/VerifToSV.cpp
@@ -71,7 +71,7 @@ struct HasBeenResetConversion : public OpConversionPattern<HasBeenResetOp> {
     auto constX = sv::ConstantXOp::create(rewriter, op.getLoc(), i1);
 
     // Declare the register that will track the reset state.
-    auto reg = sv::RegOp::create(rewriter, op.getLoc(), i1,
+    auto reg = sv::VarOp::create(rewriter, op.getLoc(), i1,
                                  rewriter.getStringAttr("hasBeenResetReg"));
 
     auto clock = operands.getClock();

--- a/lib/Dialect/Arc/Transforms/ResolveXMRRef.cpp
+++ b/lib/Dialect/Arc/Transforms/ResolveXMRRef.cpp
@@ -12,6 +12,7 @@
 #include "circt/Dialect/HW/HWTypes.h"
 #include "circt/Dialect/HW/InnerSymbolTable.h"
 #include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/SV/SVTypes.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/raw_ostream.h"
@@ -354,7 +355,7 @@ void ResolveXMRRefPass::runOnOperation() {
     OpBuilder builder(xmrRefOp);
     Value resolvedValue = nullptr;
 
-    Type targetType = cast<hw::InOutType>(xmrRefOp.getType()).getElementType();
+    Type targetType = sv::getLvalueElementType(xmrRefOp.getType());
 
     ArrayAttr pathArray = pathOp.getNamepath();
     auto currentModule = xmrRefOp->getParentOfType<hw::HWModuleOp>();

--- a/lib/Dialect/ESI/ESIServices.cpp
+++ b/lib/Dialect/ESI/ESIServices.cpp
@@ -258,7 +258,7 @@ instantiateSystemVerilogMemory(ServiceImplementReqOp implReq,
   hw::UnpackedArrayType memType =
       hw::UnpackedArrayType::get(ramDecl.getInnerType(), ramDecl.getDepth());
   auto mem =
-      sv::RegOp::create(b, memType, implReq.getServiceSymbolAttr().getAttr())
+      sv::VarOp::create(b, memType, implReq.getServiceSymbolAttr().getAttr())
           .getResult();
 
   // Do everything which doesn't actually write to the memory, store the signals

--- a/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
+++ b/lib/Dialect/ESI/Passes/ESILowerToHW.cpp
@@ -657,8 +657,9 @@ LogicalResult ManifestRomLowering::createRomModule(
       hw::UnpackedArrayType::get(rewriter.getI64Type(), words.size()),
       rewriter.getArrayAttr(wordAttrs));
   auto manifestReg =
-      sv::RegOp::create(rewriter, loc, manifestConstant.getType());
-  sv::AssignOp::create(rewriter, loc, manifestReg, manifestConstant);
+      sv::VarOp::create(rewriter, loc, manifestConstant.getType(),
+                        /*name=*/StringAttr{}, /*innerSym=*/hw::InnerSymAttr{},
+                        /*init=*/manifestConstant.getResult());
 
   // Slim down the address, register it, do the lookup, and register the output.
   size_t addrBits = llvm::Log2_64_Ceil(words.size());
@@ -739,9 +740,10 @@ LogicalResult CosimManifestLowering::matchAndRewrite(
             rewriter, loc,
             hw::ArrayType::get(rewriter.getI8Type(), bytes.size()),
             rewriter.getArrayAttr(bytes));
-        auto manifestLogic =
-            sv::LogicOp::create(rewriter, loc, manifestConstant.getType());
-        sv::AssignOp::create(rewriter, loc, manifestLogic, manifestConstant);
+        auto manifestLogic = sv::VarOp::create(
+            rewriter, loc, manifestConstant.getType(),
+            /*name=*/StringAttr{}, /*innerSym=*/hw::InnerSymAttr{},
+            /*init=*/manifestConstant.getResult());
         auto manifest = sv::ReadInOutOp::create(rewriter, loc, manifestLogic);
 
         // Then instantiate the external module.

--- a/lib/Dialect/HW/HWOps.cpp
+++ b/lib/Dialect/HW/HWOps.cpp
@@ -405,6 +405,33 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
 }
 
 //===----------------------------------------------------------------------===//
+// VarOp
+//===----------------------------------------------------------------------===//
+
+void VarOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+  // If the variable has an optional 'name' attribute, use it.
+  auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
+  if (nameAttr && !nameAttr.getValue().empty())
+    setNameFn(getResult(), nameAttr.getValue());
+}
+
+std::optional<size_t> VarOp::getTargetResultIndex() { return 0; }
+
+LogicalResult VarOp::canonicalize(VarOp var, PatternRewriter &rewriter) {
+  // If the var has a symbol, it may be referenced elsewhere; keep it.
+  if (var.getInnerSymAttr())
+    return failure();
+
+  // If the var has no uses, it's dead, so remove it.
+  if (var.getResult().use_empty()) {
+    rewriter.eraseOp(var);
+    return success();
+  }
+
+  return failure();
+}
+
+//===----------------------------------------------------------------------===//
 // AggregateConstantOp
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/SV/SVOps.cpp
+++ b/lib/Dialect/SV/SVOps.cpp
@@ -356,21 +356,46 @@ LogicalResult LocalParamOp::verify() {
 }
 
 //===----------------------------------------------------------------------===//
-// RegOp
+// VarOp
 //===----------------------------------------------------------------------===//
 
+static ParseResult parseNetAssignTypes(OpAsmParser &p, mlir::Type &destType,
+                                       mlir::Type &srcType) {
+  if (p.parseType(srcType))
+    return failure();
+  destType = NetType::get(srcType);
+  return success();
+}
+
+static void printNetAssignTypes(OpAsmPrinter &p, Operation *op,
+                                mlir::Type destType, mlir::Type srcType) {
+  p.printType(srcType);
+}
+
+static ParseResult parseVarAssignTypes(OpAsmParser &p, mlir::Type &destType,
+                                       mlir::Type &srcType) {
+  if (p.parseType(srcType))
+    return failure();
+  destType = VarType::get(srcType);
+  return success();
+}
+
+static void printVarAssignTypes(OpAsmPrinter &p, Operation *op,
+                                mlir::Type destType, mlir::Type srcType) {
+  p.printType(srcType);
+}
+
 static ParseResult
-parseImplicitInitType(OpAsmParser &p, mlir::Type regType,
+parseImplicitInitType(OpAsmParser &p, mlir::Type varType,
                       std::optional<OpAsmParser::UnresolvedOperand> &initValue,
                       mlir::Type &initType) {
   if (!initValue.has_value())
     return success();
 
-  hw::InOutType ioType = dyn_cast<hw::InOutType>(regType);
-  if (!ioType)
-    return p.emitError(p.getCurrentLocation(), "expected inout type for reg");
-
-  initType = ioType.getElementType();
+  initType = getLvalueElementType(varType);
+  if (!initType)
+    return p.emitError(p.getCurrentLocation(),
+                       "expected SV lvalue type for variable");
   return success();
 }
 
@@ -378,81 +403,78 @@ static void printImplicitInitType(OpAsmPrinter &p, Operation *op,
                                   mlir::Type regType, mlir::Value initValue,
                                   mlir::Type initType) {}
 
-void RegOp::build(OpBuilder &builder, OperationState &odsState,
+void VarOp::build(OpBuilder &builder, OperationState &odsState,
                   Type elementType, StringAttr name, hw::InnerSymAttr innerSym,
-                  mlir::Value initValue) {
+                  mlir::Value initValue, SVVarKeywordAttr keyword) {
   if (!name)
     name = builder.getStringAttr("");
   odsState.addAttribute("name", name);
   if (innerSym)
     odsState.addAttribute(hw::InnerSymbolTable::getInnerSymbolAttrName(),
                           innerSym);
-  odsState.addTypes(hw::InOutType::get(elementType));
+  if (keyword)
+    odsState.addAttribute("keyword", keyword);
+  odsState.addTypes(VarType::get(elementType));
   if (initValue)
     odsState.addOperands(initValue);
 }
 
 /// Suggest a name for each result value based on the saved result names
 /// attribute.
-void RegOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
+void VarOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   // If the wire has an optional 'name' attribute, use it.
   auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
   if (!nameAttr.getValue().empty())
     setNameFn(getResult(), nameAttr.getValue());
 }
 
-std::optional<size_t> RegOp::getTargetResultIndex() { return 0; }
+std::optional<size_t> VarOp::getTargetResultIndex() { return 0; }
 
-// If this reg is only written to, delete the reg and all writers.
-LogicalResult RegOp::canonicalize(RegOp op, PatternRewriter &rewriter) {
+// If this variable is only written to, delete the variable and all writers.
+LogicalResult VarOp::canonicalize(VarOp op, PatternRewriter &rewriter) {
   // Block if op has SV attributes.
   if (hasSVAttributes(op))
     return failure();
 
-  // If the reg has a symbol, then we can't delete it.
+  // If the variable has a symbol, then we can't delete it.
   if (op.getInnerSymAttr())
     return failure();
-  // Check that all operations on the wire are sv.assigns. All other wire
+  // Check that all operations on the variable are assignments. All other
   // operations will have been handled by other canonicalization.
   for (auto *user : op.getResult().getUsers())
-    if (!isa<AssignOp>(user))
+    if (!isa<AssignOp, BPAssignOp, PAssignOp>(user))
       return failure();
 
-  // Remove all uses of the wire.
+  // Remove all uses of the variable.
   for (auto *user : llvm::make_early_inc_range(op.getResult().getUsers()))
     rewriter.eraseOp(user);
 
-  // Remove the wire.
+  // Remove the variable.
   rewriter.eraseOp(op);
   return success();
 }
 
 //===----------------------------------------------------------------------===//
-// LogicOp
+// NetFromInOutOp / InOutFromNetOp folds
 //===----------------------------------------------------------------------===//
 
-void LogicOp::build(OpBuilder &builder, OperationState &odsState,
-                    Type elementType, StringAttr name,
-                    hw::InnerSymAttr innerSym) {
-  if (!name)
-    name = builder.getStringAttr("");
-  odsState.addAttribute("name", name);
-  if (innerSym)
-    odsState.addAttribute(hw::InnerSymbolTable::getInnerSymbolAttrName(),
-                          innerSym);
-  odsState.addTypes(hw::InOutType::get(elementType));
+OpFoldResult NetFromInOutOp::fold(FoldAdaptor adaptor) {
+  // sv.net.from_inout(sv.inout.from_net(x)) -> x
+  if (auto inoutFromNet = getInput().getDefiningOp<InOutFromNetOp>())
+    return inoutFromNet.getInput();
+  return {};
 }
 
-/// Suggest a name for each result value based on the saved result names
-/// attribute.
-void LogicOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
-  // If the logic has an optional 'name' attribute, use it.
-  auto nameAttr = (*this)->getAttrOfType<StringAttr>("name");
-  if (!nameAttr.getValue().empty())
-    setNameFn(getResult(), nameAttr.getValue());
-}
+//===----------------------------------------------------------------------===//
+// InOutFromNetOp folds
+//===----------------------------------------------------------------------===//
 
-std::optional<size_t> LogicOp::getTargetResultIndex() { return 0; }
+OpFoldResult InOutFromNetOp::fold(FoldAdaptor adaptor) {
+  // sv.inout.from_net(sv.net.from_inout(x)) -> x
+  if (auto netFromInOut = getInput().getDefiningOp<NetFromInOutOp>())
+    return netFromInOut.getInput();
+  return {};
+}
 
 //===----------------------------------------------------------------------===//
 // Control flow like-operations
@@ -1365,7 +1387,7 @@ LogicalResult BPAssignOp::verify() {
   if (isa<sv::WireOp>(getDest().getDefiningOp()))
     return emitOpError(
         "Verilog disallows procedural assignment to a net type (did you intend "
-        "to use a variable type, e.g., sv.reg?)");
+        "to use a variable type, e.g., sv.var?)");
   return success();
 }
 
@@ -1373,7 +1395,7 @@ LogicalResult PAssignOp::verify() {
   if (isa<sv::WireOp>(getDest().getDefiningOp()))
     return emitOpError(
         "Verilog disallows procedural assignment to a net type (did you intend "
-        "to use a variable type, e.g., sv.reg?)");
+        "to use a variable type, e.g., sv.var?)");
   return success();
 }
 
@@ -1763,7 +1785,7 @@ void WireOp::build(OpBuilder &builder, OperationState &odsState,
                           innerSym);
 
   odsState.addAttribute("name", name);
-  odsState.addTypes(InOutType::get(elementType));
+  odsState.addTypes(NetType::get(elementType));
 }
 
 /// Suggest a name for each result value based on the saved result names
@@ -1818,9 +1840,9 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
     // If no write and only reads, then replace with ZOp.
     // SV 6.6: "If no driver is connected to a net, its
     // value shall be high-impedance (z) unless the net is a trireg"
-    connected = ConstantZOp::create(
-        rewriter, wire.getLoc(),
-        cast<InOutType>(wire.getResult().getType()).getElementType());
+    connected =
+        ConstantZOp::create(rewriter, wire.getLoc(),
+                            getLvalueElementType(wire.getResult().getType()));
   } else if (isa<hw::HWModuleOp>(write->getParentOp()))
     connected = write.getSrc();
   else
@@ -1852,12 +1874,14 @@ LogicalResult WireOp::canonicalize(WireOp wire, PatternRewriter &rewriter) {
 
 // A helper function to infer a return type of IndexedPartSelectInOutOp.
 static Type getElementTypeOfWidth(Type type, int32_t width) {
-  auto elemTy = cast<hw::InOutType>(type).getElementType();
+  auto elemTy = getLvalueElementType(type);
   if (isa<IntegerType>(elemTy))
-    return hw::InOutType::get(IntegerType::get(type.getContext(), width));
+    return getLvalueOfSameCategory(type,
+                                   IntegerType::get(type.getContext(), width));
   if (isa<hw::ArrayType>(elemTy))
-    return hw::InOutType::get(hw::ArrayType::get(
-        cast<hw::ArrayType>(elemTy).getElementType(), width));
+    return getLvalueOfSameCategory(
+        type, hw::ArrayType::get(cast<hw::ArrayType>(elemTy).getElementType(),
+                                 width));
   return {};
 }
 
@@ -1867,22 +1891,31 @@ LogicalResult IndexedPartSelectInOutOp::inferReturnTypes(
     mlir::RegionRange regions, SmallVectorImpl<Type> &results) {
   Adaptor adaptor(operands, attrs, properties, regions);
   auto width = adaptor.getWidthAttr();
-  if (!width)
+  if (!width || operands.empty())
     return failure();
 
-  auto typ = getElementTypeOfWidth(operands[0].getType(),
-                                   width.getValue().getZExtValue());
-  if (!typ)
+  Type inputType = operands[0].getType();
+  if (!inputType)
     return failure();
-  results.push_back(typ);
+
+  Type elemType = getLvalueElementType(inputType);
+  if (!elemType)
+    return failure();
+
+  Type resultType =
+      getElementTypeOfWidth(inputType, width.getValue().getZExtValue());
+  if (!resultType)
+    return failure();
+
+  results.push_back(resultType);
   return success();
 }
 
 LogicalResult IndexedPartSelectInOutOp::verify() {
   unsigned inputWidth = 0, resultWidth = 0;
   auto opWidth = getWidth();
-  auto inputElemTy = cast<InOutType>(getInput().getType()).getElementType();
-  auto resultElemTy = cast<InOutType>(getType()).getElementType();
+  auto inputElemTy = getLvalueElementType(getInput().getType());
+  auto resultElemTy = getLvalueElementType(getType());
   if (auto i = dyn_cast<IntegerType>(inputElemTy))
     inputWidth = i.getWidth();
   else if (auto i = hw::type_cast<hw::ArrayType>(inputElemTy))
@@ -1952,19 +1985,40 @@ LogicalResult StructFieldInOutOp::inferReturnTypes(
   auto field = adaptor.getFieldAttr();
   if (!field)
     return failure();
+  auto lvalueType = operands[0].getType();
   auto structType =
-      hw::type_cast<hw::StructType>(getInOutElementType(operands[0].getType()));
+      hw::type_cast<hw::StructType>(getLvalueElementType(lvalueType));
   auto resultType = structType.getFieldType(field);
   if (!resultType)
     return failure();
-
-  results.push_back(hw::InOutType::get(resultType));
+  results.push_back(getLvalueOfSameCategory(lvalueType, resultType));
   return success();
 }
 
 //===----------------------------------------------------------------------===//
 // Other ops.
 //===----------------------------------------------------------------------===//
+
+static bool isIllegalVariableForceTarget(Value target) {
+  auto *projection = target.getDefiningOp();
+  if (!isa_and_nonnull<ArrayIndexInOutOp, IndexedPartSelectInOutOp>(projection))
+    return false;
+  return isSVVar(projection->getOperand(0).getType());
+}
+
+LogicalResult ForceOp::verify() {
+  if (isIllegalVariableForceTarget(getDest()))
+    return emitOpError(
+        "cannot force a memory word or bit/part-select of a variable");
+  return success();
+}
+
+LogicalResult ReleaseOp::verify() {
+  if (isIllegalVariableForceTarget(getDest()))
+    return emitOpError(
+        "cannot release a memory word or bit/part-select of a variable");
+  return success();
+}
 
 LogicalResult AliasOp::verify() {
   // Must have at least two operands.

--- a/lib/Dialect/SV/SVTypes.cpp
+++ b/lib/Dialect/SV/SVTypes.cpp
@@ -45,6 +45,46 @@ mlir::Type circt::sv::getInOutElementType(mlir::Type type) {
   return {};
 }
 
+Type circt::sv::getLvalueElementType(Type type) {
+  type = hw::getCanonicalType(type);
+  return TypeSwitch<Type, Type>(type)
+      .Case<NetType, VarType>([](auto type) { return type.getElementType(); })
+      .Default([](Type) { return Type{}; });
+}
+
+Type circt::sv::getForceDestElementType(Type type) {
+  if (auto element = getLvalueElementType(type))
+    return element;
+  return getInOutElementType(type);
+}
+
+bool circt::sv::isSVNet(Type type) { return hw::type_isa<NetType>(type); }
+
+bool circt::sv::isSVVar(Type type) { return hw::type_isa<VarType>(type); }
+
+Type circt::sv::getLvalueOfSameCategory(Type lvalue, Type newElement) {
+  lvalue = hw::getCanonicalType(lvalue);
+  return TypeSwitch<Type, Type>(lvalue)
+      .Case([&](NetType) -> Type { return NetType::get(newElement); })
+      .Case([&](VarType) -> Type { return VarType::get(newElement); })
+      .Default([](Type) { return Type{}; });
+}
+
+LogicalResult NetType::verify(function_ref<InFlightDiagnostic()> emitError,
+                              Type elementType) {
+  if (!hw::isHWValueType(elementType))
+    return emitError() << "invalid element for sv.net type " << elementType;
+  return success();
+}
+
+LogicalResult VarType::verify(function_ref<InFlightDiagnostic()> emitError,
+                              Type elementType) {
+  if (!hw::isHWValueType(elementType))
+    return emitError() << "invalid element for sv.var type " << elementType;
+  // TODO: Support SV variable-only element types in a later change.
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // TableGen generated logic.
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/SV/Transforms/HWEliminateInOutPorts.cpp
+++ b/lib/Dialect/SV/Transforms/HWEliminateInOutPorts.cpp
@@ -73,6 +73,7 @@ private:
   llvm::StringRef readSuffix;
   // Suffix to be used when creating write ports.
   llvm::StringRef writeSuffix;
+  llvm::SmallVector<sv::NetFromInOutOp, 1> bridges;
 };
 
 HWInOutPortConversion::HWInOutPortConversion(PortConverterImpl &converter,
@@ -83,15 +84,23 @@ HWInOutPortConversion::HWInOutPortConversion(PortConverterImpl &converter,
       writeSuffix(writeSuffix) {}
 
 LogicalResult HWInOutPortConversion::init() {
-  // Gather readers and writers (how to handle sv.passign?)
+  // An HW inout port is seen by SV operations through an SV net bridge.
   for (auto *user : body->getArgument(origPort.argNum).getUsers()) {
-    if (auto read = dyn_cast<sv::ReadInOutOp>(user))
-      readers.push_back(read);
-    else if (auto write = dyn_cast<sv::AssignOp>(user))
-      writers.push_back(write);
-    else
+    auto bridge = dyn_cast<sv::NetFromInOutOp>(user);
+    if (!bridge)
       return user->emitOpError() << "uses hw.inout port " << origPort.name
                                  << " but the operation itself is unsupported.";
+    bridges.push_back(bridge);
+    for (auto *bridgeUser : bridge.getResult().getUsers()) {
+      if (auto read = dyn_cast<sv::ReadInOutOp>(bridgeUser))
+        readers.push_back(read);
+      else if (auto write = dyn_cast<sv::AssignOp>(bridgeUser))
+        writers.push_back(write);
+      else
+        return bridgeUser->emitOpError()
+               << "uses hw.inout port " << origPort.name
+               << " but the operation itself is unsupported.";
+    }
   }
 
   if (writers.size() > 1)
@@ -107,12 +116,7 @@ void HWInOutPortConversion::buildInputSignals() {
     // Replace all sv::ReadInOutOp's with the new input.
     Value readValue =
         converter.createNewInput(origPort, readSuffix, origPort.type, readPort);
-    Value origInput = body->getArgument(origPort.argNum);
-    for (auto *user : llvm::make_early_inc_range(origInput.getUsers())) {
-      sv::ReadInOutOp read = dyn_cast<sv::ReadInOutOp>(user);
-      if (!read)
-        continue;
-
+    for (auto read : readers) {
       read.replaceAllUsesWith(readValue);
       read.erase();
     }
@@ -125,6 +129,10 @@ void HWInOutPortConversion::buildInputSignals() {
                               write.getSrc(), writePort);
     write.erase();
   }
+
+  for (auto bridge : bridges)
+    if (bridge->use_empty())
+      bridge.erase();
 }
 
 void HWInOutPortConversion::buildOutputSignals() {
@@ -144,15 +152,21 @@ void HWInOutPortConversion::mapInputSignals(OpBuilder &b, Operation *inst,
   if (hasReaders()) {
     // Create a read_inout op at the instantiation point. This effectively
     // pushes the read_inout op from the module to the instantiation site.
+    auto bridge = NetFromInOutOp::create(
+        b, inst->getLoc(),
+        NetType::get(getInOutElementType(instValue.getType())), instValue);
     newOperands[readPort.argNum] =
-        ReadInOutOp::create(b, inst->getLoc(), instValue).getResult();
+        ReadInOutOp::create(b, inst->getLoc(), bridge).getResult();
   }
 
   if (hasWriters()) {
     // Create a sv::AssignOp at the instantiation point. This effectively
     // pushes the write op from the module to the instantiation site.
     Value writeFromInsideMod = newResults[writePort.argNum];
-    sv::AssignOp::create(b, inst->getLoc(), instValue, writeFromInsideMod);
+    auto bridge = NetFromInOutOp::create(
+        b, inst->getLoc(),
+        NetType::get(getInOutElementType(instValue.getType())), instValue);
+    sv::AssignOp::create(b, inst->getLoc(), bridge, writeFromInsideMod);
   }
 }
 

--- a/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
+++ b/lib/Dialect/SV/Transforms/HWLegalizeModules.cpp
@@ -157,11 +157,12 @@ bool HWLegalizeModulesPass::tryLoweringPackedArrayOp(Operation &op) {
 
         // Skip index ops with unpacked arrays.
         auto inout = indexOp.getInput().getType();
-        if (hw::type_isa<hw::UnpackedArrayType>(inout.getElementType()))
+        if (hw::type_isa<hw::UnpackedArrayType>(
+                sv::getLvalueElementType(inout)))
           return false;
 
         // Generate case value element lookups.
-        auto ty = hw::type_cast<hw::ArrayType>(inout.getElementType());
+        auto ty = hw::type_cast<hw::ArrayType>(sv::getLvalueElementType(inout));
         OpBuilder builder(&op);
         auto loc = op.getLoc();
         const auto indexValues = createIndexValuePairs<sv::ArrayIndexInOutOp>(
@@ -201,7 +202,7 @@ bool HWLegalizeModulesPass::tryLoweringPackedArrayOp(Operation &op) {
         // Remove original assignment.
         return true;
       })
-      .Case<sv::RegOp>([&](sv::RegOp regOp) {
+      .Case<sv::VarOp>([&](sv::VarOp regOp) {
         // Transform array reg into individual regs for each array element.
         auto ty = hw::type_dyn_cast<hw::ArrayType>(regOp.getElementType());
         if (!ty)
@@ -212,7 +213,7 @@ bool HWLegalizeModulesPass::tryLoweringPackedArrayOp(Operation &op) {
         SmallVector<Value> elements;
         for (size_t i = 0, e = ty.getNumElements(); i < e; i++) {
           auto loc = op.getLoc();
-          auto element = sv::RegOp::create(builder, loc, ty.getElementType());
+          auto element = sv::VarOp::create(builder, loc, ty.getElementType());
           if (auto nameAttr = regOp->getAttrOfType<StringAttr>(name)) {
             element.setNameAttr(
                 StringAttr::get(regOp.getContext(), nameAttr.getValue()));
@@ -281,7 +282,7 @@ Value HWLegalizeModulesPass::lowerLookupToCasez(Operation &op, Value input,
   // Create the wire for the result of the casez in the
   // hw.module.
   OpBuilder builder(&op);
-  auto theWire = sv::RegOp::create(builder, op.getLoc(), elementType,
+  auto theWire = sv::VarOp::create(builder, op.getLoc(), elementType,
                                    builder.getStringAttr("casez_tmp"));
   builder.setInsertionPoint(&op);
 

--- a/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
+++ b/lib/Dialect/Seq/Transforms/HWMemSimImpl.cpp
@@ -50,7 +50,7 @@ class HWMemSimImpl {
   bool disableRegRandomization;
   bool addVivadoRAMAddressConflictSynthesisBugWorkaround;
 
-  SmallVector<sv::RegOp> registers;
+  SmallVector<sv::VarOp> registers;
 
   Value addPipelineStages(ImplicitLocOpBuilder &b,
                           hw::InnerSymbolNamespace &moduleNamespace,
@@ -112,8 +112,7 @@ static Value getMemoryRead(ImplicitLocOpBuilder &b, Value memory, Value addr,
       b, sv::ArrayIndexInOutOp::create(b, memory, addr));
   // If we don't want to add mux pragmas, just return the read value.
   if (!addMuxPragmas ||
-      cast<hw::UnpackedArrayType>(
-          cast<hw::InOutType>(memory.getType()).getElementType())
+      cast<hw::UnpackedArrayType>(sv::getLvalueElementType(memory.getType()))
               .getNumElements() <= 1)
     return slot;
   circt::sv::setSVAttributes(
@@ -150,12 +149,12 @@ Value HWMemSimImpl::addPipelineStages(ImplicitLocOpBuilder &b,
 
   // Add the necessary registers.
   auto savedIP = b.saveInsertionPoint();
-  SmallVector<sv::RegOp> regs;
+  SmallVector<sv::VarOp> regs;
   b.setInsertionPoint(alwaysOp);
   for (unsigned i = 0; i < stages; ++i) {
     auto regName =
         b.getStringAttr(moduleNamespace.newName("_" + name + "_d" + Twine(i)));
-    auto reg = sv::RegOp::create(b, data.getType(), regName,
+    auto reg = sv::VarOp::create(b, data.getType(), regName,
                                  hw::InnerSymAttr::get(regName));
     regs.push_back(reg);
     registers.push_back(reg);
@@ -199,8 +198,8 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
       mem.numReadPorts + mem.numWritePorts + mem.numReadWritePorts;
 
   // Create registers for the memory.
-  sv::RegOp reg =
-      sv::RegOp::create(b, UnpackedArrayType::get(dataType, mem.depth),
+  sv::VarOp reg =
+      sv::VarOp::create(b, UnpackedArrayType::get(dataType, mem.depth),
                         b.getStringAttr("Memory"));
 
   if (addVivadoRAMAddressConflictSynthesisBugWorkaround) {
@@ -570,23 +569,23 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
 
   constexpr unsigned randomWidth = 32;
   sv::IfDefOp::create(b, "ENABLE_INITIAL_MEM_", [&]() {
-    sv::RegOp randReg;
-    SmallVector<sv::RegOp> randRegs;
+    sv::VarOp randReg;
+    SmallVector<sv::VarOp> randRegs;
     if (!disableRegRandomization) {
       sv::IfDefOp::create(b, "RANDOMIZE_REG_INIT", [&]() {
         signed totalWidth = 0;
-        for (sv::RegOp &reg : registers)
+        for (sv::VarOp &reg : registers)
           totalWidth += reg.getElementType().getIntOrFloatBitWidth();
         while (totalWidth > 0) {
           auto name = b.getStringAttr(moduleNamespace.newName("_RANDOM"));
           auto innerSym = hw::InnerSymAttr::get(name);
-          randRegs.push_back(sv::RegOp::create(b, b.getIntegerType(randomWidth),
+          randRegs.push_back(sv::VarOp::create(b, b.getIntegerType(randomWidth),
                                                name, innerSym));
           totalWidth -= randomWidth;
         }
       });
     }
-    auto randomMemReg = sv::RegOp::create(
+    auto randomMemReg = sv::VarOp::create(
         b,
         b.getIntegerType(llvm::divideCeil(mem.dataWidth, randomWidth) *
                          randomWidth),
@@ -654,13 +653,13 @@ void HWMemSimImpl::generateMemory(HWModuleOp op, FirMemory mem) {
       if (!disableRegRandomization) {
         sv::IfDefProceduralOp::create(b, "RANDOMIZE_REG_INIT", [&]() {
           unsigned bits = randomWidth;
-          for (sv::RegOp &reg : randRegs)
+          for (sv::VarOp &reg : randRegs)
             sv::VerbatimOp::create(
                 b, b.getStringAttr("{{0}} = {`RANDOM};"), ValueRange{},
                 b.getArrayAttr(hw::InnerRefAttr::get(op.getNameAttr(),
                                                      reg.getInnerNameAttr())));
           auto randRegIdx = 0;
-          for (sv::RegOp &reg : registers) {
+          for (sv::VarOp &reg : registers) {
             SmallVector<std::pair<Attribute, std::pair<size_t, size_t>>> values;
             auto width = reg.getElementType().getIntOrFloatBitWidth();
             auto widthRemaining = width;

--- a/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
+++ b/lib/Dialect/Seq/Transforms/LowerSeqHLMem.cpp
@@ -75,7 +75,7 @@ public:
     hw::UnpackedArrayType memArrType =
         hw::UnpackedArrayType::get(memType.getElementType(), size);
     auto svMem =
-        sv::RegOp::create(rewriter, mem.getLoc(), memArrType, mem.getNameAttr())
+        sv::VarOp::create(rewriter, mem.getLoc(), memArrType, mem.getNameAttr())
             .getResult();
 
     // Create write ports by gathering up the write port inputs and

--- a/lib/Target/DebugInfo/EmitHGLDD.cpp
+++ b/lib/Target/DebugInfo/EmitHGLDD.cpp
@@ -215,6 +215,8 @@ struct EmittedType {
     type = hw::getCanonicalType(type);
     if (auto inoutType = dyn_cast<hw::InOutType>(type))
       type = hw::getCanonicalType(inoutType.getElementType());
+    if (auto lvalueType = sv::getLvalueElementType(type))
+      type = hw::getCanonicalType(lvalueType);
     if (hw::isHWIntegerType(type)) {
       name = "logic";
       addPackedDim(hw::getBitWidth(type));
@@ -698,7 +700,7 @@ EmittedExpr FileEmitter::emitExpression(Value value) {
   auto *op = result.getOwner();
 
   // If the operation is a named signal in the output Verilog, use that name.
-  if (isa<hw::WireOp, sv::WireOp, sv::RegOp, sv::LogicOp>(op)) {
+  if (isa<hw::WireOp, sv::WireOp, sv::VarOp>(op)) {
     auto name = op->getAttrOfType<StringAttr>("hw.verilogName");
     if (!name || name.empty())
       name = op->getAttrOfType<StringAttr>("name");

--- a/test/Conversion/CalyxToHW/primitives.mlir
+++ b/test/Conversion/CalyxToHW/primitives.mlir
@@ -1,18 +1,18 @@
 // RUN: circt-opt --split-input-file -lower-calyx-to-hw %s | FileCheck %s
 
 // CHECK: hw.module @main(in %in0 : i4, in %clk : i1, in %reset : i1, in %go : i1, out out0 : i8, out done : i1) {
-// CHECK:   %out0 = sv.wire  : !hw.inout<i8>
-// CHECK:   %0 = sv.read_inout %out0 : !hw.inout<i8>
-// CHECK:   %done = sv.wire  : !hw.inout<i1>
-// CHECK:   %1 = sv.read_inout %done : !hw.inout<i1>
+// CHECK:   %out0 = sv.wire  : !sv.net<i8>
+// CHECK:   %0 = sv.read_inout %out0 : !sv.net<i8>
+// CHECK:   %done = sv.wire  : !sv.net<i1>
+// CHECK:   %1 = sv.read_inout %done : !sv.net<i1>
 // CHECK:   %true = hw.constant true
-// CHECK:   %[[IN_WIRE:.*]] = sv.wire  : !hw.inout<i4>
-// CHECK:   %[[IN_WIRE_READ:.*]] = sv.read_inout %[[IN_WIRE]] : !hw.inout<i4>
+// CHECK:   %[[IN_WIRE:.*]] = sv.wire  : !sv.net<i4>
+// CHECK:   %[[IN_WIRE_READ:.*]] = sv.read_inout %[[IN_WIRE]] : !sv.net<i4>
 // CHECK:   %c0_i4 = hw.constant 0 : i4
 // CHECK:   %[[PADDED:.*]] = comb.concat %c0_i4, %[[IN_WIRE_READ]] : i4, i4
-// CHECK:   %[[PADDED_WIRE:.*]] = sv.wire  : !hw.inout<i8>
+// CHECK:   %[[PADDED_WIRE:.*]] = sv.wire  : !sv.net<i8>
 // CHECK:   sv.assign %[[PADDED_WIRE]], %[[PADDED]] : i8
-// CHECK:   %[[PADDED_WIRE_READ:.*]] = sv.read_inout %[[PADDED_WIRE]] : !hw.inout<i8>
+// CHECK:   %[[PADDED_WIRE_READ:.*]] = sv.read_inout %[[PADDED_WIRE]] : !sv.net<i8>
 // CHECK:   %[[UNDEF:.*]] = sv.constantX : i4
 // CHECK:   sv.assign %[[IN_WIRE]], %[[UNDEF]] : i4
 // CHECK:   sv.assign %out0, %[[PADDED_WIRE_READ]] : i8
@@ -36,19 +36,19 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 // CHECK: hw.module @main(in %in0 : i4, in %clk : i1, in %reset : i1, in %go : i1, out out0 : i8, out done : i1) {
-// CHECK:   %out0 = sv.wire  : !hw.inout<i8>
-// CHECK:   %0 = sv.read_inout %out0 : !hw.inout<i8>
-// CHECK:   %done = sv.wire  : !hw.inout<i1>
-// CHECK:   %1 = sv.read_inout %done : !hw.inout<i1>
+// CHECK:   %out0 = sv.wire  : !sv.net<i8>
+// CHECK:   %0 = sv.read_inout %out0 : !sv.net<i8>
+// CHECK:   %done = sv.wire  : !sv.net<i1>
+// CHECK:   %1 = sv.read_inout %done : !sv.net<i1>
 // CHECK:   %true = hw.constant true
-// CHECK:   %[[IN_WIRE:.*]] = sv.wire  : !hw.inout<i4>
-// CHECK:   %[[IN_WIRE_READ:.*]] = sv.read_inout %[[IN_WIRE]] : !hw.inout<i4>
+// CHECK:   %[[IN_WIRE:.*]] = sv.wire  : !sv.net<i4>
+// CHECK:   %[[IN_WIRE_READ:.*]] = sv.read_inout %[[IN_WIRE]] : !sv.net<i4>
 // CHECK:   %[[SIGNBIT:.*]] = comb.extract %[[IN_WIRE_READ]] from 3 : (i4) -> i1
 // CHECK:   %[[SIGNBITVEC:.*]] = comb.replicate %[[SIGNBIT]] : (i1) -> i4
 // CHECK:   %[[EXTENDED:.*]] = comb.concat %[[SIGNBITVEC]], %[[IN_WIRE_READ]] : i4, i4
-// CHECK:   %[[EXTENDED_WIRE:.*]] = sv.wire  : !hw.inout<i8>
+// CHECK:   %[[EXTENDED_WIRE:.*]] = sv.wire  : !sv.net<i8>
 // CHECK:   sv.assign %[[EXTENDED_WIRE]], %[[EXTENDED]] : i8
-// CHECK:   %[[EXTENDED_WIRE_READ:.*]] = sv.read_inout %[[EXTENDED_WIRE]] : !hw.inout<i8>
+// CHECK:   %[[EXTENDED_WIRE_READ:.*]] = sv.read_inout %[[EXTENDED_WIRE]] : !sv.net<i8>
 // CHECK:   sv.assign %[[IN_WIRE]], %in0 : i4
 // CHECK:   sv.assign %out0, %[[EXTENDED_WIRE_READ]] : i8
 // CHECK:   sv.assign %done, %true : i1
@@ -70,10 +70,10 @@ module attributes {calyx.entrypoint = "main"} {
 // -----
 
 // CHECK: hw.module @main(in %in0 : i8, in %in1 : i8, in %cond0 : i1, in %cond1 : i1, in %clk : i1, in %reset : i1, in %go : i1, out out : i8, out done : i1) {
-// CHECK:   %out = sv.wire  : !hw.inout<i8>
-// CHECK:   %0 = sv.read_inout %out : !hw.inout<i8>
-// CHECK:   %done = sv.wire  : !hw.inout<i1>
-// CHECK:   %1 = sv.read_inout %done : !hw.inout<i1>
+// CHECK:   %out = sv.wire  : !sv.net<i8>
+// CHECK:   %0 = sv.read_inout %out : !sv.net<i8>
+// CHECK:   %done = sv.wire  : !sv.net<i1>
+// CHECK:   %1 = sv.read_inout %done : !sv.net<i1>
 // CHECK:   %true = hw.constant true
 // CHECK:   %c0_i8 = hw.constant 0 : i8
 // CHECK:   %[[MUX0:.*]] = comb.mux %cond0, %in0, %c0_i8 : i8

--- a/test/Conversion/ExportVerilog/bugs.mlir
+++ b/test/Conversion/ExportVerilog/bugs.mlir
@@ -6,8 +6,9 @@ module attributes {circt.loweringOptions = "disallowExpressionInliningInPorts"} 
   hw.module.extern @Bar(inout %a: i1, out b: i1)
   hw.module private @InOutWire() {
 // CHECK: wire a;
-    %a = sv.wire : !hw.inout<i1>
+    %a = sv.wire name "a" : !sv.net<i1>
+    %a_inout = sv.inout.from_net %a : !sv.net<i1> -> !hw.inout<i1>
 // CHECK: .a (a),
-    %bar.b = hw.instance "bar" @Bar(a: %a: !hw.inout<i1>) -> (b: i1)
+    %bar.b = hw.instance "bar" @Bar(a: %a_inout: !hw.inout<i1>) -> (b: i1)
   }
 }

--- a/test/Conversion/ExportVerilog/complex-locations.mlir
+++ b/test/Conversion/ExportVerilog/complex-locations.mlir
@@ -20,8 +20,8 @@ hw.module @Callstack(in %a: i1 loc("")) {
 hw.module @MergedLocations(in %clock: i1, in %flag1 : i1, in %flag2: i1, in %flag3: i1) {
   %true = hw.constant 1 : i1 loc("")
   %false = hw.constant 0 : i1
-  %r1 = sv.reg : !hw.inout<i1>
-  %r2 = sv.reg : !hw.inout<i1>
+  %r1 = sv.var : !sv.var<i1>
+  %r2 = sv.var : !sv.var<i1>
   sv.always posedge %clock {
     
     // Induce FileLineColLoc merging.

--- a/test/Conversion/ExportVerilog/debug-info.mlir
+++ b/test/Conversion/ExportVerilog/debug-info.mlir
@@ -5,8 +5,8 @@
 module attributes {circt.loweringOptions="printDebugInfo"} {
 hw.module @symbols(in %baz: i1 {hw.exportPort = #hw<innerSym@bazSym>}) {
     // CHECK: wire foo /* #hw<innerSym@fooSym> */;
-    %foo = sv.wire sym @fooSym : !hw.inout<i1>
-    // CHECK: reg bar /* #hw<innerSym@barSym> */;
-    %bar = sv.reg sym @barSym : !hw.inout<i1>
+    %foo = sv.wire sym @fooSym : !sv.net<i1>
+    // CHECK: logic bar /* #hw<innerSym@barSym> */;
+    %bar = sv.var sym @barSym : !sv.var<i1>
 }
 }

--- a/test/Conversion/ExportVerilog/decl-align.mlir
+++ b/test/Conversion/ExportVerilog/decl-align.mlir
@@ -5,13 +5,13 @@ sv.macro.decl @foo
 // CHECK-LABEL: module Decl
 hw.module @Decl() {
   // CHECK: wire [3:0] x;
-  %x = sv.wire : !hw.inout<i4>
+  %x = sv.wire : !sv.net<i4>
   // CHECK: wire       y;
-  %y = sv.wire : !hw.inout<i1>
+  %y = sv.wire : !sv.net<i1>
   sv.ifdef @foo {
     // CHECK: wire [11:0][9:0][3:0] w;
-    %w = sv.wire : !hw.inout<array<12 x array<10xi4>>>
+    %w = sv.wire : !sv.net<!hw.array<12 x array<10xi4>>>
   }
   // CHECK: wire [5:0] z;
-  %z = sv.wire : !hw.inout<i6>
+  %z = sv.wire : !sv.net<i6>
 }

--- a/test/Conversion/ExportVerilog/decl-assignments.mlir
+++ b/test/Conversion/ExportVerilog/decl-assignments.mlir
@@ -9,20 +9,20 @@ hw.module @test(in %v: i1) {
   // DISALLOW-NEXT: wire x;
   // DISALLOW-NEXT: assign w = v;
   // DISALLOW-NEXT: assign u = v;
-  %w = sv.wire : !hw.inout<i1>
+  %w = sv.wire : !sv.net<i1>
   sv.assign %w, %v : i1
-  %u = sv.wire : !hw.inout<i1>
+  %u = sv.wire : !sv.net<i1>
   sv.assign %u, %v : i1
   // CHECK: initial begin
   sv.initial {
     // ALLOW:         automatic logic l = v;
     // DISALLOW:      automatic logic l;
     // DISALLOW-NEXT: l = v;
-    %l = sv.logic : !hw.inout<i1>
+    %l = sv.var : !sv.var<i1>
     sv.bpassign %l, %v : i1
   }
   // ALLOW:         wire x = v;
   // DISALLOW:      assign x = v;
-  %x = sv.wire : !hw.inout<i1>
+  %x = sv.wire : !sv.net<i1>
   sv.assign %x, %v : i1
 }

--- a/test/Conversion/ExportVerilog/disallow-local-vars.mlir
+++ b/test/Conversion/ExportVerilog/disallow-local-vars.mlir
@@ -14,14 +14,14 @@ hw.module @side_effect_expr(in %clock: i1, out a: i1, out a2: i1) {
   // DISALLOW: `ifdef FOO_MACRO
   sv.ifdef @FOO_MACRO {
     // DISALLOW: logic logicOp;
-    // DISALLOW: {{^    }}reg   [[SE_REG:[_A-Za-z0-9]+]];
+    // DISALLOW: {{^    }}logic [[SE_REG:[_A-Za-z0-9]+]];
 
     // CHECK:    always @(posedge clock)
     // DISALLOW: always @(posedge clock)
     sv.always posedge %clock  {
       %0 = sv.verbatim.expr "INLINE_OK" : () -> i1
       // CHECK: automatic logic logicOp;
-      %logicOp = sv.logic : !hw.inout<i1>
+      %logicOp = sv.var : !sv.var<i1>
 
       // This shouldn't be pushed into a reg.
       // CHECK: if (INLINE_OK)
@@ -82,13 +82,13 @@ hw.module @hoist_expressions(in %clock: i1, in %x: i8, in %y: i8, in %z: i8) {
   // Check out wires.
   // CHECK: wire [7:0] myWire = x;
   // DISALLOW: wire [7:0] myWire = x;
-  %myWire = sv.wire : !hw.inout<i8>
+  %myWire = sv.wire : !sv.net<i8>
   sv.assign %myWire, %x : i8
 
   // CHECK: always @(posedge clock)
   // DISALLOW: always @(posedge clock)
   sv.always posedge %clock  {
-    %wireout = sv.read_inout %myWire : !hw.inout<i8>
+    %wireout = sv.read_inout %myWire : !sv.net<i8>
     %3 = comb.add %x, %wireout: i8
     %4 = comb.icmp eq %3, %z : i8
     // CHECK: if (x + myWire == z)
@@ -105,9 +105,9 @@ hw.module @hoist_expressions(in %clock: i1, in %x: i8, in %y: i8, in %z: i8) {
 // DISALLOW-LABEL: module always_inline_expr
 // https://github.com/llvm/circt/issues/1705
 hw.module @always_inline_expr(in %ro_clock_0: i1, in %ro_en_0: i1, in %ro_addr_0: i1, in %wo_clock_0: i1, in %wo_en_0: i1, in %wo_addr_0: i1, in %wo_mask_0: i1, in %wo_data_0: i5, out ro_data_0: i5) {
-  %Memory = sv.reg  : !hw.inout<uarray<2xi5>>
-  %0 = sv.array_index_inout %Memory[%ro_addr_0] : !hw.inout<uarray<2xi5>>, i1
-  %1 = sv.read_inout %0 : !hw.inout<i5>
+  %Memory = sv.var  : !sv.var<!hw.uarray<2xi5>>
+  %0 = sv.array_index_inout %Memory[%ro_addr_0] : !sv.var<!hw.uarray<2xi5>>, i1
+  %1 = sv.read_inout %0 : !sv.var<i5>
   %x_i5 = sv.constantX : i5
   %2 = comb.mux %ro_en_0, %1, %x_i5 : i5
   sv.alwaysff(posedge %wo_clock_0)  {
@@ -117,7 +117,7 @@ hw.module @always_inline_expr(in %ro_clock_0: i1, in %ro_en_0: i1, in %ro_addr_0
     sv.if %3  {
       // CHECK: Memory[wo_addr_0] <= wo_data_0;
       // DISALLOW: Memory[wo_addr_0] <= wo_data_0;
-      %4 = sv.array_index_inout %Memory[%wo_addr_0] : !hw.inout<uarray<2xi5>>, i1
+      %4 = sv.array_index_inout %Memory[%wo_addr_0] : !sv.var<!hw.uarray<2xi5>>, i1
       sv.passign %4, %wo_data_0 : i5
     }
   }
@@ -128,11 +128,11 @@ hw.module @always_inline_expr(in %ro_clock_0: i1, in %ro_en_0: i1, in %ro_addr_0
 // DISALLOW-LABEL: module EmittedDespiteDisallowed
 // https://github.com/llvm/circt/issues/2216
 hw.module @EmittedDespiteDisallowed(in %clock: i1, in %reset: i1) {
-  %tick_value_2 = sv.reg  : !hw.inout<i1>
-  %counter_value = sv.reg  : !hw.inout<i1>
+  %tick_value_2 = sv.var  : !sv.var<i1>
+  %counter_value = sv.var  : !sv.var<i1>
 
   // Temporary reg gets introduced.
-  // DISALLOW: reg [1:0] [[TEMP:.+]];
+  // DISALLOW: logic [1:0] [[TEMP:.+]];
 
   // DISALLOW: initial begin
   sv.initial {
@@ -155,13 +155,13 @@ hw.module @EmittedDespiteDisallowed(in %clock: i1, in %reset: i1) {
 
 // CHECK-LABEL: module ReadInoutAggregate(
 hw.module @ReadInoutAggregate(in %clock: i1) {
-  %register = sv.reg  : !hw.inout<array<1xstruct<a: i32>>>
+  %register = sv.var  : !sv.var<!hw.array<1xstruct<a: i32>>>
   sv.always posedge %clock  {
     %c0_i16 = hw.constant 0 : i16
     %false = hw.constant false
-    %0 = sv.array_index_inout %register[%false] : !hw.inout<array<1xstruct<a: i32>>>, i1
-    %1 = sv.struct_field_inout %0["a"] : !hw.inout<struct<a: i32>>
-    %2 = sv.read_inout %1 : !hw.inout<i32>
+    %0 = sv.array_index_inout %register[%false] : !sv.var<!hw.array<1xstruct<a: i32>>>, i1
+    %1 = sv.struct_field_inout %0["a"] : !sv.var<!hw.struct<a: i32>>
+    %2 = sv.read_inout %1 : !sv.var<i32>
     %3 = comb.extract %2 from 0 : (i32) -> i16
     %4 = comb.concat %c0_i16, %3 : i16, i16
     sv.passign %1, %4 : i32
@@ -224,7 +224,7 @@ hw.module @AggregateInline(in %clock: i1) {
   // CHECK: wire [15:0]{{ *}}[[GEN:.+]];
   // DISALLOW: wire [15:0]{{ *}}[[GEN:.+]];
 
-  %register = sv.reg  : !hw.inout<struct<a: i32>>
+  %register = sv.var  : !sv.var<!hw.struct<a: i32>>
   sv.always posedge %clock  {
     // %4 can not be inlined because %3 uses %2.
     %4 = comb.concat %c0_i16, %3 : i16, i16
@@ -232,8 +232,8 @@ hw.module @AggregateInline(in %clock: i1) {
     // CHECK: register.a <= {16'h0, [[GEN]]};
     sv.passign %1, %4 : i32
   }
-  %1 = sv.struct_field_inout %register["a"] : !hw.inout<struct<a: i32>>
-  %2 = sv.read_inout %1 : !hw.inout<i32>
+  %1 = sv.struct_field_inout %register["a"] : !sv.var<!hw.struct<a: i32>>
+  %2 = sv.read_inout %1 : !sv.var<i32>
   %3 = comb.extract %2 from 0 : (i32) -> i16
   // DISALLOW: assign [[GEN]] = register.a[15:0]
   // CHECK: assign [[GEN]] = register.a[15:0]
@@ -243,29 +243,29 @@ hw.module @AggregateInline(in %clock: i1) {
 // CHECK-LABEL: module hoist_reg
 // DISALLOW-LABEL: module hoist_reg
 hw.module @hoist_reg(in %dummy : i32, out out : i17) {
-  %res_reg = sv.reg : !hw.inout<i17>
+  %res_reg = sv.var : !sv.var<i17>
   // CHECK: initial
-  // CHECK: reg  [31:0] tmp;
+  // CHECK: logic [31:0] tmp;
   // CHECK end // initial
-  // DISALLOW: reg  [31:0] tmp;
+  // DISALLOW: logic [31:0] tmp;
   // DISALLOW: initial
   sv.initial {
-    %tmp = sv.reg : !hw.inout<i32>
-    %17 = sv.read_inout %tmp : !hw.inout<i32>
+    %tmp = sv.var : !sv.var<i32>
+    %17 = sv.read_inout %tmp : !sv.var<i32>
     %29 = comb.xor %dummy, %17 : i32
     %32 = comb.extract %29 from 3 : (i32) -> i17
     sv.passign %res_reg, %32 : i17
   }
 
-  %res_reg_data = sv.read_inout %res_reg : !hw.inout<i17>
+  %res_reg_data = sv.read_inout %res_reg : !sv.var<i17>
   hw.output %res_reg_data : i17
 }
 
 // DISALLOW-LABEL: module ArrayInjectProcedural(
 hw.module @ArrayInjectProcedural(in %a: !hw.array<4xi42>, in %b: i42, in %i: i2) {
-  // DISALLOW: reg [3:0][41:0] z;
-  %z = sv.reg : !hw.inout<array<4xi42>>
-  // DISALLOW-NEXT: reg [3:0][41:0] [[TMP:.+]];
+  // DISALLOW: logic [3:0][41:0] z;
+  %z = sv.var : !sv.var<!hw.array<4xi42>>
+  // DISALLOW-NEXT: logic [3:0][41:0] [[TMP:.+]];
   // DISALLOW-NEXT: always_comb begin
   // DISALLOW-NEXT:   [[TMP]] = a;
   // DISALLOW-NEXT:   [[TMP]][i] = b;

--- a/test/Conversion/ExportVerilog/hw-dialect.mlir
+++ b/test/Conversion/ExportVerilog/hw-dialect.mlir
@@ -350,7 +350,8 @@ hw.module @shl(in %a: i1, out b: i1) {
 
 
 hw.module @inout_0(inout %a: i42, out out: i42) {
-  %aget = sv.read_inout %a: !hw.inout<i42>
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  %aget = sv.read_inout %a_net: !sv.net<i42>
   hw.output %aget : i42
 }
 // CHECK-LABEL:  module inout_0(
@@ -390,41 +391,41 @@ hw.module @wires(in %in4: i4, in %in8: i8, out a: i4, out b: i8, out c: i8) {
 
   // Wires.
   // CHECK-NEXT: wire [3:0]            myWire = in4;
-  %myWire = sv.wire : !hw.inout<i4>
+  %myWire = sv.wire : !sv.net<i4>
 
   // Packed arrays.
 
   // CHECK-NEXT: wire [41:0][7:0]      myArray1;
-  %myArray1 = sv.wire : !hw.inout<array<42 x i8>>
+  %myArray1 = sv.wire : !sv.net<!hw.array<42 x i8>>
   // CHECK-NEXT: wire [2:0][41:0][3:0] myWireArray2;
-  %myWireArray2 = sv.wire : !hw.inout<array<3 x array<42 x i4>>>
+  %myWireArray2 = sv.wire : !sv.net<!hw.array<3 x array<42 x i4>>>
 
   // Unpacked arrays, and unpacked arrays of packed arrays.
 
   // CHECK-NEXT: wire [7:0]            myUArray1[0:41];
-  %myUArray1 = sv.wire : !hw.inout<uarray<42 x i8>>
+  %myUArray1 = sv.wire : !sv.net<!hw.uarray<42 x i8>>
 
   // CHECK-NEXT: wire [9:0][7:0]       myUArray2[0:13][0:11];
-  %myUArray2 = sv.wire : !hw.inout<uarray<14 x uarray<12 x array<10 x i8>>>>
+  %myUArray2 = sv.wire : !sv.net<!hw.uarray<14 x uarray<12 x array<10 x i8>>>>
 
   // Wires.
   sv.assign %myWire, %in4 : i4
-  %wireout = sv.read_inout %myWire : !hw.inout<i4>
+  %wireout = sv.read_inout %myWire : !sv.net<i4>
 
   // Packed arrays.
 
-  %subscript = sv.array_index_inout %myArray1[%in4] : !hw.inout<array<42 x i8>>, i4
+  %subscript = sv.array_index_inout %myArray1[%in4] : !sv.net<!hw.array<42 x i8>>, i4
   // CHECK-NEXT: assign myArray1[in4] = in8;
   sv.assign %subscript, %in8 : i8
 
-  %memout1 = sv.read_inout %subscript : !hw.inout<i8>
+  %memout1 = sv.read_inout %subscript : !sv.net<i8>
 
     // Unpacked arrays, and unpacked arrays of packed arrays.
-  %subscriptu = sv.array_index_inout %myUArray1[%in4] : !hw.inout<uarray<42 x i8>>, i4
+  %subscriptu = sv.array_index_inout %myUArray1[%in4] : !sv.net<!hw.uarray<42 x i8>>, i4
   // CHECK-NEXT: assign myUArray1[in4] = in8;
   sv.assign %subscriptu, %in8 : i8
 
-  %memout2 = sv.read_inout %subscriptu : !hw.inout<i8>
+  %memout2 = sv.read_inout %subscriptu : !sv.net<i8>
 
   // CHECK-NEXT: assign a = myWire;
   // CHECK-NEXT: assign b = myArray1[in4];
@@ -434,7 +435,7 @@ hw.module @wires(in %in4: i4, in %in8: i8, out a: i4, out b: i8, out c: i8) {
 
 // CHECK-LABEL: module signs
 hw.module @signs(in %in1: i4, in %in2: i4, in %in3: i4, in %in4: i4)  {
-  %awire = sv.wire : !hw.inout<i4>
+  %awire = sv.wire : !sv.net<i4>
   // CHECK: wire [3:0] awire;
 
   // CHECK:      assign awire =
@@ -683,7 +684,7 @@ hw.module @longvariadic(in %a: i8, out b: i8) {
 // CHECK-NEXT:    input clock
 // CHECK-NEXT:  );
 // CHECK-EMPTY:
-// CHECK-NEXT:   reg memory_r_en_pipe[0:0];
+// CHECK-NEXT:   logic memory_r_en_pipe[0:0];
 // CHECK:        always_ff @(posedge clock)
 // CHECK-NEXT:     memory_r_en_pipe[1'h0] <= 1'h0;
 // CHECK-NEXT:   initial
@@ -691,8 +692,8 @@ hw.module @longvariadic(in %a: i8, out b: i8) {
 // CHECK-NEXT: endmodule
 hw.module @ArrayLHS(in %clock: i1) {
   %false = hw.constant false
-  %memory_r_en_pipe = sv.reg  : !hw.inout<uarray<1xi1>>
-  %3 = sv.array_index_inout %memory_r_en_pipe[%false] : !hw.inout<uarray<1xi1>>, i1
+  %memory_r_en_pipe = sv.var  : !sv.var<!hw.uarray<1xi1>>
+  %3 = sv.array_index_inout %memory_r_en_pipe[%false] : !sv.var<!hw.uarray<1xi1>>, i1
   sv.alwaysff(posedge %clock)  {
     sv.passign %3, %false : i1
   }
@@ -715,8 +716,8 @@ hw.module @noTemporaryIfReadInOutIsAfterUse(in %clock: i1, in %x: i1) {
   }
 
   // CHECK: end // always_ff @(posedge)
-  %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !hw.inout<i1>
-  %1 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !hw.inout<i1>
+  %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !sv.net<i1>
+  %1 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !sv.net<i1>
 }
 
 // CHECK-LABEL: module largeConstant
@@ -763,7 +764,7 @@ hw.module @StrurctExtractInline(in %a: !hw.struct<v: i1>, out b: i1, out c: i1) 
 hw.module @NoExtraTemporaryWireForAssign(in %a: i2, in %b: i4) {
   // CHECK: wire struct packed {logic [1:0] foo; logic [3:0] bar; } _GEN = '{foo: a, bar: b};
   %0 = hw.struct_create (%a, %b) : !hw.struct<foo: i2, bar: i4>
-  %1 = sv.wire : !hw.inout<!hw.struct<foo: i2, bar: i4>>
+  %1 = sv.wire : !sv.net<!hw.struct<foo: i2, bar: i4>>
   sv.assign %1, %0: !hw.struct<foo: i2, bar: i4>
 }
 
@@ -791,8 +792,8 @@ hw.module @instance_result_reuse_wires(out b: i3) {
   // CHECK-NEXT:  .res (some_wire)
   // CHECK-NEXT:  );
   // CHECK-NEXT:  assign b = some_wire;
-  %some_wire = sv.wire : !hw.inout<i3>
-  %read = sv.read_inout %some_wire : !hw.inout<i3>
+  %some_wire = sv.wire : !sv.net<i3>
+  %read = sv.read_inout %some_wire : !sv.net<i3>
 
   %out1 = hw.instance "b1" @single_result() -> (res: i3)
   sv.assign %some_wire, %out1 : i3
@@ -805,8 +806,8 @@ hw.module @InternalDestMod(in %a: i1, in %b: i3, in %c: i1) {}
 // CHECK-LABEL: module ABC
 hw.module @ABC(in %a: i1, in %b: i2, out c: i4) {
   %0,%1 = hw.instance "whatever" sym @a1 @ExternDestMod(a: %a: i1, b: %b: i2) -> (c: i3, d: i4) {doNotPrint}
-  %2 = sv.xmr "whatever", "a" : !hw.inout<i1>
-  %3 = sv.read_inout %2: !hw.inout<i1>
+  %2 = sv.xmr "whatever", "a" : !sv.var<i1>
+  %3 = sv.read_inout %2: !sv.var<i1>
   hw.instance "yo" sym @b1 @InternalDestMod(a: %a: i1, b: %0: i3, c: %3: i1) -> () {doNotPrint}
   hw.output %1 : i4
 }
@@ -1093,7 +1094,8 @@ hw.module @renameKeyword(in %a: !hw.struct<repeat: i1, repeat_0: i1>, out r1: !h
 // CHECK-NEXT:                                                            r4
 // CHECK-NEXT:  );
 hw.module @useRenamedStruct(inout %a: !hw.struct<repeat: i1, repeat_0: i1>, out r1: i1, out r2: i1, out r3: !hw.struct<repeat: i1, repeat_0: i1>, out r4: !hw.struct<repeat: i1, repeat_0: i1>) {
-  %read = sv.read_inout %a : !hw.inout<struct<repeat: i1, repeat_0: i1>>
+  %a_net = sv.net.from_inout %a : !hw.inout<struct<repeat: i1, repeat_0: i1>> -> !sv.net<!hw.struct<repeat: i1, repeat_0: i1>>
+  %read = sv.read_inout %a_net : !sv.net<!hw.struct<repeat: i1, repeat_0: i1>>
 
   %i0 = hw.instance "inst1" @renameKeyword(a: %read: !hw.struct<repeat: i1, repeat_0: i1>) -> (r1: !hw.struct<repeat: i1, repeat_0: i1>)
   // CHECK:      renameKeyword inst1 (
@@ -1101,8 +1103,8 @@ hw.module @useRenamedStruct(inout %a: !hw.struct<repeat: i1, repeat_0: i1>, out 
   // CHECK-NEXT:   .r1 (r4)
   // CHECK-NEXT: )
 
-  %0 = sv.struct_field_inout %a["repeat"] : !hw.inout<struct<repeat: i1, repeat_0: i1>>
-  %1 = sv.read_inout %0 : !hw.inout<i1>
+  %0 = sv.struct_field_inout %a_net["repeat"] : !sv.net<!hw.struct<repeat: i1, repeat_0: i1>>
+  %1 = sv.read_inout %0 : !sv.net<i1>
   // CHECK: assign r1 = a.repeat_0;
   %2 = hw.struct_extract %read["repeat_0"] : !hw.struct<repeat: i1, repeat_0: i1>
   // CHECK: assign r2 = a.repeat_0_0
@@ -1165,9 +1167,9 @@ hw.module @addParenthesesToSuccessiveOperators(in %a: i4, in %b: i1, in %c: i4, 
 hw.module @parameters<p1: i42 = 17, p2: i1>(in %arg0: i8, out out: i8) {
   // Local values should not conflict with output or parameter names.
   // CHECK: wire [3:0] p1_0;
-  %p1 = sv.wire : !hw.inout<i4>
+  %p1 = sv.wire : !sv.net<i4>
 
-  %out = sv.wire : !hw.inout<i4>
+  %out = sv.wire : !sv.net<i4>
   // CHECK: wire [3:0] out_0;
   hw.output %arg0 : i8
 }
@@ -1294,7 +1296,7 @@ hw.module @parameterizedTypes<param: i32 = 1, wire: i32 = 2>
 
   // Check that the parameter name renamification propagates.
   // CHECK: wire [wire_0 - 1:0] paramWire;
-  %paramWire = sv.wire : !hw.inout<!hw.int<#hw.param.decl.ref<"wire">>>
+  %paramWire = sv.wire : !sv.net<!hw.int<#hw.param.decl.ref<"wire">>>
 
 }
 
@@ -1388,7 +1390,8 @@ hw.module @ArrayGetInline(in %a: !hw.array<4xstruct<a: i32>>, in %b: !hw.array<4
   // CHECK-NEXT: assign out4 = b[idx_port];
   // CHECK-NEXT: assign out5 = b[idx_port];
   %array_get_idx = hw.array_get %b[%idx] : !hw.array<4xi1>, i2
-  %read = sv.read_inout %idx_port : !hw.inout<i2>
+  %idx_port_net = sv.net.from_inout %idx_port : !hw.inout<i2> -> !sv.net<i2>
+  %read = sv.read_inout %idx_port_net : !sv.net<i2>
   %array_get_idx_port = hw.array_get %b[%read] : !hw.array<4xi1>, i2
   hw.output %y, %array_get_idx, %array_get_idx, %array_get_idx_port, %array_get_idx_port : i32, i1, i1, i1, i1
 }
@@ -1479,7 +1482,7 @@ hw.module @Issue6275(out z: !hw.struct<a: !hw.array<2xstruct<b: i1>>>) {
 
 // CHECK-LABEL: module ArrayInjectStructural(
 hw.module @ArrayInjectStructural(in %a: !hw.array<4xi42>, in %b: i42, in %i: i2, out z: !hw.array<4xi42>) {
-  // CHECK: reg [3:0][41:0] [[TMP:.+]];
+  // CHECK: logic [3:0][41:0] [[TMP:.+]];
   // CHECK-NEXT: always_comb begin
   // CHECK-NEXT:   [[TMP]] = a;
   // CHECK-NEXT:   [[TMP]][i] = b;
@@ -1491,8 +1494,8 @@ hw.module @ArrayInjectStructural(in %a: !hw.array<4xi42>, in %b: i42, in %i: i2,
 
 // CHECK-LABEL: module ArrayInjectProcedural(
 hw.module @ArrayInjectProcedural(in %a: !hw.array<4xi42>, in %b: i42, in %i: i2) {
-  // CHECK: reg [3:0][41:0] z;
-  %z = sv.reg : !hw.inout<array<4xi42>>
+  // CHECK: logic [3:0][41:0] z;
+  %z = sv.var : !sv.var<!hw.array<4xi42>>
   // CHECK-NEXT: always_comb begin
   sv.alwayscomb {
     // CHECK-NEXT: automatic logic [3:0][41:0] [[TMP:.+]];

--- a/test/Conversion/ExportVerilog/hw-enums.mlir
+++ b/test/Conversion/ExportVerilog/hw-enums.mlir
@@ -80,8 +80,8 @@ hw.type_scope @__AnFSMTypedecl {
 
 hw.module @AnFSM(in %clock : i1) {
   // Anonymous enum
-  %reg = sv.reg : !hw.inout<!hw.enum<A, B>>
-  %reg_read = sv.read_inout %reg : !hw.inout<!hw.enum<A, B>>
+  %reg = sv.var : !sv.var<!hw.enum<A, B>>
+  %reg_read = sv.read_inout %reg : !sv.var<!hw.enum<A, B>>
   %A = hw.enum.constant A : !hw.enum<A, B>
   %B = hw.enum.constant B : !hw.enum<A, B>
   sv.always posedge %clock {
@@ -91,8 +91,8 @@ hw.module @AnFSM(in %clock : i1) {
   }
 
   // typedecl'd # 1
-  %reg_state1 = sv.reg : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
-  %reg_read_state1 = sv.read_inout %reg_state1 : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
+  %reg_state1 = sv.var : !sv.var<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
+  %reg_read_state1 = sv.read_inout %reg_state1 : !sv.var<!hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>>
 
   %A_state1 = hw.enum.constant A : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
   %B_state1 = hw.enum.constant B : !hw.typealias<@__AnFSMTypedecl::@_state1,!hw.enum<A, B>>
@@ -103,8 +103,8 @@ hw.module @AnFSM(in %clock : i1) {
   }
 
   // typedecl'd # 2
-  %reg_state2 = sv.reg : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
-  %reg_read_state2 = sv.read_inout %reg_state2 : !hw.inout<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
+  %reg_state2 = sv.var : !sv.var<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
+  %reg_read_state2 = sv.read_inout %reg_state2 : !sv.var<!hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>>
 
   %A_state2 = hw.enum.constant A : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>
   %B_state2 = hw.enum.constant B : !hw.typealias<@__AnFSMTypedecl::@_state2,!hw.enum<A, B>>

--- a/test/Conversion/ExportVerilog/hw-typedecls.mlir
+++ b/test/Conversion/ExportVerilog/hw-typedecls.mlir
@@ -58,30 +58,30 @@ hw.module @testTypeAlias(
 // CHECK-LABEL: module testRegOp
 hw.module @testRegOp() {
   // CHECK: foo {{.+}};
-  %r1 = sv.reg : !hw.inout<!hw.typealias<@__hw_typedecls::@foo,i1>>
+  %r1 = sv.var : !sv.var<!hw.typealias<@__hw_typedecls::@foo,i1>>
   // CHECK: foo[2:0] {{.+}};
-  %r2 = sv.reg : !hw.inout<!hw.array<3xtypealias<@__hw_typedecls::@foo,i1>>>
+  %r2 = sv.var : !sv.var<!hw.array<3xtypealias<@__hw_typedecls::@foo,i1>>>
 }
 
-// Check that sv.reg omits the "reg" keyword for typealias types wrapped in
+// Check that sv.var omits the "reg" keyword for typealias types wrapped in
 // unpacked arrays, matching the behaviour for StructType in the same position.
 // CHECK-LABEL: module testRegOpUnpackedArrayTypealias
 hw.module @testRegOpUnpackedArrayTypealias() {
   // CHECK-NOT: reg
   // CHECK: foo{{.*}}[0:7]
-  %r1 = sv.reg : !hw.inout<uarray<8xtypealias<@__hw_typedecls::@foo, i1>>>
+  %r1 = sv.var : !sv.var<!hw.uarray<8xtypealias<@__hw_typedecls::@foo, i1>>>
 
   // CHECK-NOT: reg
   // CHECK: foo{{.*}}[0:3][0:7]
-  %r2 = sv.reg : !hw.inout<uarray<4xuarray<8xtypealias<@__hw_typedecls::@foo, i1>>>>
+  %r2 = sv.var : !sv.var<!hw.uarray<4xuarray<8xtypealias<@__hw_typedecls::@foo, i1>>>>
 
   // CHECK-NOT: reg
   // CHECK: bar{{.*}}[0:7]
-  %r3 = sv.reg : !hw.inout<uarray<8xtypealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>
+  %r3 = sv.var : !sv.var<!hw.uarray<8xtypealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>
 
   // CHECK-NOT: reg
   // CHECK: bar[7:0]{{.*}}[0:3]
-  %r4 = sv.reg : !hw.inout<uarray<4xarray<8xtypealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>>
+  %r4 = sv.var : !sv.var<!hw.uarray<4xarray<8xtypealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>>>
 }
 
 // CHECK-LABEL: module testAggregateCreate
@@ -105,13 +105,13 @@ hw.module @testAggregateInout(in %i: i1, out out1: i8, out out2: i1) {
   // CHECK-NEXT: wire bar str;
   // CHECK-NEXT: assign out1 = array[4'h0];
   // CHECK-NEXT: assign out2 = str.a;
-  %array = sv.wire : !hw.inout<!hw.typealias<@__hw_typedecls::@arr, !hw.array<16xi8>>>
-  %str = sv.wire : !hw.inout<!hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
+  %array = sv.wire : !sv.net<!hw.typealias<@__hw_typedecls::@arr, !hw.array<16xi8>>>
+  %str = sv.wire : !sv.net<!hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
   %c0_i4 = hw.constant 0 : i4
-  %0 = sv.array_index_inout %array[%c0_i4] : !hw.inout<!hw.typealias<@__hw_typedecls::@arr, !hw.array<16xi8>>>, i4
-  %1 = sv.struct_field_inout %str["a"] : !hw.inout<!hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
-  %2 = sv.read_inout %0 : !hw.inout<i8>
-  %3 = sv.read_inout %1 : !hw.inout<i1>
+  %0 = sv.array_index_inout %array[%c0_i4] : !sv.net<!hw.typealias<@__hw_typedecls::@arr, !hw.array<16xi8>>>, i4
+  %1 = sv.struct_field_inout %str["a"] : !sv.net<!hw.typealias<@__hw_typedecls::@bar, !hw.struct<a: i1, b: i1>>>
+  %2 = sv.read_inout %0 : !sv.net<i8>
+  %3 = sv.read_inout %1 : !sv.net<i1>
   hw.output %2, %3 : i8, i1
 }
 

--- a/test/Conversion/ExportVerilog/max-terms.mlir
+++ b/test/Conversion/ExportVerilog/max-terms.mlir
@@ -25,15 +25,15 @@ hw.module @large_use_in_procedural(in %clock: i1, in %a: i1) {
     }
   }
 
-  // CHECK: reg [[REG:.+]];
-  %reg = sv.reg : !hw.inout<i1>
+  // CHECK: logic [[REG:.+]];
+  %reg = sv.var : !sv.var<i1>
 
   // CHECK: wire [[GEN_0:.+]] = reg_0 + reg_0 + reg_0 + reg_0 + reg_0;
   sv.alwaysff(posedge %clock) {
     // CHECK: always
     // CHECK: [[REG]] = a;
     sv.bpassign %reg, %a : i1
-    %0 = sv.read_inout %reg : !hw.inout<i1>
+    %0 = sv.read_inout %reg : !sv.var<i1>
     %1 = comb.add %0, %0, %0, %0, %0 : i1
     // CHECK: if ([[GEN_0]])
     sv.if %1 {
@@ -60,8 +60,8 @@ hw.module @large_use_in_procedural_successive(in %clock: i1, in %a: i1) {
 
 // CHECK-LABEL: module dont_spill_to_procedural_regions
 hw.module @dont_spill_to_procedural_regions(in %z: i10) {
-  %r1 = sv.reg : !hw.inout<i1>
-  %r2 = sv.reg : !hw.inout<i10>
+  %r1 = sv.var : !sv.var<i1>
+  %r2 = sv.var : !sv.var<i10>
   // CHECK: wire [9:0] _GEN = r2 + r2 + r2 + r2 + r2;
   // CHECK: initial begin
   // CHECK-NEXT:   `ifdef BAR
@@ -69,7 +69,7 @@ hw.module @dont_spill_to_procedural_regions(in %z: i10) {
   // CHECK-NEXT:   `endif
   // CHECK-NEXT: end // initial
   sv.initial {
-    %x = sv.read_inout %r2: !hw.inout<i10>
+    %x = sv.read_inout %r2: !sv.var<i10>
     sv.ifdef.procedural @BAR {
       %2 = comb.add %x, %x, %x, %x, %x : i10
       %3 = comb.icmp eq %2, %z: i10

--- a/test/Conversion/ExportVerilog/mitigate-vivado-array-index-const-prop-bug.mlir
+++ b/test/Conversion/ExportVerilog/mitigate-vivado-array-index-const-prop-bug.mlir
@@ -31,9 +31,9 @@ hw.module @ExistingWire(in %a: !hw.array<16xi1>, in %b : i4, out c: i1) {
 
   %c1_i4 = hw.constant 3 : i4
   %0 = comb.add %b, %c1_i4 : i4
-  %existingWire = sv.wire : !hw.inout<i4>
+  %existingWire = sv.wire : !sv.net<i4>
   sv.assign %existingWire, %0 : i4
-  %1 = sv.read_inout %existingWire : !hw.inout<i4>
+  %1 = sv.read_inout %existingWire : !sv.net<i4>
   %2 = hw.array_get %a[%1] : !hw.array<16xi1>, i4
   hw.output %2 : i1
 }

--- a/test/Conversion/ExportVerilog/name-legalize.mlir
+++ b/test/Conversion/ExportVerilog/name-legalize.mlir
@@ -53,7 +53,7 @@ hw.module.extern @module_with_bool<bparam: i1>()
 // CHECK-NEXT:    input [7:0] p1
 // CHECK-NEXT: );
 hw.module @parametersNameConflict<p2: i42 = 17, wire: i1>(in %p1: i8) {
-  %myWire = sv.wire : !hw.inout<i1>
+  %myWire = sv.wire : !sv.net<i1>
 
   // CHECK: `ifdef SOMEMACRO
   sv.ifdef @SOMEMACRO {
@@ -92,8 +92,8 @@ hw.module @useParametersNameConflict(in %xxx: i8) {
 
   // CHECK: `ifdef SOMEMACRO
   sv.ifdef @SOMEMACRO {
-    // CHECK: reg [3:0] xxx_0;
-    %0 = sv.reg name "xxx" : !hw.inout<i4>
+    // CHECK: logic [3:0] xxx_0;
+    %0 = sv.var name "xxx" : !sv.var<i4>
   }
 }
 
@@ -161,12 +161,12 @@ hw.module @TestEmptyInstanceName(in %a: i1) {
 
 // CHECK-LABEL: module TestInstanceNameValueConflict(
 hw.module @TestInstanceNameValueConflict(in %a: i1) {
-  // CHECK:  wire name;
-  %name = sv.wire : !hw.inout<i1>
-  // CHECK:  wire output_0;
-  %output = sv.wire : !hw.inout<i1>
-  // CHECK:  reg  input_0;
-  %input = sv.reg : !hw.inout<i1>
+  // CHECK: wire  name;
+  %name = sv.wire : !sv.net<i1>
+  // CHECK:  wire  output_0;
+  %output = sv.wire : !sv.net<i1>
+  // CHECK:  logic input_0;
+  %input = sv.var : !sv.var<i1>
   // CHECK: B name_0 (
   hw.instance "name" @B(a: %a: i1) -> ()
 }
@@ -174,8 +174,8 @@ hw.module @TestInstanceNameValueConflict(in %a: i1) {
 // https://github.com/llvm/circt/issues/855
 // CHECK-LABEL: module nameless_reg(
 hw.module @nameless_reg(in %a: i1) {
-  // CHECK: reg [3:0] _GEN;
-  %661 = sv.reg : !hw.inout<i4>
+  // CHECK: logic [3:0] _GEN;
+  %661 = sv.var : !sv.var<i4>
 }
 
 // CHECK-LABEL: module verif_renames(
@@ -194,7 +194,7 @@ hw.module @verbatim_renames(in %a: i1 {hw.exportPort = #hw<innerSym@asym>}) {
   sv.verbatim "// VERB Module : {{0}} {{1}}" {symbols = [@reg, @inout]}
 
   // Make sure symbol references to wires and instances get renamed correctly.
-  %wire = sv.wire sym @wire1 : !hw.inout<i1>
+  %wire = sv.wire sym @wire1 : !sv.net<i1>
 
   // CHECK: inout_0 module_0 (
   %0 = hw.instance "module" sym @struct @inout (inout: %a: i1) -> (output: i1)

--- a/test/Conversion/ExportVerilog/prepare-for-emission.mlir
+++ b/test/Conversion/ExportVerilog/prepare-for-emission.mlir
@@ -18,11 +18,11 @@ hw.module @outOfOrderInoutOperations(in %a: i4, out c: i4) {
   // CHECK-NEXT: %2 = sv.array_index_inout %1[%false]
   // CHECK-NEXT: %3 = sv.read_inout %2
   %false = hw.constant false
-  %0 = sv.read_inout %3 : !hw.inout<i4>
-  %3 = sv.array_index_inout %2[%false] : !hw.inout<array<1xi4>>, i1
-  %2 = sv.array_index_inout %1[%false] : !hw.inout<array<1xarray<1xi4>>>, i1
-  %1 = sv.array_index_inout %wire[%false] : !hw.inout<array<1xarray<1xarray<1xi4>>>>, i1
-  %wire = sv.wire  : !hw.inout<array<1xarray<1xarray<1xi4>>>>
+  %0 = sv.read_inout %3 : !sv.net<i4>
+  %3 = sv.array_index_inout %2[%false] : !sv.net<!hw.array<1xi4>>, i1
+  %2 = sv.array_index_inout %1[%false] : !sv.net<!hw.array<1xarray<1xi4>>>, i1
+  %1 = sv.array_index_inout %wire[%false] : !sv.net<!hw.array<1xarray<1xarray<1xi4>>>>, i1
+  %wire = sv.wire  : !sv.net<!hw.array<1xarray<1xarray<1xi4>>>>
   hw.output %0: i4
 }
 
@@ -37,7 +37,7 @@ hw.module @twoState_variadic(in %a: i1, in %b: i1, in %c: i1, out d:i1){
 
 // CHECK-LABEL: @carryOverWireAttrs
 hw.module @carryOverWireAttrs(in %a: i1, out b: i1){
-  // CHECK-NEXT: %foo = sv.wire {magic, sv.attributes = []} : !hw.inout<i1>
+  // CHECK-NEXT: %foo = sv.wire {magic, sv.attributes = []} : !sv.net<i1>
   // CHECK-NEXT: sv.assign %foo, %a
   // CHECK-NEXT: [[TMP:%.+]] = sv.read_inout %foo
   // CHECK-NEXT: hw.output [[TMP]] : i1
@@ -50,9 +50,9 @@ hw.module @carryOverWireAttrs(in %a: i1, out b: i1){
 module {
   // CHECK-LABEL:  hw.module @SpillTemporaryInProceduralRegion
   hw.module @SpillTemporaryInProceduralRegion(in %a: i4, in %b: i4, in %fd: i32) {
-    // CHECK-NEXT: %r = sv.reg
+    // CHECK-NEXT: %r = sv.var
     // CHECK-NEXT: sv.initial {
-    // CHECK-NEXT:   %0 = sv.logic
+    // CHECK-NEXT:   %0 = sv.var
     // CHECK-NEXT:   %1 = comb.add %a, %b
     // CHECK-NEXT:   sv.bpassign %0, %1
     // CHECK-NEXT:   %2 = sv.read_inout %0
@@ -60,7 +60,7 @@ module {
     // CHECK-NEXT:   sv.passign %r, %3
     // CHECK-NEXT: }
     // CHECK-NEXT: hw.output
-    %r = sv.reg : !hw.inout<i1>
+    %r = sv.var : !sv.var<i1>
     sv.initial {
       %0 = comb.add %a, %b : i4
       %1 = comb.extract %0 from 3 : (i4) -> i1
@@ -74,8 +74,8 @@ module {
 module attributes {circt.loweringOptions = "disallowLocalVariables"} {
   // CHECK: @test_hoist
   hw.module @test_hoist(in %a: i3) {
-    // CHECK-NEXT: %reg = sv.reg
-    %reg = sv.reg : !hw.inout<i3>
+    // CHECK-NEXT: %reg = sv.var
+    %reg = sv.var : !sv.var<i3>
     // CHECK-NEXT: %0 = comb.add
     // CHECK-NEXT: sv.initial
     sv.initial {
@@ -99,7 +99,7 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
 
   // CHECK-LABEL:  hw.module @SpillTemporaryInProceduralRegion
   hw.module @SpillTemporaryInProceduralRegion(in %a: i4, in %b: i4, in %fd: i32) {
-    // CHECK-NEXT: %r = sv.reg
+    // CHECK-NEXT: %r = sv.var
     // CHECK-NEXT: %[[VAL:.+]] = comb.add %a, %b
     // CHECK-NEXT: %[[GEN:.+]] = sv.wire
     // CHECK-NEXT: sv.assign %[[GEN]], %[[VAL]]
@@ -109,7 +109,7 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
     // CHECK-NEXT:   sv.passign %r, %3
     // CHECK-NEXT: }
     // CHECK-NEXT: hw.output
-    %r = sv.reg : !hw.inout<i1>
+    %r = sv.var : !sv.var<i1>
     sv.initial {
       %0 = comb.add %a, %b : i4
       %1 = comb.extract %0 from 3 : (i4) -> i1
@@ -191,10 +191,10 @@ module attributes {circt.loweringOptions =
   hw.module @mux(in %c: i1, in %b: i8, in %a: i8, out d: i8, out e: i8) {
     // CHECK:      %use_for_mux = sv.wire
     // CHECK-NEXT: sv.assign %use_for_mux, %0 : i8
-    // CHECK-NEXT: %[[read:.+]] = sv.read_inout %use_for_mux : !hw.inout<i8>
+    // CHECK-NEXT: %[[read:.+]] = sv.read_inout %use_for_mux : !sv.net<i8>
     // CHECK-NEXT: %[[add:.+]] = comb.add %[[read]], %a : i8
     %0 = comb.mux %c, %a, %b : i8
-    %use_for_mux = sv.wire : !hw.inout<i8>
+    %use_for_mux = sv.wire : !sv.net<i8>
     sv.assign %use_for_mux, %0 : i8
     %1 = comb.add %0, %a : i8
     // CHECK: %[[mux2:.+]] = comb.mux
@@ -305,8 +305,8 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
     // CHECK: sv.alwayscomb
     sv.alwayscomb {
       // CHECK-NEXT: sv.xmr.ref
-      %0 = sv.xmr.ref @xmr : !hw.inout<i1>
-      sv.verbatim "{{0}}" (%0) : !hw.inout<i1>
+      %0 = sv.xmr.ref @xmr : !sv.var<i1>
+      sv.verbatim "{{0}}" (%0) : !sv.var<i1>
     }
   }
   hw.hierpath @xmr [@Foo::@a]
@@ -317,31 +317,31 @@ module attributes {circt.loweringOptions = "disallowLocalVariables"} {
 
 // CHECK-LABEL: @constantInitRegWithBackEdge
 hw.module @constantInitRegWithBackEdge() {
-  // CHECK: %reg = sv.reg init %false : !hw.inout<i1>
+  // CHECK: %reg = sv.var init %false : !sv.var<i1>
   // CHECK-NEXT: %false = hw.constant false
-  // CHECK-NEXT: %[[VAL_0:.*]] = sv.read_inout %reg : !hw.inout<i1>
+  // CHECK-NEXT: %[[VAL_0:.*]] = sv.read_inout %reg : !sv.var<i1>
   // CHECK-NEXT: %[[VAL_1:.*]] = comb.or %false, %[[VAL_0]] : i1
   %false = hw.constant false
   %0 = comb.or %false, %1 : i1
-  %reg = sv.reg init %false : !hw.inout<i1>
-  %1 = sv.read_inout %reg : !hw.inout<i1>
+  %reg = sv.var init %false : !sv.var<i1>
+  %1 = sv.read_inout %reg : !sv.var<i1>
 }
 
 // -----
 
 // CHECK-LABEL: @temporaryWireForReg
 hw.module @temporaryWireForReg() {
-  // CHECK: %[[WIRE:.*]] = sv.wire : !hw.inout<i1>
-  // CHECK-NEXT: %[[VAL_0:.*]] = sv.read_inout %[[WIRE]]  : !hw.inout<i1>
-  // CHECK-NEXT: %b = sv.reg init %[[VAL_0]] : !hw.inout<i1>
-  // CHECK-NEXT: %[[VAL_1:.*]] = sv.read_inout %b : !hw.inout<i1>
-  // CHECK-NEXT: %a = sv.reg init %[[VAL_1]] : !hw.inout<i1>
-  // CHECK-NEXT: %[[VAL_2:.*]] = sv.read_inout %a : !hw.inout<i1>
+  // CHECK: %[[WIRE:.*]] = sv.wire : !sv.net<i1>
+  // CHECK-NEXT: %[[VAL_0:.*]] = sv.read_inout %[[WIRE]]  : !sv.net<i1>
+  // CHECK-NEXT: %b = sv.var init %[[VAL_0]] : !sv.var<i1>
+  // CHECK-NEXT: %[[VAL_1:.*]] = sv.read_inout %b : !sv.var<i1>
+  // CHECK-NEXT: %a = sv.var init %[[VAL_1]] : !sv.var<i1>
+  // CHECK-NEXT: %[[VAL_2:.*]] = sv.read_inout %a : !sv.var<i1>
   // CHECK-NEXT: sv.assign %[[WIRE]], %[[VAL_2]] : i1
-  %0 = sv.read_inout %a : !hw.inout<i1>
-  %1 = sv.read_inout %b : !hw.inout<i1>
-  %b = sv.reg init %0 : !hw.inout<i1>
-  %a = sv.reg init %1 : !hw.inout<i1>
+  %0 = sv.read_inout %a : !sv.var<i1>
+  %1 = sv.read_inout %b : !sv.var<i1>
+  %b = sv.var init %0 : !sv.var<i1>
+  %a = sv.var init %1 : !sv.var<i1>
 }
 
 // -----

--- a/test/Conversion/ExportVerilog/pretty.mlir
+++ b/test/Conversion/ExportVerilog/pretty.mlir
@@ -165,8 +165,8 @@ hw.module @MuxChain(in %a_0: i1, in %a_1: i1, in %a_2: i1, in %c_0: i1, in %c_1:
 hw.module @svattrs() {
 //      CHECK:  (* dont_merge, dont_retime = true, foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3,
 // CHECK-NEXT:     foo4 = bar4, foo5 = bar5, foo6 = bar6 *)
-// CHECK-NEXT:  reg [9:0] reg0;{{.*}}
-  %reg0 = sv.reg {
+// CHECK-NEXT:  logic [9:0] reg0;{{.*}}
+  %reg0 = sv.var {
     sv.attributes = [
       #sv.attribute<"dont_merge">,
       #sv.attribute<"dont_retime" ="true">,
@@ -177,15 +177,15 @@ hw.module @svattrs() {
       #sv.attribute<"foo4"="bar4">,
       #sv.attribute<"foo5"="bar5">,
       #sv.attribute<"foo6"="bar6">
-   ]} : !hw.inout<i10>
+   ]} : !sv.var<i10>
 
 //      CHECK:  (* start *)
 // CHECK-NEXT:  /* foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3, foo4 = bar4, foo5 = bar5,
 // CHECK-NEXT:     foo6 = bar6 */
 // CHECK-NEXT:  (* foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3, foo4 = bar4, foo5 = bar5,
 // CHECK-NEXT:     foo6 = bar6 *)
-// CHECK-NEXT:  reg [9:0] reg1;{{.*}}
-  %reg1 = sv.reg {
+// CHECK-NEXT:  logic [9:0] reg1;{{.*}}
+  %reg1 = sv.var {
     sv.attributes = [
       #sv.attribute<"start">,
       #sv.attribute<"foo0"="bar0", emitAsComment>,
@@ -202,17 +202,17 @@ hw.module @svattrs() {
       #sv.attribute<"foo4"="bar4">,
       #sv.attribute<"foo5"="bar5">,
       #sv.attribute<"foo6"="bar6">
-   ]} : !hw.inout<i10>
+   ]} : !sv.var<i10>
 
 // Put containers on same line if they fit!
 //      CHECK:  (* start *) /* comment */ (* end *)
-// CHECK-NEXT:  reg [9:0] reg2;{{.*}}
-  %reg2 = sv.reg {
+// CHECK-NEXT:  logic [9:0] reg2;{{.*}}
+  %reg2 = sv.var {
     sv.attributes = [
       #sv.attribute<"start">,
       #sv.attribute<"comment", emitAsComment>,
       #sv.attribute<"end">
-   ]} : !hw.inout<i10>
+   ]} : !sv.var<i10>
 
 // Check behavior where some fit and some don't:
 // (notably don't glue '(* end *)' after the comment container)
@@ -220,8 +220,8 @@ hw.module @svattrs() {
 // CHECK-NEXT:  /* foo0 = bar0, foo1 = bar1, foo2 = bar2, foo3 = bar3, foo4 = bar4, foo5 = bar5,
 // CHECK-NEXT:     foo6 = bar6 */
 // CHECK-NEXT:  (* end *)
-// CHECK-NEXT:  reg [9:0] reg3;{{.*}}
-  %reg3 = sv.reg {
+// CHECK-NEXT:  logic [9:0] reg3;{{.*}}
+  %reg3 = sv.var {
     sv.attributes = [
       #sv.attribute<"start">,
       #sv.attribute<"foo0"="bar0", emitAsComment>,
@@ -232,7 +232,7 @@ hw.module @svattrs() {
       #sv.attribute<"foo5"="bar5", emitAsComment>,
       #sv.attribute<"foo6"="bar6", emitAsComment>,
       #sv.attribute<"end">
-   ]} : !hw.inout<i10>
+   ]} : !sv.var<i10>
 }
 
 // -----
@@ -241,7 +241,7 @@ sv.macro.decl @RANDOM
 
 // CHECK-LABEL:module ForStatement{{.*}}
 hw.module @ForStatement(in %aaaaaaaaaaa: i5, in %xxxxxxxxxxxxxxx : i2, in %yyyyyyyyyyyyyyy : i2, in %zzzzzzzzzzzzzzz : i2) {
-  %_RANDOM = sv.logic : !hw.inout<uarray<3xi32>>
+  %_RANDOM = sv.var : !sv.var<!hw.uarray<3xi32>>
   sv.initial {
     %x_and_y = comb.and %xxxxxxxxxxxxxxx, %yyyyyyyyyyyyyyy : i2
     %x_or_y = comb.or %xxxxxxxxxxxxxxx, %yyyyyyyyyyyyyyy : i2
@@ -257,7 +257,7 @@ hw.module @ForStatement(in %aaaaaaaaaaa: i5, in %xxxxxxxxxxxxxxx : i2, in %yyyyy
     // CHECK-NEXT:    end{{.*}}
     sv.for %iiiiiiiiiiiiiiiiiiiiiiiii = %lowerBound to %upperBound step %step : i2 {
       %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
-      %index = sv.array_index_inout %_RANDOM[%iiiiiiiiiiiiiiiiiiiiiiiii] : !hw.inout<uarray<3xi32>>, i2
+      %index = sv.array_index_inout %_RANDOM[%iiiiiiiiiiiiiiiiiiiiiiiii] : !sv.var<!hw.uarray<3xi32>>, i2
       sv.bpassign %index, %RANDOM : i32
     }
   }
@@ -293,14 +293,14 @@ hw.module @TestCond() {
 // See https://github.com/llvm/circt/pull/6171
 
 // CHECK-LABEL:module Top{{.*}}
-// CHECK-NEXT:  reg        foo;{{.*}}
-// CHECK-NEXT:  reg [63:0] bar;{{.*}}
+// CHECK-NEXT:  logic        foo;{{.*}}
+// CHECK-NEXT:  logic [63:0] bar;{{.*}}
 // CHECK-NEXT:  struct packed {logic dw; logic [3:0] fn; logic [63:0] in; } agg;{{.*}}
 // CHECK-NEXT:endmodule
 hw.module @Top() {
-  %foo = sv.reg : !hw.inout<i1>
-  %bar = sv.reg : !hw.inout<i64>
-  %agg = sv.reg : !hw.inout<struct<dw: i1, fn: i4, in: i64>>
+  %foo = sv.var : !sv.var<i1>
+  %bar = sv.var : !sv.var<i64>
+  %agg = sv.var : !sv.var<!hw.struct<dw: i1, fn: i4, in: i64>>
 }
 
 // -----

--- a/test/Conversion/ExportVerilog/pruning.mlir
+++ b/test/Conversion/ExportVerilog/pruning.mlir
@@ -4,19 +4,19 @@
 // CHECK:       always_ff @(posedge clk) begin        
 // CHECK-NEXT:  end
 hw.module @zeroWidthPAssign(in %arg0 : i0, in %clk: i1, out out: i0) {
-  %0 = sv.reg  {hw.verilogName = "_GEN"} : !hw.inout<i0>
+  %0 = sv.var  {hw.verilogName = "_GEN"} : !sv.var<i0>
   sv.alwaysff(posedge %clk) {
     sv.passign %0, %arg0 : i0
   }
-  %1 = sv.read_inout %0 : !hw.inout<i0>
+  %1 = sv.read_inout %0 : !sv.var<i0>
   hw.output %1 : i0
 }
 
 // CHECK-LABEL: module zeroWidthLogic(
 // CHECK-NOT: reg
 hw.module @zeroWidthLogic(in %arg0 : i0, in %sel : i1, in %clk : i1, out out : i0) {
-  %r = sv.reg : !hw.inout<i0>
-  %rr = sv.read_inout %r : !hw.inout<i0>
+  %r = sv.var : !sv.var<i0>
+  %rr = sv.read_inout %r : !sv.var<i0>
   %2 = comb.mux %sel, %rr, %arg0 : i0
   hw.output %2 : i0
 }

--- a/test/Conversion/ExportVerilog/sv-always-wire.mlir
+++ b/test/Conversion/ExportVerilog/sv-always-wire.mlir
@@ -5,12 +5,12 @@
 hw.module @AlwaysSpill(in %port: i1) {
   %false = hw.constant false
   %true = hw.constant true
-  %awire = sv.wire : !hw.inout<i1>
+  %awire = sv.wire : !sv.net<i1>
 
   // CHECK: wire [[TMP1:.+]] = 1'h0;
   // CHECK: wire [[TMP2:.+]] = 1'h1;
   // CHECK: wire{{ *}}awire;
-  %awire2 = sv.read_inout %awire : !hw.inout<i1>
+  %awire2 = sv.read_inout %awire : !sv.net<i1>
 
   // Existing simple names should not cause additional spill.
   // CHECK: always @(posedge port)

--- a/test/Conversion/ExportVerilog/sv-dialect.mlir
+++ b/test/Conversion/ExportVerilog/sv-dialect.mlir
@@ -8,15 +8,15 @@ sv.macro.decl @VERILATOR
 // CHECK-NOT:   reg reservedName3;
 sv.reserve_names ["ReservedName1", "reservedName2", "reservedName3"]
 hw.module @ReservedName1 (in %reservedName2 : i1) {
-  %reservedName3 = sv.reg : !hw.inout<i1>
+  %reservedName3 = sv.var : !sv.var<i1>
 }
 
 // CHECK-LABEL: module M1
 // CHECK-NEXT:    #(parameter [41:0] param1) (
 hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
-  %wire42 = sv.reg : !hw.inout<i42>
-  %forceWire = sv.wire sym @wire1 : !hw.inout<i1>
-  %partSelectReg = sv.reg : !hw.inout<i42>
+  %wire42 = sv.var : !sv.var<i42>
+  %forceWire = sv.wire sym @wire1 : !sv.net<i1>
+  %partSelectReg = sv.var : !sv.var<i42>
 
   %fd = hw.constant 0x80000002 : i32
 
@@ -27,11 +27,10 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
   // CHECK: localparam [41:0]{{ *}} param_y = param1;
   %param_y = sv.localparam { value = #hw.param.decl.ref<"param1"> : i42 } : i42
 
-  // CHECK:        logic{{ *}} [7:0]{{ *}} logic_op;
+  // CHECK:        wire{{ *}} [7:0]{{ *}} logic_op = val;
   // CHECK-NEXT: struct packed {logic b; } logic_op_struct;
-  // CHECK-NEXT: assign logic_op = val;
-  %logic_op = sv.logic : !hw.inout<i8>
-  %logic_op_struct = sv.logic : !hw.inout<struct<b: i1>>
+  %logic_op = sv.wire : !sv.net<i8>
+  %logic_op_struct = sv.wire : !sv.net<!hw.struct<b: i1>>
   sv.assign %logic_op, %val: i8
 
   // CHECK:           (* sv attr *)
@@ -41,9 +40,9 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
     // CHECK-NEXT: automatic       struct packed {logic b; } logic_op_struct_procedural
 
     // CHECK: force forceWire = cond;
-    sv.force %forceWire, %cond : i1
-    %logic_op_procedural = sv.logic : !hw.inout<i8>
-    %logic_op_struct_procedural = sv.logic : !hw.inout<struct<b: i1>>
+    sv.force %forceWire, %cond : !sv.net<i1>
+    %logic_op_procedural = sv.var : !sv.var<i8>
+    %logic_op_struct_procedural = sv.var : !sv.var<!hw.struct<b: i1>>
 
     sv.bpassign %logic_op_procedural, %val: i8
   // CHECK-NEXT:   `ifndef SYNTHESIS
@@ -61,7 +60,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
       }
 
   // CHECK-NEXT: release forceWire;
-    sv.release %forceWire : !hw.inout<i1>
+    sv.release %forceWire : !sv.net<i1>
   // CHECK-NEXT:   `endif
   // CHECK-NEXT: end // always @(posedge)
     }
@@ -128,10 +127,10 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
 
       %c2_i3 = hw.constant 2 : i3
       // CHECK-NEXT: partSelectReg[3'h2 +: 40] = 40'h2A;
-      %a = sv.indexed_part_select_inout %partSelectReg[%c2_i3 : 40] : !hw.inout<i42>, i3
+      %a = sv.indexed_part_select_inout %partSelectReg[%c2_i3 : 40] : !sv.var<i42>, i3
       sv.bpassign %a, %c40 : i40
       // CHECK-NEXT: partSelectReg[3'h2 -: 40] = 40'h2A;
-      %b = sv.indexed_part_select_inout %partSelectReg[%c2_i3 decrement: 40] : !hw.inout<i42>, i3
+      %b = sv.indexed_part_select_inout %partSelectReg[%c2_i3 decrement: 40] : !sv.var<i42>, i3
       sv.bpassign %b, %c40 : i40
     } else {
       // CHECK: wire42 = param_y;
@@ -482,7 +481,7 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
   %add = comb.add %val, %val : i8
 
   // CHECK-NEXT: `define STUFF "wire42 (8'(val + val))"
-  sv.verbatim "`define STUFF \"{{0}} ({{1}})\"" (%wire42, %add) : !hw.inout<i42>, i8
+  sv.verbatim "`define STUFF \"{{0}} ({{1}})\"" (%wire42, %add) : !sv.var<i42>, i8
 
   // CHECK-NEXT: `ifdef FOO
   sv.ifdef @FOO {
@@ -508,11 +507,14 @@ hw.module @M1<param1: i42>(in %clock : i1, in %cond : i1, in %val : i8) {
 // CHECK-NEXT:                 c //
 // CHECK-NEXT:  );
 hw.module @Aliasing(inout %a : i42, inout %b : i42, inout %c : i42) {
-
   // CHECK: alias a = b;
-  sv.alias %a, %b     : !hw.inout<i42>, !hw.inout<i42>
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  %b_net = sv.net.from_inout %b : !hw.inout<i42> -> !sv.net<i42>
+  %c_net = sv.net.from_inout %c : !hw.inout<i42> -> !sv.net<i42>
+
+  sv.alias %a_net, %b_net      : !sv.net<i42>, !sv.net<i42>
   // CHECK: alias a = b = c;
-  sv.alias %a, %b, %c : !hw.inout<i42>, !hw.inout<i42>, !hw.inout<i42>
+  sv.alias %a_net, %b_net, %c_net : !sv.net<i42>, !sv.net<i42>, !sv.net<i42>
 }
 
 hw.module @reg_0(in %in4: i4, in %in8: i8, in %in8_2: i8, out a: i8, out b: i8) {
@@ -526,35 +528,35 @@ hw.module @reg_0(in %in4: i4, in %in8: i8, in %in8_2: i8, out a: i8, out b: i8) 
 
   // CHECK-EMPTY:
   // CHECK-NEXT: (* dont_merge *)
-  // CHECK-NEXT: reg [7:0]       myReg;
-  %myReg = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i8>
+  // CHECK-NEXT: wire [7:0]      myReg;
+  %myReg = sv.wire {sv.attributes = [#sv.attribute<"dont_merge">]} : !sv.net<i8>
 
   // CHECK-NEXT: (* dont_merge, dont_retime = true *)
   // CHECK-NEXT: /* comment_merge, comment_retime = true */
   // CHECK-NEXT: (* another_attr *)
-  // CHECK-NEXT: reg [41:0][7:0] myRegArray1;
-  %myRegArray1 = sv.reg {sv.attributes = [
+  // CHECK-NEXT: wire [41:0][7:0] myRegArray1;
+  %myRegArray1 = sv.wire {sv.attributes = [
     #sv.attribute<"dont_merge">,
     #sv.attribute<"dont_retime" = "true">,
     #sv.attribute<"comment_merge", emitAsComment>,
     #sv.attribute<"comment_retime" = "true", emitAsComment>,
     #sv.attribute<"another_attr">
-  ]} : !hw.inout<array<42 x i8>>
+  ]} : !sv.net<!hw.array<42 x i8>>
 
   // CHECK:      /* assign_attr */
   // CHECK-NEXT: assign myReg = in8;
   sv.assign %myReg, %in8 {sv.attributes = [#sv.attribute<"assign_attr", emitAsComment>]} : i8
 
-  %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
+  %subscript1 = sv.array_index_inout %myRegArray1[%in4] : !sv.net<!hw.array<42 x i8>>, i4
   sv.assign %subscript1, %in8 : i8   // CHECK-NEXT: assign myRegArray1[in4] = in8;
 
-  %regout = sv.read_inout %myReg : !hw.inout<i8>
+  %regout = sv.read_inout %myReg : !sv.net<i8>
 
-  %subscript2 = sv.array_index_inout %myRegArray1[%in4] : !hw.inout<array<42 x i8>>, i4
-  %memout = sv.read_inout %subscript2 : !hw.inout<i8>
+  %subscript2 = sv.array_index_inout %myRegArray1[%in4] : !sv.net<!hw.array<42 x i8>>, i4
+  %memout = sv.read_inout %subscript2 : !sv.net<i8>
 
   %unpacked_array = sv.unpacked_array_create %in8, %in8_2 : (i8, i8) -> !hw.uarray<2xi8>
-  %unpacked_wire = sv.wire : !hw.inout<uarray<2xi8>>
+  %unpacked_wire = sv.wire : !sv.net<!hw.uarray<2xi8>>
   // CHECK: wire [7:0] unpacked_wire[0:1];
   // CHECK-NEXT: assign unpacked_wire = '{in8_2, in8};
   sv.assign %unpacked_wire, %unpacked_array: !hw.uarray<2xi8>
@@ -567,19 +569,19 @@ hw.module @reg_0(in %in4: i4, in %in8: i8, in %in8_2: i8, out a: i8, out b: i8) 
 hw.module @reg_1(in %in4: i4, in %in8: i8, out a : i3, out b : i5) {
   // CHECK-LABEL: module reg_1(
 
-  // CHECK: reg [17:0] myReg2
-  %myReg2 = sv.reg : !hw.inout<i18>
+  // CHECK: wire [17:0] myReg2
+  %myReg2 = sv.wire : !sv.net<i18>
 
   // CHECK:      assign myReg2[4'h7 +: 8] = in8;
   // CHECK-NEXT: assign myReg2[4'h7 -: 8] = in8;
 
   %c2_i3 = hw.constant 7 : i4
-  %a1 = sv.indexed_part_select_inout %myReg2[%c2_i3 : 8] : !hw.inout<i18>, i4
+  %a1 = sv.indexed_part_select_inout %myReg2[%c2_i3 : 8] : !sv.net<i18>, i4
   sv.assign %a1, %in8 : i8
-  %b1 = sv.indexed_part_select_inout %myReg2[%c2_i3 decrement: 8] : !hw.inout<i18>, i4
+  %b1 = sv.indexed_part_select_inout %myReg2[%c2_i3 decrement: 8] : !sv.net<i18>, i4
   sv.assign %b1, %in8 : i8
   %c3_i3 = hw.constant 3 : i4
-  %r1 = sv.read_inout %myReg2 : !hw.inout<i18>
+  %r1 = sv.read_inout %myReg2 : !sv.net<i18>
   %c = sv.indexed_part_select %r1[%c3_i3 : 3] : i18,i4
   %d = sv.indexed_part_select %r1[%in4 decrement:5] :i18, i4
   // CHECK-NEXT: assign a = myReg2[4'h3 +: 3];
@@ -588,14 +590,14 @@ hw.module @reg_1(in %in4: i4, in %in8: i8, out a : i3, out b : i5) {
 }
 
 // CHECK-LABEL: module regWithInit(
-// CHECK:     reg        reg1 = 1'h0;
-// CHECK:     reg [31:0] reg2 = 32'(arg + arg);
+// CHECK:     logic        reg1 = 1'h0;
+// CHECK:     logic [31:0] reg2 = 32'(arg + arg);
 hw.module @regWithInit(in %arg : i32) {
   %c0_i1 = hw.constant 0 : i1
-  %reg1 = sv.reg init %c0_i1 : !hw.inout<i1>
+  %reg1 = sv.var init %c0_i1 : !sv.var<i1>
 
   %init = comb.add %arg, %arg : i32
-  %reg2 = sv.reg init %init : !hw.inout<i32>
+  %reg2 = sv.var init %init : !sv.var<i32>
 }
 
 // CHECK-LABEL: module struct_field_inout1(
@@ -604,7 +606,8 @@ hw.module @regWithInit(in %arg : i32) {
 hw.module @struct_field_inout1(inout %a : !hw.struct<b: i1>) {
   // CHECK: assign a.b = 1'h1;
   %true = hw.constant true
-  %0 = sv.struct_field_inout %a["b"] : !hw.inout<struct<b: i1>>
+  %a_net = sv.net.from_inout %a : !hw.inout<struct<b: i1>> -> !sv.net<!hw.struct<b: i1>>
+  %0 = sv.struct_field_inout %a_net["b"] : !sv.net<!hw.struct<b: i1>>
   sv.assign %0, %true : i1
 }
 
@@ -614,16 +617,17 @@ hw.module @struct_field_inout1(inout %a : !hw.struct<b: i1>) {
 hw.module @struct_field_inout2(inout %a: !hw.struct<b: !hw.struct<c: i1>>) {
   // CHECK: assign a.b.c = 1'h1;
   %true = hw.constant true
-  %0 = sv.struct_field_inout %a["b"] : !hw.inout<struct<b: !hw.struct<c: i1>>>
-  %1 = sv.struct_field_inout %0["c"] : !hw.inout<struct<c: i1>>
+  %a_net = sv.net.from_inout %a : !hw.inout<struct<b: !hw.struct<c: i1>>> -> !sv.net<!hw.struct<b: !hw.struct<c: i1>>>
+  %0 = sv.struct_field_inout %a_net["b"] : !sv.net<!hw.struct<b: !hw.struct<c: i1>>>
+  %1 = sv.struct_field_inout %0["c"] : !sv.net<!hw.struct<c: i1>>
   sv.assign %1, %true : i1
 }
 
 // CHECK-LABEL: module PartSelectInoutInline(
 hw.module @PartSelectInoutInline(in %v:i40) {
-  %r = sv.reg : !hw.inout<i42>
+  %r = sv.var : !sv.var<i42>
   %c2_i3 = hw.constant 2 : i3
-  %a = sv.indexed_part_select_inout %r[%c2_i3 : 40] : !hw.inout<i42>, i3
+  %a = sv.indexed_part_select_inout %r[%c2_i3 : 40] : !sv.var<i42>, i3
   // CHECK: initial
   // CHECK-NEXT:   r[3'h2 +: 40] = v;
   sv.initial {
@@ -775,7 +779,7 @@ hw.module @slice_inline_ports(in %arr: !hw.array<128xi1>, in %x: i3, in %y: i7,
 
 // CHECK-LABEL: if_multi_line_expr1
 hw.module @if_multi_line_expr1(in %clock: i1, in %reset: i1, in %really_long_port: i11) {
-  %tmp6 = sv.reg  : !hw.inout<i25>
+  %tmp6 = sv.var  : !sv.var<i25>
 
   // CHECK: if (reset)
   // CHECK-NEXT:   tmp6 <= 25'h0;
@@ -798,7 +802,7 @@ hw.module @if_multi_line_expr1(in %clock: i1, in %reset: i1, in %really_long_por
 
 // CHECK-LABEL: if_multi_line_expr2
 hw.module @if_multi_line_expr2(in %clock: i1, in %reset: i1, in %really_long_port: i11) {
-  %tmp6 = sv.reg  : !hw.inout<i25>
+  %tmp6 = sv.var  : !sv.var<i25>
 
   %c12345_i25 = hw.constant 12345 : i25
   %sign = comb.extract %really_long_port from 10 : (i11) -> i1
@@ -939,8 +943,8 @@ hw.module @issue728ifdef(in %clock: i1, in %asdfasdfasdfasdfafa: i1, in %gasfdas
 
 // CHECK-LABEL: module alwayscombTest(
 hw.module @alwayscombTest(in %a: i1, out x: i1) {
-  // CHECK: reg combWire;
-  %combWire = sv.reg : !hw.inout<i1>
+  // CHECK: logic combWire;
+  %combWire = sv.var : !sv.var<i1>
   // CHECK: always_comb
   sv.alwayscomb {
     // CHECK-NEXT: combWire <= a
@@ -948,7 +952,7 @@ hw.module @alwayscombTest(in %a: i1, out x: i1) {
   }
 
   // CHECK: assign x = combWire;
-  %out = sv.read_inout %combWire : !hw.inout<i1>
+  %out = sv.read_inout %combWire : !sv.var<i1>
   hw.output %out : i1
 }
 
@@ -956,14 +960,14 @@ hw.module @alwayscombTest(in %a: i1, out x: i1) {
 // https://github.com/llvm/circt/issues/838
 // CHECK-LABEL: module inlineProceduralWiresWithLongNames(
 hw.module @inlineProceduralWiresWithLongNames(in %clock: i1, in %in: i1) {
-  %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !hw.inout<i1>
-  %0 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !hw.inout<i1>
-  %bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = sv.wire  : !hw.inout<i1>
-  %1 = sv.read_inout %bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb : !hw.inout<i1>
-  %r = sv.reg  : !hw.inout<uarray<1xi1>>
-  %s = sv.reg  : !hw.inout<uarray<1xi1>>
-  %2 = sv.array_index_inout %r[%0] : !hw.inout<uarray<1xi1>>, i1
-  %3 = sv.array_index_inout %s[%1] : !hw.inout<uarray<1xi1>>, i1
+  %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = sv.wire  : !sv.net<i1>
+  %0 = sv.read_inout %aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa : !sv.net<i1>
+  %bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = sv.wire  : !sv.net<i1>
+  %1 = sv.read_inout %bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb : !sv.net<i1>
+  %r = sv.var  : !sv.var<!hw.uarray<1xi1>>
+  %s = sv.var  : !sv.var<!hw.uarray<1xi1>>
+  %2 = sv.array_index_inout %r[%0] : !sv.var<!hw.uarray<1xi1>>, i1
+  %3 = sv.array_index_inout %s[%1] : !sv.var<!hw.uarray<1xi1>>, i1
   // CHECK: always_ff
   sv.alwaysff(posedge %clock)  {
     // CHECK-NEXT: r[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa] <= in;
@@ -977,10 +981,10 @@ hw.module @inlineProceduralWiresWithLongNames(in %clock: i1, in %in: i1) {
 // CHECK-LABEL: module oooReg(
 hw.module @oooReg(in %in: i1, out result: i1) {
   // CHECK: wire abc = in;
-  %0 = sv.read_inout %abc : !hw.inout<i1>
+  %0 = sv.read_inout %abc : !sv.net<i1>
 
   sv.assign %abc, %in : i1
-  %abc = sv.wire  : !hw.inout<i1>
+  %abc = sv.wire  : !sv.net<i1>
 
   // CHECK: assign result = abc;
   hw.output %0 : i1
@@ -1001,7 +1005,7 @@ hw.module @ifdef_beginend(in %clock: i1, in %cond: i1, in %val: i8) {
 // CHECK-LABEL: module ConstResetValueMustBeInlined(
 hw.module @ConstResetValueMustBeInlined(in %clock: i1, in %reset: i1, in %d: i42, out q: i42) {
   %c0_i42 = hw.constant 0 : i42
-  %tmp = sv.reg : !hw.inout<i42>
+  %tmp = sv.var : !sv.var<i42>
   // CHECK: always_ff @(posedge clock or posedge reset) begin
   // CHECK-NEXT:   if (reset)
   // CHECK-NEXT:     tmp <= 42'h0;
@@ -1010,7 +1014,7 @@ hw.module @ConstResetValueMustBeInlined(in %clock: i1, in %reset: i1, in %d: i42
   } (asyncreset : posedge %reset)  {
     sv.passign %tmp, %c0_i42 : i42
   }
-  %1 = sv.read_inout %tmp : !hw.inout<i42>
+  %1 = sv.read_inout %tmp : !sv.var<i42>
   hw.output %1 : i42
 }
 
@@ -1024,7 +1028,7 @@ hw.module @OutOfLineConstantsInAlwaysSensitivity() {
 
 // CHECK-LABEL: module TooLongConstExpr
 hw.module @TooLongConstExpr() {
-  %myreg = sv.reg : !hw.inout<i4200>
+  %myreg = sv.var : !sv.var<i4200>
   // CHECK: always @*
   sv.always {
     // CHECK-NEXT: myreg <=
@@ -1039,7 +1043,7 @@ hw.module @TooLongConstExpr() {
 // Constants defined before use should be emitted in-place.
 // CHECK-LABEL: module ConstantDefBeforeUse
 hw.module @ConstantDefBeforeUse() {
-  %myreg = sv.reg : !hw.inout<i32>
+  %myreg = sv.var : !sv.var<i32>
   // CHECK: always @*
   // CHECK-NEXT:   myreg <= 32'h2A;
   %0 = hw.constant 42 : i32
@@ -1052,7 +1056,7 @@ hw.module @ConstantDefBeforeUse() {
 // top of the block.
 // CHECK-LABEL: module ConstantDefAfterUse
 hw.module @ConstantDefAfterUse() {
-  %myreg = sv.reg : !hw.inout<i32>
+  %myreg = sv.var : !sv.var<i32>
   // CHECK: always @*
   // CHECK-NEXT:   myreg <= 32'h2A;
   sv.always {
@@ -1065,7 +1069,7 @@ hw.module @ConstantDefAfterUse() {
 // should be emitted at the top of their defining block.
 // CHECK-LABEL: module ConstantEmissionAtTopOfBlock
 hw.module @ConstantEmissionAtTopOfBlock() {
-  %myreg = sv.reg : !hw.inout<i32>
+  %myreg = sv.var : !sv.var<i32>
   // CHECK:      always @* begin
   // CHECK-NEXT:   if (1'h1)
   // CHECK-NEXT:     myreg <= 32'h2A;
@@ -1083,15 +1087,15 @@ hw.module @ConstantEmissionAtTopOfBlock() {
 hw.module @RegisterOfStructOrArrayOfStruct() {
   // CHECK-NOT: reg
   // CHECK: struct packed {logic a; logic b; }           reg1
-  %reg1 = sv.reg : !hw.inout<struct<a: i1, b: i1>>
+  %reg1 = sv.var : !sv.var<!hw.struct<a: i1, b: i1>>
 
   // CHECK-NOT: reg
   // CHECK: struct packed {logic a; logic b; }[7:0]      reg2
-  %reg2 = sv.reg : !hw.inout<array<8xstruct<a: i1, b: i1>>>
+  %reg2 = sv.var : !sv.var<!hw.array<8xstruct<a: i1, b: i1>>>
 
   // CHECK-NOT: reg
   // CHECK: struct packed {logic a; logic b; }[3:0][7:0] reg3
-  %reg3 = sv.reg : !hw.inout<array<4xarray<8xstruct<a: i1, b: i1>>>>
+  %reg3 = sv.var : !sv.var<!hw.array<4xarray<8xstruct<a: i1, b: i1>>>>
 }
 
 // See https://github.com/llvm/circt/issues/7733
@@ -1099,28 +1103,28 @@ hw.module @RegisterOfStructOrArrayOfStruct() {
 hw.module @RegisterOfUnpackedArrayOfStruct() {
   // CHECK-NOT: reg
   // CHECK: struct packed {logic a; logic b; }{{.*}}reg4[0:7]
-  %reg4 = sv.reg : !hw.inout<uarray<8xstruct<a: i1, b: i1>>>
+  %reg4 = sv.var : !sv.var<!hw.uarray<8xstruct<a: i1, b: i1>>>
 
   // CHECK-NOT: reg
   // CHECK: struct packed {logic a; logic b; }{{.*}}reg5[0:3][0:7]
-  %reg5 = sv.reg : !hw.inout<uarray<4xuarray<8xstruct<a: i1, b: i1>>>>
+  %reg5 = sv.var : !sv.var<!hw.uarray<4xuarray<8xstruct<a: i1, b: i1>>>>
 
   // CHECK-NOT: reg
   // CHECK: struct packed {logic a; logic b; }[7:0]{{.*}}reg6[0:3]
-  %reg6 = sv.reg : !hw.inout<uarray<4xarray<8xstruct<a: i1, b: i1>>>>
+  %reg6 = sv.var : !sv.var<!hw.uarray<4xarray<8xstruct<a: i1, b: i1>>>>
 }
 
 // CHECK-LABEL: module MultiUseReadInOut(
 // Issue #1564
 hw.module @MultiUseReadInOut(in %auto_in_ar_bits_id : i2, out aa: i3, out bb: i3){
-  %a = sv.reg  : !hw.inout<i3>
-  %b = sv.reg  : !hw.inout<i3>
-  %c = sv.reg  : !hw.inout<i3>
-  %d = sv.reg  : !hw.inout<i3>
-  %123 = sv.read_inout %b : !hw.inout<i3>
-  %124 = sv.read_inout %a : !hw.inout<i3>
-  %125 = sv.read_inout %c : !hw.inout<i3>
-  %126 = sv.read_inout %d : !hw.inout<i3>
+  %a = sv.var  : !sv.var<i3>
+  %b = sv.var  : !sv.var<i3>
+  %c = sv.var  : !sv.var<i3>
+  %d = sv.var  : !sv.var<i3>
+  %123 = sv.read_inout %b : !sv.var<i3>
+  %124 = sv.read_inout %a : !sv.var<i3>
+  %125 = sv.read_inout %c : !sv.var<i3>
+  %126 = sv.read_inout %d : !sv.var<i3>
 
   // We should directly use a/b/c/d here instead of emitting temporary wires.
 
@@ -1136,8 +1140,8 @@ hw.module @MultiUseReadInOut(in %auto_in_ar_bits_id : i2, out aa: i3, out bb: i3
 
 // CHECK-LABEL: module DontDuplicateSideEffectingVerbatim(
 hw.module @DontDuplicateSideEffectingVerbatim() {
-  %a = sv.reg : !hw.inout<i42>
-  %b = sv.reg sym @regSym : !hw.inout<i42>
+  %a = sv.var : !sv.var<i42>
+  %b = sv.var sym @regSym : !sv.var<i42>
 
   sv.initial {
     // CHECK: automatic logic [41:0] _SIDEEFFECT = SIDEEFFECT;
@@ -1166,12 +1170,12 @@ hw.module @DontDuplicateSideEffectingVerbatim() {
 hw.module @DontInlineAssignmentForUnpackedArrays(in %a: !hw.uarray<2xi1>) {
 // CHECK:      wire w[0:1];
 // CHECK-NEXT: assign w = a;
-   %w = sv.wire  : !hw.inout<uarray<2xi1>>
+   %w = sv.wire  : !sv.net<!hw.uarray<2xi1>>
    sv.assign %w, %a : !hw.uarray<2xi1>
    // CHECK: logic u[0:1];
    // CHECK-NEXT: u = a;
    sv.initial {
-    %u = sv.logic  : !hw.inout<uarray<2xi1>>
+    %u = sv.var  : !sv.var<!hw.uarray<2xi1>>
     sv.bpassign %u, %a : !hw.uarray<2xi1>
    }
 
@@ -1183,11 +1187,11 @@ hw.module.extern @verbatim_inout_2 ()
 // CHECK-LABEL: module verbatim_M1(
 hw.module @verbatim_M1(in %clock : i1, in %cond : i1, in %val : i8) {
   %c42 = hw.constant 42 : i8
-  %reg1 = sv.reg sym @verbatim_reg1: !hw.inout<i8>
-  %reg2 = sv.reg sym @verbatim_reg2: !hw.inout<i8>
+  %reg1 = sv.var sym @verbatim_reg1: !sv.var<i8>
+  %reg2 = sv.var sym @verbatim_reg2: !sv.var<i8>
   // CHECK:      (* dont_merge *)
   // CHECK-NEXT: wire [22:0] wire25
-  %wire25 = sv.wire sym @verbatim_wireSym1 {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i23>
+  %wire25 = sv.wire sym @verbatim_wireSym1 {sv.attributes = [#sv.attribute<"dont_merge">]} : !sv.net<i23>
   %add = comb.add %val, %c42 : i8
   %c42_2 = hw.constant 42 : i8
   %xor = comb.xor %val, %c42_2 : i8
@@ -1216,7 +1220,7 @@ hw.module @verbatim_M2(in %clock : i1, in %cond : i1, in %val : i8) {
 // CHECK-LABEL: module InlineAutomaticLogicInit(
 // Issue #1567: https://github.com/llvm/circt/issues/1567
 hw.module @InlineAutomaticLogicInit(in %a : i42, in %b: i42, in %really_really_long_port: i11) {
-  %regValue = sv.reg : !hw.inout<i42>
+  %regValue = sv.var : !sv.var<i42>
   // CHECK: initial begin
   sv.initial {
     // CHECK-DAG: automatic logic [63:0] [[_THING:.+]] = `THING;
@@ -1319,23 +1323,23 @@ hw.module @InlineAutomaticLogicInit(in %a : i42, in %b: i42, in %really_really_l
 hw.module @InlineNonProceduralContinuousNetAssignment(in %a: i1) {
   // CHECK:     wire  someWire = a;
   // CHECK-NOT: assign
-  %someWire = sv.wire {hw.verilogName = "someWire"} : !hw.inout<i1>
+  %someWire = sv.wire {hw.verilogName = "someWire"} : !sv.net<i1>
   sv.assign %someWire, %a : i1
-  // CHECK:      logic  someLogic;
-  // CHECK-NEXT: assign someLogic = a;
-  %someLogic = sv.logic {hw.verilogName = "someLogic"} : !hw.inout<i1>
+  // CHECK:      wire  someLogic = a;
+  // CHECK-NOT:  assign
+  %someLogic = sv.wire {hw.verilogName = "someLogic"} : !sv.net<i1>
   sv.assign %someLogic, %a : i1
-  // CHECK:      reg  someReg;
-  // CHECK-NEXT: assign someReg = a;
-  %someReg = sv.reg {hw.verilogName = "someReg"} : !hw.inout<i1>
+  // CHECK:      wire  someReg = a;
+  // CHECK-NOT:  assign
+  %someReg = sv.wire {hw.verilogName = "someReg"} : !sv.net<i1>
   sv.assign %someReg, %a : i1
 }
 
 // Issue #2335: https://github.com/llvm/circt/issues/2335
 // CHECK-LABEL: module AggregateTemporay(
 hw.module @AggregateTemporay(in %clock: i1, in %foo: i1, in %bar: i25) {
-  %temp1 = sv.reg  : !hw.inout<!hw.struct<b: i1>>
-  %temp2 = sv.reg  : !hw.inout<!hw.array<5x!hw.array<5x!hw.struct<b: i1>>>>
+  %temp1 = sv.var  : !sv.var<!hw.struct<b: i1>>
+  %temp2 = sv.var  : !sv.var<!hw.array<5x!hw.array<5x!hw.struct<b: i1>>>>
   sv.always posedge %clock  {
     // CHECK: automatic struct packed {logic b; } [[T0:.+]];
     // CHECK: automatic struct packed {logic b; }[4:0][4:0] [[T1:.+]];
@@ -1352,9 +1356,9 @@ hw.module @AggregateTemporay(in %clock: i1, in %foo: i1, in %bar: i25) {
 //CHECK: assign $root.a.b.c = a;
 //CHECK-NEXT: assign aa = d.e.f;
 hw.module @XMR_src(in %a : i23, out aa: i3) {
-  %xmr1 = sv.xmr isRooted a,b,c : !hw.inout<i23>
-  %xmr2 = sv.xmr "d",e,f : !hw.inout<i3>
-  %r = sv.read_inout %xmr2 : !hw.inout<i3>
+  %xmr1 = sv.xmr isRooted a,b,c : !sv.net<i23>
+  %xmr2 = sv.xmr "d",e,f : !sv.var<i3>
+  %r = sv.read_inout %xmr2 : !sv.var<i3>
   sv.assign %xmr1, %a : i23
   hw.output %r : i3
 }
@@ -1367,17 +1371,17 @@ hw.module @XMR_src(in %a : i23, out aa: i3) {
 hw.hierpath private @ref [@wait_order::@bar, @XMRRef_Bar::@new]
 hw.hierpath private @ref2 [@wait_order::@baz]
 hw.module @XMRRef_Bar() {
-  %new = sv.wire sym @new : !hw.inout<i2>
+  %new = sv.wire sym @new : !sv.net<i2>
 }
 hw.module.extern @XMRRef_Baz(in %a: i2, in %b: i1)
 hw.module.extern @XMRRef_Qux(in %a: i2, in %b: i1)
 // CHECK-LABEL: module wait_order
 hw.module @wait_order() {
   hw.instance "bar" sym @bar @XMRRef_Bar() -> ()
-  %xmr = sv.xmr.ref @ref : !hw.inout<i2>
-  %xmrRead = sv.read_inout %xmr : !hw.inout<i2>
-  %xmr2 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i1>
-  %xmr2Read = sv.read_inout %xmr2 : !hw.inout<i1>
+  %xmr = sv.xmr.ref @ref : !sv.var<i2>
+  %xmrRead = sv.read_inout %xmr : !sv.var<i2>
+  %xmr2 = sv.xmr.ref @ref2 ".x.y.z[42]" : !sv.var<i1>
+  %xmr2Read = sv.read_inout %xmr2 : !sv.var<i1>
   // CHECK:      /* This instance is elsewhere emitted as a bind statement.
   // CHECK-NEXT: XMRRef_Baz baz (
   // CHECK-NEXT:   .a (wait_order_0.bar.new_0),
@@ -1412,8 +1416,8 @@ hw.module @InlineBind(in %a_in: i8, out wire: i8){
   // CHECK-NEXT:     .out (wire_0)
   // CHECK-NEXT:   );
   // CHECK-NEXT: */
-  %0 = sv.wire : !hw.inout<i8>
-  %1 = sv.read_inout %0: !hw.inout<i8>
+  %0 = sv.wire : !sv.net<i8>
+  %1 = sv.read_inout %0: !sv.net<i8>
   %2 = comb.add %a_in, %1 : i8
   %3 = hw.instance "ext1" sym @foo1 @ExtModule(in: %2: i8) -> (out: i8) {doNotPrint}
   %4 = hw.instance "ext2" sym @foo2 @ExtModule(in: %3: i8) -> (out: i8) {doNotPrint}
@@ -1447,25 +1451,25 @@ hw.module @extInst2(in %signed: i1, in %_i: i1, in %_j: i1, in %_k: i1, in %_z :
 
 // CHECK-LABEL: module zeroWidthArrayIndex
 hw.module @zeroWidthArrayIndex(in %clock : i1, in %data : i64) {
-  %reg = sv.reg  : !hw.inout<uarray<1xi64>>
+  %reg = sv.var  : !sv.var<!hw.uarray<1xi64>>
   sv.alwaysff(posedge %clock) {
     %c0_i0_1 = hw.constant 0 : i0
     // CHECK: reg_0[/*Zero width*/ 1'b0] <= data;
-    %0 = sv.array_index_inout %reg[%c0_i0_1] : !hw.inout<uarray<1xi64>>, i0
+    %0 = sv.array_index_inout %reg[%c0_i0_1] : !sv.var<!hw.uarray<1xi64>>, i0
     sv.passign %0, %data : i64
   }
 }
 
 // CHECK-LABEL: module remoteInstDut
 hw.module @remoteInstDut(in %i: i1, in %j: i1, in %z: i0) {
-  %mywire = sv.wire : !hw.inout<i1>
-  %mywire_rd = sv.read_inout %mywire : !hw.inout<i1>
-  %myreg = sv.reg : !hw.inout<i1>
-  %myreg_rd = sv.read_inout %myreg : !hw.inout<i1>
-  %signed = sv.wire  : !hw.inout<i1>
-  %mywire_rd1 = sv.read_inout %signed : !hw.inout<i1>
-  %output = sv.reg : !hw.inout<i1>
-  %myreg_rd1 = sv.read_inout %output: !hw.inout<i1>
+  %mywire = sv.wire : !sv.net<i1>
+  %mywire_rd = sv.read_inout %mywire : !sv.net<i1>
+  %myreg = sv.var : !sv.var<i1>
+  %myreg_rd = sv.read_inout %myreg : !sv.var<i1>
+  %signed = sv.wire  : !sv.net<i1>
+  %mywire_rd1 = sv.read_inout %signed : !sv.net<i1>
+  %output = sv.var : !sv.var<i1>
+  %myreg_rd1 = sv.read_inout %output: !sv.var<i1>
   %0 = hw.constant 1 : i1
   hw.instance "a1" sym @bindInst @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint}
   hw.instance "a2" sym @bindInst2 @extInst(_h: %mywire_rd: i1, _i: %myreg_rd: i1, _j: %j: i1, _k: %0: i1, _z: %z: i0) -> () {doNotPrint}
@@ -1473,7 +1477,7 @@ hw.module @remoteInstDut(in %i: i1, in %j: i1, in %z: i0) {
 // CHECK:      wire mywire
 // CHECK-NEXT: myreg
 // CHECK-NEXT: wire signed_0
-// CHECK-NEXT: reg  output_0
+// CHECK-NEXT: logic  output_0
 // CHECK-NEXT: /* This instance is elsewhere emitted as a bind statement
 // CHECK-NEXT:    extInst a1
 // CHECK: /* This instance is elsewhere emitted as a bind statement
@@ -1523,7 +1527,7 @@ hw.module @SimplyNestedElseIf(in %clock: i1, in %flag1 : i1, in %flag2: i1, in %
 // CHECK: else
 // CHECK: end
 hw.module @DoNotChainElseIf(in %clock: i1, in %flag1 : i1, in %flag2: i1) {
-  %wire = sv.reg : !hw.inout<i32>
+  %wire = sv.var : !sv.var<i32>
   %fd = hw.constant 0x80000002 : i32
 
   sv.always posedge %clock {
@@ -1619,10 +1623,10 @@ hw.module @ReuseExistingInOut(in %clock: i1, in %a: i1, out out1: i1) {
 
   // CHECK: wire [[WIRE1:.+]];
   // CHECK: wire [[WIRE2:.+]];
-  // CHECK: reg  [[REG:.+]];
-  %mywire = sv.wire : !hw.inout<i1>
-  %otherwire = sv.wire : !hw.inout<i1>
-  %myreg = sv.reg : !hw.inout<i1>
+  // CHECK: logic  [[REG:.+]];
+  %mywire = sv.wire : !sv.net<i1>
+  %otherwire = sv.wire : !sv.net<i1>
+  %myreg = sv.var : !sv.var<i1>
 
   // CHECK: assign [[WIRE1]] = [[INPUT]] | [[INPUT]];
   sv.assign %mywire, %expr1 : i1
@@ -1650,7 +1654,7 @@ hw.module @ProhibitReuseOfExistingInOut(in %a: i1, out out1: i1) {
   // CHECK-NEXT: `endif
   // CHECK-NEXT: assign out1 = [[GEN]];
   %0 = comb.or %a, %a : i1
-  %mywire = sv.wire  : !hw.inout<i1>
+  %mywire = sv.wire  : !sv.net<i1>
   sv.ifdef @FOO {
     sv.assign %mywire, %0 : i1
   }
@@ -1680,15 +1684,15 @@ hw.module @Verilator3405(
 }
 
 hw.module @prohiditInline(in %a:i4, in %b:i1, in %c:i1, in %d: i4) {
-  %0 = sv.reg : !hw.inout<i4>
-  %1 = sv.reg : !hw.inout<i4>
-  %2 = sv.reg : !hw.inout<i2>
+  %0 = sv.var : !sv.var<i4>
+  %1 = sv.var : !sv.var<i4>
+  %2 = sv.var : !sv.var<i2>
   sv.always posedge %b {
     // CHECK: automatic logic [3:0][[GEN1:.+]];
     // CHECK: [[GEN2:_GEN.*]] = a;
     sv.bpassign %0, %a: i4
     // CHECK-NEXT: [[GEN1]] = 4'([[GEN2]] + d);
-    %3 = sv.read_inout %0: !hw.inout<i4>
+    %3 = sv.read_inout %0: !sv.var<i4>
     %add =comb.add %3, %d: i4
     %extract = comb.extract %add from 1 : (i4) -> i2
     sv.bpassign %2, %extract: i2
@@ -1701,7 +1705,7 @@ hw.module @CollectNamesOrder(in %in: i1, out out: i1) {
   // CHECK: wire _GEN;
   %0 = comb.or %in, %in : i1
   %1 = comb.or %0, %0 : i1
-  %foo = sv.wire {hw.verilogName = "_GEN" } : !hw.inout<i1>
+  %foo = sv.wire {hw.verilogName = "_GEN" } : !sv.net<i1>
   hw.output %1 : i1
 }
 
@@ -1709,14 +1713,14 @@ hw.module @CollectNamesOrder(in %in: i1, out out: i1) {
 hw.module private @InlineReadInout() {
   %c0_i32 = hw.constant 0 : i32
   %false = hw.constant false
-  %r1 = sv.reg  : !hw.inout<i2>
+  %r1 = sv.var  : !sv.var<i2>
   sv.initial {
-    %_RANDOM = sv.logic  : !hw.inout<uarray<1xi32>>
-    %2 = sv.array_index_inout %_RANDOM[%c0_i32] : !hw.inout<uarray<1xi32>>, i32
+    %_RANDOM = sv.var  : !sv.var<!hw.uarray<1xi32>>
+    %2 = sv.array_index_inout %_RANDOM[%c0_i32] : !sv.var<!hw.uarray<1xi32>>, i32
     %RAMDOM = sv.verbatim.expr.se "`RAMDOM" : () -> i32 {symbols = []}
     sv.bpassign %2, %RAMDOM : i32
-    %3 = sv.array_index_inout %_RANDOM[%c0_i32] : !hw.inout<uarray<1xi32>>, i32
-    %4 = sv.read_inout %3 : !hw.inout<i32>
+    %3 = sv.array_index_inout %_RANDOM[%c0_i32] : !sv.var<!hw.uarray<1xi32>>, i32
+    %4 = sv.read_inout %3 : !sv.var<i32>
     // CHECK: automatic logic [31:0] _RANDOM[0:0];
     // CHECK: _RANDOM[32'h0] = `RAMDOM;
     // CHECK-NEXT: r1 = _RANDOM[32'h0][1:0];
@@ -1738,10 +1742,10 @@ hw.module private @Dollar(in %cond: i1) {
 // CHECK-LABEL: IndexPartSelectInoutArray
 hw.module @IndexPartSelectInoutArray(in %a: !hw.array<2xi1>, in %c: i1, in %d: i1) {
   %c0_i2 = hw.constant 0 : i2
-  %r1 = sv.reg  : !hw.inout<array<3xi1>>
+  %r1 = sv.var  : !sv.var<!hw.array<3xi1>>
   sv.always posedge %d {
     // CHECK: r1[2'h0 +: 2] <= a;
-    %1 = sv.indexed_part_select_inout %r1[%c0_i2 : 2] : !hw.inout<array<3xi1>>, i2
+    %1 = sv.indexed_part_select_inout %r1[%c0_i2 : 2] : !sv.var<!hw.array<3xi1>>, i2
     sv.passign %1, %a : !hw.array<2xi1>
   }
   hw.output
@@ -1823,7 +1827,7 @@ sv.func @func_def(in %in_0 : i2, out out_0: i1, in %in_1: i2, out out_1 : i1 {sv
 sv.func @recurse_add(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
   %one = hw.constant 1 : i32
   %cond = comb.icmp bin ule %n, %one: i32
-  %result = sv.logic : !hw.inout<i32>
+  %result = sv.var : !sv.var<i32>
   sv.if %cond {
     sv.bpassign %result, %n: i32
   } else {
@@ -1832,7 +1836,7 @@ sv.func @recurse_add(in %n : i32, out out : i32 {sv.func.explicitly_returned}) {
     %add = comb.add %n, %v: i32
     sv.bpassign %result, %add: i32
   }
-  %read = sv.read_inout %result: !hw.inout<i32>
+  %read = sv.read_inout %result: !sv.var<i32>
   sv.return %read : i32
 }
 
@@ -1905,7 +1909,7 @@ sv.macro.decl @INIT_RANDOM
 
 // CHECK-LABEL: module ForStatement
 hw.module @ForStatement(in %a: i5) {
-  %_RANDOM = sv.logic : !hw.inout<uarray<3xi32>>
+  %_RANDOM = sv.var : !sv.var<!hw.uarray<3xi32>>
   sv.initial {
     %c-2_i2 = hw.constant -2 : i2
     %c1_i2 = hw.constant 1 : i2
@@ -1916,7 +1920,7 @@ hw.module @ForStatement(in %a: i5) {
     // CHECK-NEXT: end
     sv.for %i = %c0_i2 to %c-1_i2 step %c1_i2 : i2 {
       %RANDOM = sv.macro.ref.expr.se @RANDOM() : ()->i32
-      %index = sv.array_index_inout %_RANDOM[%i] : !hw.inout<uarray<3xi32>>, i2
+      %index = sv.array_index_inout %_RANDOM[%i] : !sv.var<!hw.uarray<3xi32>>, i2
       sv.bpassign %index, %RANDOM : i32
     }
   }
@@ -1934,9 +1938,9 @@ hw.module @intrinsic(in %clk: i1, out io1: i1, out io2: i1, out io3: i1, out io4
   %2 = sv.system "test$plusargs"(%1) : (!hw.string) -> i1
   // CHECK: assign io2 = $test$plusargs("foo")
 
-  %_pargs = sv.wire  : !hw.inout<i5>
-  %3 = sv.read_inout %_pargs : !hw.inout<i5>
-  %4 = sv.system "value$plusargs"(%1, %_pargs) : (!hw.string, !hw.inout<i5>) -> i1
+  %_pargs = sv.wire  : !sv.net<i5>
+  %3 = sv.read_inout %_pargs : !sv.net<i5>
+  %4 = sv.system "value$plusargs"(%1, %_pargs) : (!hw.string, !sv.net<i5>) -> i1
   // CHECK: assign io3 = $value$plusargs("foo", [[tmp]])
   // CHECK: assign io4 = [[tmp]]
 
@@ -2074,11 +2078,11 @@ sv.bind #hw.innerNameRef<@InlineBind::@foo2>
 // CHECK-NEXT:  );
 
 // CHECK-LABEL:  hw.module @issue595
-// CHECK:     sv.wire  {hw.verilogName = "_GEN"} : !hw.inout<i32>
+// CHECK:     sv.wire  {hw.verilogName = "_GEN"} : !sv.net<i32>
 
 // CHECK-LABEL: hw.module @extInst2
 // CHECK-SAME: (in %signed : i1 {hw.verilogName = "signed_0"}
 
 // CHECK-LABEL:  hw.module @remoteInstDut
-// CHECK:    %signed = sv.wire  {hw.verilogName = "signed_0"} : !hw.inout<i1>
-// CHECK:    %output = sv.reg  {hw.verilogName = "output_0"} : !hw.inout<i1>
+// CHECK:    %signed = sv.wire  {hw.verilogName = "signed_0"} : !sv.net<i1>
+// CHECK:    %output = sv.var  {hw.verilogName = "output_0"} : !sv.var<i1>

--- a/test/Conversion/ExportVerilog/verilog-basic.mlir
+++ b/test/Conversion/ExportVerilog/verilog-basic.mlir
@@ -100,8 +100,8 @@ hw.module @Expressions(in %in8: i8, in %in4: i4, in %clock: i1,
   %26 = comb.concat %c0_i2, %9 : i2, i2
   %27 = comb.concat %c0_i2, %17 : i2, i2
 
-  %w1 = sv.wire : !hw.inout<i4>
-  %w1_use = sv.read_inout %w1 : !hw.inout<i4>
+  %w1 = sv.wire : !sv.net<i4>
+  %w1_use = sv.read_inout %w1 : !sv.net<i4>
 
   sv.assign %w1, %3 : i4
   sv.assign %w1, %4 : i4
@@ -116,13 +116,13 @@ hw.module @Expressions(in %in8: i8, in %in4: i4, in %clock: i1,
   %29 = comb.concat %c0_i6, %in4, %clock, %clock, %in4 : i6, i4, i1, i1, i4
   %30 = comb.concat %c0_i10, %21 : i10, i6
 
-  %w2 = sv.wire : !hw.inout<i16>
-  %w2_use = sv.read_inout %w2 : !hw.inout<i16>
+  %w2 = sv.wire : !sv.net<i16>
+  %w2_use = sv.read_inout %w2 : !sv.net<i16>
   sv.assign %w2, %29 : i16
   sv.assign %w2, %30 : i16
 
-  %w3 = sv.wire : !hw.inout<i16>
-  %w3_use = sv.read_inout %w3 : !hw.inout<i16>
+  %w3 = sv.wire : !sv.net<i16>
+  %w3_use = sv.read_inout %w3 : !sv.net<i16>
 
   // CHECK-DAG: assign out1a = ^in4;
   %p_res = comb.parity %in4 : i4
@@ -173,8 +173,8 @@ hw.module @Precedence(in %a: i4, in %b: i4, in %c: i4, out out1: i1, out out: i1
   %c0_i5 = hw.constant 0 : i5
   %c0_i3 = hw.constant 0 : i3
   %c0_i6 = hw.constant 0 : i6
-  %_out1_output = sv.wire  : !hw.inout<i1>
-  %_out_output = sv.wire  : !hw.inout<i10>
+  %_out1_output = sv.wire  : !sv.net<i1>
+  %_out_output = sv.wire  : !sv.net<i10>
 
   // CHECK: wire [4:0] _GEN = {1'h0, b};
   // CHECK: wire [4:0] _GEN_0 = _GEN + {1'h0, c};
@@ -249,12 +249,12 @@ hw.module @Precedence(in %a: i4, in %b: i4, in %c: i4, out out1: i1, out out: i1
   %40 = comb.or %38, %39 : i1
   sv.assign %_out1_output, %40 : i1
   %41 = comb.xor %b, %c : i4
-  %42 = sv.read_inout %_out1_output : !hw.inout<i1>
+  %42 = sv.read_inout %_out1_output : !sv.net<i1>
   %43 = comb.concat %c0_i3, %42 : i3, i1
   %44 = comb.and %41, %43 : i4
   %45 = comb.concat %c0_i6, %44 : i6, i4
   sv.assign %_out_output, %45 : i10
-  %46 = sv.read_inout %_out_output : !hw.inout<i10>
+  %46 = sv.read_inout %_out_output : !sv.net<i10>
   %47 = comb.extract %46 from 2 : (i10) -> i8
   %48 = comb.concat %c0_i2, %47 : i2, i8
   sv.assign %_out_output, %48 : i10
@@ -336,8 +336,8 @@ hw.module @Wires(in %a: i4, out x: i4, out y: i4) {
   // CHECK-DAG: symRef2(Wires.wire5);
   %wire5 = hw.wire %a sym @myWire : i4
   sv.verbatim "symRef1({{0}});" {symbols = [#hw.innerNameRef<@Wires::@myWire>]}
-  %2 = sv.xmr.ref @myWirePath : !hw.inout<i4>
-  %3 = sv.read_inout %2 : !hw.inout<i4>
+  %2 = sv.xmr.ref @myWirePath : !sv.var<i4>
+  %3 = sv.read_inout %2 : !sv.var<i4>
   sv.verbatim "symRef2({{0}});"(%3) : i4
 
   hw.output %wire1, %0 : i4, i4
@@ -378,7 +378,7 @@ hw.module @MultiUseExpr(in %a: i4, out b0: i1, out b1: i1, out b2: i1, out b3: i
 // CHECK:  assign out4 = in4 + 4'h1;
 // CHECK-NEXT: endmodule
 hw.module @SimpleConstPrint(in %in4: i4, out out4: i4) {
-  %w = sv.wire : !hw.inout<i4>
+  %w = sv.wire : !sv.net<i4>
   %c1_i4 = hw.constant 1 : i4
   sv.assign %w, %c1_i4 : i4
   %1 = comb.add %in4, %c1_i4 : i4
@@ -389,8 +389,8 @@ hw.module @SimpleConstPrint(in %in4: i4, out out4: i4) {
 // CHECK-LABEL: module SimpleConstPrintReset(
 // CHECK:  q <= 4'h1;
 hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
-  %w = sv.wire : !hw.inout<i4>
-  %q = sv.reg : !hw.inout<i4>
+  %w = sv.wire : !sv.net<i4>
+  %q = sv.var : !sv.var<i4>
   %c1_i4 = hw.constant 1 : i4
   sv.assign %w, %c1_i4 : i4
   sv.always posedge %clock, posedge %reset {
@@ -407,12 +407,12 @@ hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
 // CHECK-LABEL: module InlineDeclAssignment
 hw.module @InlineDeclAssignment(in %a: i1) {
   // CHECK: wire b = a;
-  %b = sv.wire : !hw.inout<i1>
+  %b = sv.wire : !sv.net<i1>
   sv.assign %b, %a : i1
 
   // CHECK: wire c = a + a;
   %0 = comb.add %a, %a : i1
-  %c = sv.wire : !hw.inout<i1>
+  %c = sv.wire : !sv.net<i1>
   sv.assign %c, %0 : i1
 }
 
@@ -428,14 +428,14 @@ hw.module @ordered_region(in %a: i1) {
     // CHECK-NEXT: `ifdef foo
     sv.ifdef @foo {
       // CHECK-NEXT: wire_0 = a;
-      %wire = sv.wire : !hw.inout<i1>
+      %wire = sv.wire : !sv.net<i1>
       sv.assign %wire, %a : i1
     }
     // CHECK-NEXT: `endif
     // CHECK-NEXT: `ifdef bar
     sv.ifdef @bar {
       // CHECK-NEXT: wire_1 = a;
-      %wire = sv.wire : !hw.inout<i1>
+      %wire = sv.wire : !sv.net<i1>
       sv.assign %wire, %a : i1
     }
     // CHECK-NEXT: `endif
@@ -583,15 +583,15 @@ hw.module @Print(in %clock: i1, in %reset: i1, in %a: i4, in %b: i4) {
 
 // CHECK-LABEL: module ReadMem()
 hw.module @ReadMem() {
-  // CHECK:      reg [31:0] mem[0:7];
-  %mem = sv.reg sym @mem : !hw.inout<uarray<8xi32>>
+  // CHECK:      logic [31:0] mem[0:7];
+  %mem = sv.var sym @mem : !sv.var<!hw.uarray<8xi32>>
   // CHECK-NEXT: initial begin
   // CHECK-NEXT:   $readmemb("file1.txt", mem);
   // CHECK-NEXT:   $readmemh("file2.txt", mem);
   // CHECK-NEXT: end
   sv.initial {
-    sv.readmem %mem, "file1.txt", MemBaseBin : !hw.inout<uarray<8xi32>>
-    sv.readmem %mem, "file2.txt", MemBaseHex : !hw.inout<uarray<8xi32>>
+    sv.readmem %mem, "file1.txt", MemBaseBin : !sv.var<!hw.uarray<8xi32>>
+    sv.readmem %mem, "file2.txt", MemBaseHex : !sv.var<!hw.uarray<8xi32>>
   }
 
 }
@@ -603,8 +603,8 @@ hw.module @ReadMemXMR() {
   // CHECK:      initial
   // CHECK-NEXT:   $readmemb("file3.txt", ReadMem.mem)
   sv.initial {
-    %xmr = sv.xmr.ref @ReadMemXMRPath {} : !hw.inout<uarray<8xi32>>
-    sv.readmem %xmr, "file3.txt", MemBaseBin : !hw.inout<uarray<8xi32>>
+    %xmr = sv.xmr.ref @ReadMemXMRPath {} : !sv.var<!hw.uarray<8xi32>>
+    sv.readmem %xmr, "file3.txt", MemBaseBin : !sv.var<!hw.uarray<8xi32>>
   }
 }
 
@@ -615,8 +615,8 @@ hw.module @ReadMemXMRHierPath() {
   // CHECK:      initial
   // CHECK-NEXT:   $readmemb("file4.txt", ReadMemXMRHierPath.ReadMemXMR.ReadMem.mem)
   sv.initial {
-    %xmr = sv.xmr.ref @ReadMem_path : !hw.inout<uarray<8xi32>>
-    sv.readmem %xmr, "file4.txt", MemBaseBin : !hw.inout<uarray<8xi32>>
+    %xmr = sv.xmr.ref @ReadMem_path : !sv.var<!hw.uarray<8xi32>>
+    sv.readmem %xmr, "file4.txt", MemBaseBin : !sv.var<!hw.uarray<8xi32>>
   }
 }
 
@@ -626,12 +626,12 @@ sv.verbatim "// VERB: hierpath {{0:|}}" {symbols = [@ReadMem_path]}
 // CHECK-LABEL: module UninitReg1(
 hw.module @UninitReg1(in %clock: i1, in %reset: i1, in %cond: i1, in %value: i2) {
   %c-1_i2 = hw.constant -1 : i2
-  %count = sv.reg  : !hw.inout<i2>
+  %count = sv.var  : !sv.var<i2>
 
   // CHECK: always_ff @(posedge clock)
   // CHECK-NEXT:   count <= ~{2{reset}} & (cond ? value : count);
 
-  %0 = sv.read_inout %count : !hw.inout<i2>
+  %0 = sv.read_inout %count : !sv.var<i2>
   %1 = comb.mux %cond, %value, %0 : i2
   %2 = comb.replicate %reset : (i1) -> i2
   %3 = comb.xor %2, %c-1_i2 : i2
@@ -671,11 +671,11 @@ hw.module.extern @VerbatimModuleExtern(in %foo: i1 {hw.exportPort = #hw<innerSym
 // CHECK-NEXT:    input  signed_0
 // CHECK-NEXT:    output unsigned_0
 hw.module @VerbatimModule(in %signed: i1 {hw.exportPort = #hw<innerSym@symA>}, out unsigned: i1 {hw.exportPort = #hw<innerSym@symB>}) {
-  %parameter = sv.wire sym @symC : !hw.inout<i4>
-  %localparam = sv.reg sym @symD : !hw.inout<i4>
+  %parameter = sv.wire sym @symC : !sv.net<i4>
+  %localparam = sv.var sym @symD : !sv.var<i4>
   %shortint = sv.interface.instance sym @symE : !sv.interface<@Interface>
-  // CHECK: wire [3:0] parameter_0;
-  // CHECK: reg  [3:0] localparam_0;
+  // CHECK: wire  [3:0] parameter_0;
+  // CHECK: logic [3:0] localparam_0;
   // CHECK: Interface shortint();
   hw.output %signed : i1
 }
@@ -731,7 +731,7 @@ hw.module @rename_port(in %r: i1 {hw.verilogName = "w"}) {
 // CHECK-LABEL: module rename_port
 // CHECK:  input w
 // CHECK:  wire [3:0] w_0;
-    %w = sv.wire : !hw.inout<i4>
+    %w = sv.wire : !sv.net<i4>
     hw.output
 }
 
@@ -774,7 +774,7 @@ hw.module @W422_Foo() {
   %false = hw.constant false
   %bar.clock, %bar.reset = hw.instance "bar" @W422_Bar() -> (clock: i1, reset: i1)
   %baz.q = hw.instance "baz" @W422_Baz() -> (q: i1)
-  %q = sv.reg sym @__q__  : !hw.inout<i1>
+  %q = sv.var sym @__q__  : !sv.var<i1>
   sv.always posedge %bar.clock, posedge %bar.reset {
     sv.if %bar.reset {
       sv.passign %q, %false : i1

--- a/test/Conversion/ExportVerilog/verilog-locations.mlir
+++ b/test/Conversion/ExportVerilog/verilog-locations.mlir
@@ -42,8 +42,8 @@ hw.module @MultiUseExpr(in %a: i4, out b0: i1) {
 
 module attributes {circt.loweringOptions = "locationInfoStyle=none,emitVerilogLocations"} {
 hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
-  %w = sv.wire : !hw.inout<i4>
-  %q = sv.reg : !hw.inout<i4>
+  %w = sv.wire : !sv.net<i4>
+  %q = sv.var : !sv.var<i4>
   %c1_i4 = hw.constant 1 : i4
   sv.assign %w, %c1_i4 : i4
   sv.always posedge %clock, posedge %reset {
@@ -63,7 +63,7 @@ hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
 // );
 //
 //   wire [3:0] w = 4'h1;
-//   reg  [3:0] q;
+//   logic  [3:0] q;
 //   always @(posedge clock or posedge reset) begin
 //     if (reset)
 //       q <= 4'h1;
@@ -72,8 +72,8 @@ hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
 //   end // always @(posedge, posedge)
 // endmodule
 // CHECK:   hw.module @SimpleConstPrintReset
-// CHECK:     %w = sv.wire {hw.verilogName = "w"} : !hw.inout<i4> loc(#loc49)
-// CHECK:     %q = sv.reg {hw.verilogName = "q"} : !hw.inout<i4>  loc(#loc50)
+// CHECK:     %w = sv.wire {hw.verilogName = "w"} : !sv.net<i4> loc(#loc49)
+// CHECK:     %q = sv.var {hw.verilogName = "q"} : !sv.var<i4>  loc(#loc50)
 // CHECK:     %c1_i4 = hw.constant 1 : i4 loc(#loc51)
 // CHECK:     sv.assign %w, %c1_i4 : i4 loc(#loc18)
 // CHECK:     sv.always posedge %clock, posedge %reset {
@@ -92,13 +92,13 @@ hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
 // CHECK: #loc3 = loc("":16:9)
 // CHECK: #loc7 = loc("{{.*}}verilog-locations.mlir{{.*}})
 // CHECK: #loc8 = loc("":8:2)
-// CHECK: #loc9 = loc("":8:22)
+// CHECK: #loc9 = loc("":8:23)
 // CHECK: #loc10 = loc("{{.*}}verilog-locations.mlir{{.*}})
 // CHECK: #loc11 = loc("":9:2)
-// CHECK: #loc12 = loc("":9:15)
+// CHECK: #loc12 = loc("":9:16)
 // CHECK: #loc13 = loc("{{.*}}verilog-locations.mlir{{.*}})
-// CHECK: #loc14 = loc("":8:17)
-// CHECK: #loc15 = loc("":8:21)
+// CHECK: #loc14 = loc("":8:18)
+// CHECK: #loc15 = loc("":8:22)
 // CHECK: #loc16 = loc("":12:11)
 // CHECK: #loc17 = loc("":12:15)
 // CHECK: #loc18 = loc("{{.*}}verilog-locations.mlir{{.*}})
@@ -144,11 +144,11 @@ hw.module @SimpleConstPrintReset(in %clock: i1, in %reset: i1, in %in4: i4) {
 
 module attributes {circt.loweringOptions = "emitVerilogLocations"} {
 hw.module @InlineDeclAssignment(in %a: i1) {
-  %b = sv.wire : !hw.inout<i1>
+  %b = sv.wire : !sv.net<i1>
   sv.assign %b, %a : i1
 
   %0 = comb.add %a, %a : i1
-  %c = sv.wire : !hw.inout<i1>
+  %c = sv.wire : !sv.net<i1>
   sv.assign %c, %0 : i1
 }
 }
@@ -162,10 +162,10 @@ hw.module @InlineDeclAssignment(in %a: i1) {
 // endmodule
 //
 // CHECK:   hw.module @InlineDeclAssignment
-// CHECK:     %b = sv.wire {hw.verilogName = "b"} : !hw.inout<i1> loc(#loc25)
+// CHECK:     %b = sv.wire {hw.verilogName = "b"} : !sv.net<i1> loc(#loc25)
 // CHECK:     sv.assign %b, %a : i1 loc(#loc8)
 // CHECK:     %[[v0:.+]] = comb.add %a, %a : i1 loc(#loc26)
-// CHECK:     %c = sv.wire {hw.verilogName = "c"} : !hw.inout<i1> loc(#loc27)
+// CHECK:     %c = sv.wire {hw.verilogName = "c"} : !sv.net<i1> loc(#loc27)
 // CHECK:     sv.assign %c, %[[v0]] : i1 loc(#loc15)
 // CHECK:     hw.output loc(#loc1)
 // CHECK:   } loc(#loc24)

--- a/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw-module.mlir
@@ -136,7 +136,8 @@ firrtl.circuit "Simple" {
   }
 
   // CHECK-LABEL: hw.module private @Analog(inout %a1 : i1, out outClock : !seq.clock) {
-  // CHECK-NEXT:    [[READ:%.+]] = sv.read_inout %a1 : !hw.inout<i1>
+  // CHECK-NEXT:    [[NET:%.+]] = sv.net.from_inout %a1 : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT:    [[READ:%.+]] = sv.read_inout [[NET]] : !sv.net<i1>
   // CHECK-NEXT:    [[CLK:%.+]] = seq.to_clock [[READ]]
   // CHECK-NEXT:    hw.output [[CLK]] : !seq.clock
   firrtl.module private @Analog(in %a1: !firrtl.analog<1>,
@@ -249,7 +250,7 @@ firrtl.circuit "Simple" {
   }
   // CHECK-LABEL: hw.module private @foo690()
   firrtl.module private @foo690() {
-    // CHECK: %.led_0.wire = sv.wire
+    // CHECK: %.led_0.wire = hw.var
     // CHECK: hw.instance "fpga" @bar690(led_0: %.led_0.wire: !hw.inout<i1>) -> ()
     %result = firrtl.instance fpga @bar690(in led_0: !firrtl.analog<1>)
   }

--- a/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
+++ b/test/Conversion/FIRRTLToHW/lower-to-hw.mlir
@@ -291,7 +291,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
     // CHECK: [[VERB1:%.+]] = sv.verbatim.expr "MAGIC_CONSTANT" : () -> i42
     // CHECK: [[VERB2:%.+]] = sv.verbatim.expr "$bits({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> i32 {symbols = [@Simple]}
-    // CHECK: [[VERB3:%.+]] = sv.verbatim.expr.se "$size({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> !hw.inout<i32> {symbols = [@Simple]}
+    // CHECK: [[VERB3:%.+]] = sv.verbatim.expr.se "$size({{[{][{]0[}][}]}}, {{[{][{]1[}][}]}})"([[VERB1]]) : (i42) -> !sv.net<i32> {symbols = [@Simple]}
     // CHECK: [[VERB3READ:%.+]] = sv.read_inout [[VERB3]]
     // CHECK: [[VERB1EXT:%.+]] = comb.concat {{%.+}}, [[VERB1]] : i1, i42
     // CHECK: [[VERB2EXT:%.+]] = comb.concat {{%.+}}, [[VERB2]] : i11, i32
@@ -806,32 +806,38 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @Analog(inout %a1 : i1, inout %b1 : i1,
   // CHECK:                          inout %c1 : i1, out outClock : !seq.clock) {
-  // CHECK-NEXT:   %0 = sv.read_inout %c1 : !hw.inout<i1>
-  // CHECK-NEXT:   %1 = sv.read_inout %b1 : !hw.inout<i1>
-  // CHECK-NEXT:   %2 = sv.read_inout %a1 : !hw.inout<i1>
-  // CHECK-NEXT:   sv.ifdef @SYNTHESIS {
-  // CHECK-NEXT:     sv.assign %a1, %1 : i1
-  // CHECK-NEXT:     sv.assign %a1, %0 : i1
-  // CHECK-NEXT:     sv.assign %b1, %2 : i1
-  // CHECK-NEXT:     sv.assign %b1, %0 : i1
-  // CHECK-NEXT:     sv.assign %c1, %2 : i1
-  // CHECK-NEXT:     sv.assign %c1, %1 : i1
-  // CHECK-NEXT:    } else {
-  // CHECK-NEXT:     sv.ifdef @VERILATOR {
-  // CHECK-NEXT:       sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
-  // CHECK-NEXT:     } else {
-  // CHECK-NEXT:       sv.alias %a1, %b1, %c1 : !hw.inout<i1>
-  // CHECK-NEXT:     }
-  // CHECK-NEXT:    }
-  // CHECK-NEXT:    [[CLOCK:%.+]] = seq.to_clock %2
-  // CHECK-NEXT:    hw.output [[CLOCK]] : !seq.clock
-  firrtl.module private @Analog(in %a1: !firrtl.analog<1>, in %b1: !firrtl.analog<1>,
-                        in %c1: !firrtl.analog<1>, out %outClock: !firrtl.clock) {
-    firrtl.attach %a1, %b1, %c1 : !firrtl.analog<1>, !firrtl.analog<1>, !firrtl.analog<1>
 
-    %1 = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
-    firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
-  }
+  // CHECK-NEXT:  %0 = sv.net.from_inout %a1 : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT:  %1 = sv.read_inout %0 : !sv.net<i1>
+  // CHECK-NEXT:  %2 = sv.net.from_inout %a1 : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT:  %3 = sv.read_inout %2 : !sv.net<i1>
+  // CHECK-NEXT:  %4 = sv.net.from_inout %b1 : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT:  %5 = sv.read_inout %4 : !sv.net<i1>
+  // CHECK-NEXT:  %6 = sv.net.from_inout %c1 : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT:  %7 = sv.read_inout %6 : !sv.net<i1>
+  // CHECK-NEXT:  sv.ifdef @SYNTHESIS {
+  // CHECK-NEXT:   sv.assign %2, %5 : i1
+  // CHECK-NEXT:   sv.assign %2, %7 : i1
+  // CHECK-NEXT:   sv.assign %4, %3 : i1
+  // CHECK-NEXT:   sv.assign %4, %7 : i1
+  // CHECK-NEXT:   sv.assign %6, %3 : i1
+  // CHECK-NEXT:   sv.assign %6, %5 : i1
+  // CHECK-NEXT:  } else  {
+  // CHECK-NEXT:   sv.ifdef @VERILATOR {
+  // CHECK-NEXT:     sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.alias %2, %4, %6 : !sv.net<i1>, !sv.net<i1>, !sv.net<i1>
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  // CHECK-NEXT: [[CLOCK:%.+]] = seq.to_clock %1
+  // CHECK-NEXT: hw.output [[CLOCK]] : !seq.clock
+firrtl.module private @Analog(in %a1: !firrtl.analog<1>, in %b1: !firrtl.analog<1>,
+                      in %c1: !firrtl.analog<1>, out %outClock: !firrtl.clock) {
+  firrtl.attach %a1, %b1, %c1 : !firrtl.analog<1>, !firrtl.analog<1>, !firrtl.analog<1>
+
+  %1 = firrtl.asClock %a1 : (!firrtl.analog<1>) -> !firrtl.clock
+  firrtl.connect %outClock, %1 : !firrtl.clock, !firrtl.clock
+}
 
   // CHECK-LABEL: hw.module private @top_modx(out tmp27 : i23) {
   // CHECK-NEXT:    %c0_i23 = hw.constant 0 : i23
@@ -956,27 +962,28 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.matchingconnect %o, %0 : !firrtl.uint<1>
   }
 
-  // CHECK-LABEL: IsInvalidIssue572
-  // https://github.com/llvm/circt/issues/572
-  firrtl.module private @IsInvalidIssue572(in %a: !firrtl.analog<1>) {
-    // CHECK-NEXT: %0 = sv.read_inout %a : !hw.inout<i1>
+ // CHECK-LABEL: IsInvalidIssue572
+ // https://github.com/llvm/circt/issues/572
+ firrtl.module private @IsInvalidIssue572(in %a: !firrtl.analog<1>) {
+  // CHECK-NEXT: %.invalid_analog = hw.var  : !hw.inout<i1>
+  // CHECK-NEXT: %0 = sv.net.from_inout %a : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT: %1 = sv.read_inout %0 : !sv.net<i1>
+  // CHECK-NEXT: %2 = sv.net.from_inout %.invalid_analog : !hw.inout<i1> -> !sv.net<i1>
+  // CHECK-NEXT: %3 = sv.read_inout %2 : !sv.net<i1>
+  %0 = firrtl.invalidvalue : !firrtl.analog<1>
 
-    // CHECK-NEXT: %.invalid_analog = sv.wire : !hw.inout<i1>
-    // CHECK-NEXT: %1 = sv.read_inout %.invalid_analog : !hw.inout<i1>
-    %0 = firrtl.invalidvalue : !firrtl.analog<1>
-
-    // CHECK-NEXT: sv.ifdef @SYNTHESIS {
-    // CHECK-NEXT:   sv.assign %a, %1 : i1
-    // CHECK-NEXT:   sv.assign %.invalid_analog, %0 : i1
-    // CHECK-NEXT: } else {
-    // CHECK-NEXT:   sv.ifdef @VERILATOR {
-    // CHECK-NEXT:     sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
-    // CHECK-NEXT:   } else {
-    // CHECK-NEXT:     sv.alias %a, %.invalid_analog : !hw.inout<i1>, !hw.inout<i1>
-    // CHECK-NEXT:   }
-    // CHECK-NEXT: }
-    firrtl.attach %a, %0 : !firrtl.analog<1>, !firrtl.analog<1>
-  }
+  // CHECK-NEXT: sv.ifdef @SYNTHESIS {
+  // CHECK-NEXT:   sv.assign %0, %3 : i1
+  // CHECK-NEXT:   sv.assign %2, %1 : i1
+  // CHECK-NEXT: } else {
+  // CHECK-NEXT:   sv.ifdef @VERILATOR {
+  // CHECK-NEXT:     sv.verbatim "`error \22Verilator does not support alias and thus cannot arbitrarily connect bidirectional wires and ports\22"
+  // CHECK-NEXT:   } else {
+  // CHECK-NEXT:     sv.alias %0, %2 : !sv.net<i1>, !sv.net<i1>
+  // CHECK-NEXT:   }
+  // CHECK-NEXT: }
+  firrtl.attach %a, %0 : !firrtl.analog<1>, !firrtl.analog<1>
+}
 
   // CHECK-LABEL: IsInvalidIssue654
   // https://github.com/llvm/circt/issues/654
@@ -1017,9 +1024,9 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
 
   // CHECK-LABEL: hw.module private @Force
   firrtl.module private @Force(in %in: !firrtl.uint<42>) {
-    // CHECK: %foo = sv.verbatim.expr.se "foo" : () -> !hw.inout<i42>
+    // CHECK: %foo = sv.verbatim.expr.se "foo" : () -> !sv.net<i42>
     // CHECK: sv.initial {
-    // CHECK:   sv.force %foo, %in : i42
+    // CHECK:   sv.force %foo, %in : !sv.net<i42>
     // CHECK: }
     %foo = firrtl.verbatim.wire "foo" : () -> !firrtl.uint<42>
     firrtl.force %foo, %in : !firrtl.uint<42>, !firrtl.uint<42>
@@ -1521,7 +1528,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.attach %result_iIn, %result_iOut : !firrtl.analog<8>, !firrtl.analog<8>
   }
   // CHECK-LABEL: hw.module @AnalogMergeTwo() {
-  // CHECK:         %.a.wire = sv.wire : !hw.inout<i8>
+  // CHECK:         %.a.wire = hw.var : !hw.inout<i8>
   // CHECK:         hw.instance "iIn" @AnalogInModA(a: %.a.wire: !hw.inout<i8>) -> ()
   // CHECK:         hw.instance "iOut" @AnalogOutModA(a: %.a.wire: !hw.inout<i8>) -> ()
   // CHECK-NEXT:    hw.output
@@ -1535,7 +1542,7 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     firrtl.attach %result_iInA, %result_iInB, %result_iOut : !firrtl.analog<8>, !firrtl.analog<8>, !firrtl.analog<8>
   }
   // CHECK-LABEL: hw.module @AnalogMergeThree() {
-  // CHECK:         %.a.wire = sv.wire : !hw.inout<i8>
+  // CHECK:         %.a.wire = hw.var : !hw.inout<i8>
   // CHECK:         hw.instance "iInA" @AnalogInModA(a: %.a.wire: !hw.inout<i8>) -> ()
   // CHECK:         hw.instance "iInB" @AnalogInModB(a: %.a.wire: !hw.inout<i8>) -> ()
   // CHECK:         hw.instance "iOut" @AnalogOutModA(a: %.a.wire: !hw.inout<i8>) -> ()
@@ -1588,22 +1595,22 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
   }
   // CHECK-NEXT:  [[CLOCK:%.+]] = seq.from_clock %clock
   // CHECK-NEXT:  hw.instance "r" sym @xmr_sym @RefMe() -> ()
-  // CHECK-NEXT:  %[[XMR1:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
-  // CHECK-NEXT:  %[[XMR2:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
-  // CHECK-NEXT:  %[[XMR3:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
-  // CHECK-NEXT:  %[[XMR4:.+]] = sv.xmr.ref @xmrPath : !hw.inout<i4>
+  // CHECK-NEXT:  %[[XMR1:.+]] = sv.xmr.ref @xmrPath : !sv.var<i4>
+  // CHECK-NEXT:  %[[XMR2:.+]] = sv.xmr.ref @xmrPath : !sv.var<i4>
+  // CHECK-NEXT:  %[[XMR3:.+]] = sv.xmr.ref @xmrPath : !sv.var<i4>
+  // CHECK-NEXT:  %[[XMR4:.+]] = sv.xmr.ref @xmrPath : !sv.var<i4>
   // CHECK-NEXT:  sv.ifdef @SYNTHESIS {
   // CHECK-NEXT:  } else {
   // CHECK-NEXT:    sv.always posedge [[CLOCK]] {
   // CHECK-NEXT:      sv.if %c {
-  // CHECK-NEXT:        sv.force %[[XMR1]], %x : i4
-  // CHECK-NEXT:        sv.release %[[XMR3]] : !hw.inout<i4>
+  // CHECK-NEXT:        sv.force %[[XMR1]], %x : !sv.var<i4>
+  // CHECK-NEXT:        sv.release %[[XMR3]] : !sv.var<i4>
   // CHECK-NEXT:      }
   // CHECK-NEXT:    }
   // CHECK-NEXT:    sv.initial {
   // CHECK-NEXT:      sv.if %c {
-  // CHECK-NEXT:        sv.force %[[XMR2]], %x : i4
-  // CHECK-NEXT:        sv.release %[[XMR4]] : !hw.inout<i4>
+  // CHECK-NEXT:        sv.force %[[XMR2]], %x : !sv.var<i4>
+  // CHECK-NEXT:        sv.release %[[XMR4]] : !sv.var<i4>
   // CHECK-NEXT:      }
   // CHECK-NEXT:    }
   // CHECK-NEXT:  }
@@ -1657,18 +1664,18 @@ firrtl.circuit "Simple"   attributes {annotations = [{class =
     // CHECK-NEXT: %mux2cell_in1 = hw.wire %v1 sym @{{.+}} : i32
     // CHECK-NEXT: %mux2cell_in2 = hw.wire %v0 sym @{{.+}} : i32
     // CHECK-NEXT: %0 = comb.mux bin %mux2cell_in0, %mux2cell_in1, %mux2cell_in2 {sv.attributes = [#sv.attribute<"cadence map_to_mux", emitAsComment>]} : i32
-    // CHECK-NEXT: %1 = sv.wire : !hw.inout<i32>
+    // CHECK-NEXT: %1 = sv.wire : !sv.net<i32>
     // CHECK-NEXT: sv.assign %1, %0 {sv.attributes = [#sv.attribute<"synopsys infer_mux_override", emitAsComment>]} : i32
-    // CHECK-NEXT: %2 = sv.read_inout %1 : !hw.inout<i32>
+    // CHECK-NEXT: %2 = sv.read_inout %1 : !sv.net<i32>
 
     %1 = firrtl.int.mux4cell(%sel2, %v3, %v2, %v1, %v0) : (!firrtl.uint<2>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>, !firrtl.uint<32>) -> !firrtl.uint<32>
     firrtl.matchingconnect %out2, %1 : !firrtl.uint<32>
     // CHECK:      %mux4cell_in0 = hw.wire %3 sym @{{.+}} : !hw.array<4xi32>
     // CHECK-NEXT: %mux4cell_in1 = hw.wire %sel2 sym @{{.+}} : i2
     // CHECK-NEXT: %4 = hw.array_get %mux4cell_in0[%mux4cell_in1] {sv.attributes = [#sv.attribute<"cadence map_to_mux", emitAsComment>]} : !hw.array<4xi32>, i2
-    // CHECK-NEXT: %5 = sv.wire : !hw.inout<i32>
+    // CHECK-NEXT: %5 = sv.wire : !sv.net<i32>
     // CHECK-NEXT: sv.assign %5, %4 {sv.attributes = [#sv.attribute<"synopsys infer_mux_override", emitAsComment>]} : i32
-    // CHECK-NEXT: %6 = sv.read_inout %5 : !hw.inout<i32>
+    // CHECK-NEXT: %6 = sv.read_inout %5 : !sv.net<i32>
     // CHECK-NEXT: hw.output %2, %6 : i32, i32
   }
 
@@ -1802,7 +1809,7 @@ firrtl.circuit "RefXMRLowering" {
   hw.hierpath private @path [@RefXMRLowering::@dummy]
 
   firrtl.module @RefXMRLowering() {
-    // CHECK: sv.xmr.ref @path "test" : !hw.inout<i3>
+    // CHECK: sv.xmr.ref @path "test" : !sv.var<i3>
     firrtl.wire sym @dummy : !firrtl.uint<1>
     firrtl.xmr.ref @path, "test" : !firrtl.rwprobe<uint<3>>
   }

--- a/test/Conversion/FSMToSV/test_basic.mlir
+++ b/test/Conversion/FSMToSV/test_basic.mlir
@@ -32,23 +32,23 @@ hw.module @top(in %arg0: i1, in %arg1: i1, in %clk : !seq.clock, in %rst : i1, o
 
 // CHECK-LABEL:  hw.module @top(in %a0 : i1, in %a1 : i1, out r0 : i8, out r1 : i8, in %clk : !seq.clock, in %rst : i1)
 // CHECK-NEXT:    %A = hw.enum.constant A : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %to_A = sv.reg sym @A  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %to_A = sv.wire sym @A  : !sv.net<!hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    sv.assign %to_A, %A : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %0 = sv.read_inout %to_A : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %0 = sv.read_inout %to_A : !sv.net<!hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    %B = hw.enum.constant B : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %to_B = sv.reg sym @B  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %to_B = sv.wire sym @B  : !sv.net<!hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    sv.assign %to_B, %B : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %1 = sv.read_inout %to_B : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %state_next = sv.reg  : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
-// CHECK-NEXT:    %2 = sv.read_inout %state_next : !hw.inout<typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %1 = sv.read_inout %to_B : !sv.net<!hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %state_next = sv.var  : !sv.var<!hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
+// CHECK-NEXT:    %2 = sv.read_inout %state_next : !sv.var<!hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>>
 // CHECK-NEXT:    %state_reg = seq.compreg sym @state_reg %2, %clk reset %rst, %0  : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:    %c42_i8 = hw.constant 42 : i8
 // CHECK-NEXT:    %c0_i8 = hw.constant 0 : i8
 // CHECK-NEXT:    %c1_i8 = hw.constant 1 : i8
 // CHECK-NEXT:    %3 = comb.and %a0, %a1 : i1
 // CHECK-NEXT:    %4 = comb.mux %3, %0, %1 : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
-// CHECK-NEXT:    %output_0 = sv.reg  : !hw.inout<i8>
-// CHECK-NEXT:    %output_1 = sv.reg  : !hw.inout<i8>
+// CHECK-NEXT:    %output_0 = sv.var  : !sv.var<i8>
+// CHECK-NEXT:    %output_1 = sv.var  : !sv.var<i8>
 // CHECK-NEXT:    sv.alwayscomb {
 // CHECK-NEXT:      sv.case %state_reg : !hw.typealias<@fsm_enum_typedecls::@top_state_t, !hw.enum<A, B>>
 // CHECK-NEXT:      case A: {
@@ -64,8 +64,8 @@ hw.module @top(in %arg0: i1, in %arg1: i1, in %clk : !seq.clock, in %rst : i1, o
 // CHECK-NEXT:      default: {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %5 = sv.read_inout %output_0 : !hw.inout<i8>
-// CHECK-NEXT:    %6 = sv.read_inout %output_1 : !hw.inout<i8>
+// CHECK-NEXT:    %5 = sv.read_inout %output_0 : !sv.var<i8>
+// CHECK-NEXT:    %6 = sv.read_inout %output_1 : !sv.var<i8>
 // CHECK-NEXT:    hw.output %5, %6 : i8, i8
 // CHECK-NEXT:  }
 

--- a/test/Conversion/HWArithToHW/test_basic.mlir
+++ b/test/Conversion/HWArithToHW/test_basic.mlir
@@ -349,10 +349,10 @@ hw.module @backedges() {
 // -----
 
 // CHECK-LABEL:   hw.module @wires() {
-// CHECK:           %[[VAL_0:.*]] = sv.wire  : !hw.inout<i2>
-// CHECK:           %[[VAL_1:.*]] = sv.reg  : !hw.inout<i2>
-// CHECK:           %[[VAL_2:.*]] = sv.read_inout %[[VAL_0]] : !hw.inout<i2>
-// CHECK:           %[[VAL_3:.*]] = sv.read_inout %[[VAL_1]] : !hw.inout<i2>
+// CHECK:           %[[VAL_0:.*]] = sv.wire  : !sv.net<i2>
+// CHECK:           %[[VAL_1:.*]] = sv.wire  : !sv.net<i2>
+// CHECK:           %[[VAL_2:.*]] = sv.read_inout %[[VAL_0]] : !sv.net<i2>
+// CHECK:           %[[VAL_3:.*]] = sv.read_inout %[[VAL_1]] : !sv.net<i2>
 // CHECK:           %[[VAL_4:.*]] = comb.icmp eq %[[VAL_3]], %[[VAL_2]] : i2
 // CHECK:           %[[VAL_5:.*]] = hw.constant -2 : i2
 // CHECK:           sv.assign %[[VAL_0]], %[[VAL_5]] : i2
@@ -360,10 +360,10 @@ hw.module @backedges() {
 // CHECK:           hw.output
 // CHECK:         }
 hw.module @wires () {
-  %r52 = sv.wire  : !hw.inout<ui2>
-  %r53 = sv.reg : !hw.inout<ui2>
-  %0 = sv.read_inout %r52 : !hw.inout<ui2>
-  %1 = sv.read_inout %r53 : !hw.inout<ui2>
+  %r52 = sv.wire  : !sv.net<ui2>
+  %r53 = sv.wire : !sv.net<ui2>
+  %0 = sv.read_inout %r52 : !sv.net<ui2>
+  %1 = sv.read_inout %r53 : !sv.net<ui2>
   %33 = hwarith.cast %0 : (ui2) -> i2
   %34 = hwarith.cast %1 : (ui2) -> i2
   %35 = comb.icmp eq %34, %33 : i2
@@ -397,13 +397,13 @@ hw.module @MMIOAxiReadWriteMux(out cmd : !hw.typealias<@pycde::@MMIOIntermediate
 
 // -----
 // CHECK-LABEL:  hw.module @UnpackedArrayInout() {
-// CHECK-NEXT:     %vec_a = sv.reg : !hw.inout<uarray<16xi32>>
+// CHECK-NEXT:     %vec_a = sv.var : !sv.var<!hw.uarray<16xi32>>
 // CHECK-NEXT:     %c0_i4 = hw.constant 0 : i4
-// CHECK-NEXT:     [[R0:%.+]] = sv.array_index_inout %vec_a[%c0_i4] : !hw.inout<uarray<16xi32>>, i4
-// CHECK-NEXT:     sv.read_inout [[R0]] : !hw.inout<i32>
+// CHECK-NEXT:     [[R0:%.+]] = sv.array_index_inout %vec_a[%c0_i4] : !sv.var<!hw.uarray<16xi32>>, i4
+// CHECK-NEXT:     sv.read_inout [[R0]] : !sv.var<i32>
 hw.module @UnpackedArrayInout() {
-    %vec_a = sv.reg : !hw.inout<uarray<16xsi32>>
+    %vec_a = sv.var : !sv.var<!hw.uarray<16xsi32>>
     %1 = hw.constant 0 : i4
-    %2 = sv.array_index_inout %vec_a[%1] : !hw.inout<uarray<16xsi32>>, i4
-    %3 = sv.read_inout %2 : !hw.inout<si32>
+    %2 = sv.array_index_inout %vec_a[%1] : !sv.var<!hw.uarray<16xsi32>>, i4
+    %3 = sv.read_inout %2 : !sv.var<si32>
 }

--- a/test/Conversion/PipelineToHW/test_basic.mlir
+++ b/test/Conversion/PipelineToHW/test_basic.mlir
@@ -146,24 +146,24 @@ hw.module @testSingleWithExt(in %arg0: i32, in %ext1: i32, in %go : i1, in %clk:
 
 // CHECK:   hw.module @testControlUsage(in %[[VAL_0:.*]] : i32, in %[[VAL_1:.*]] : i1, in %[[CLOCK:.*]] : !seq.clock, in %[[VAL_3:.*]] : i1, out out0 : i32) {
 // CHECK:           %[[VAL_4:.*]] = hw.constant 0 : i32
-// CHECK:           %[[VAL_5:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_6:.*]] = sv.read_inout %[[VAL_5]] : !hw.inout<i32>
+// CHECK:           %[[VAL_5:.*]] = sv.wire : !sv.net<i32>
+// CHECK:           %[[VAL_6:.*]] = sv.read_inout %[[VAL_5]] : !sv.net<i32>
 // CHECK:           %[[VAL_7:.*]] = comb.add %[[VAL_6]], %[[VAL_0]] : i32
 // CHECK:           %[[VAL_8:.*]] = seq.compreg.ce %[[VAL_7]], %[[CLOCK]], %[[VAL_1]] reset %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_5]], %[[VAL_8]] : i32
 // CHECK:           %[[VAL_9:.*]] = seq.compreg sym @p0_stage0_reg0 %[[VAL_8]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_10:.*]] = hw.constant false
 // CHECK:           %[[VAL_11:.*]] = seq.compreg sym @p0_stage1_enable  %[[VAL_1]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_10]]  : i1
-// CHECK:           %[[VAL_12:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !hw.inout<i32>
+// CHECK:           %[[VAL_12:.*]] = sv.wire : !sv.net<i32>
+// CHECK:           %[[VAL_13:.*]] = sv.read_inout %[[VAL_12]] : !sv.net<i32>
 // CHECK:           %[[VAL_14:.*]] = comb.add %[[VAL_13]], %[[VAL_9]] : i32
 // CHECK:           %[[VAL_15:.*]] = seq.compreg.ce %[[VAL_14]], %[[CLOCK]], %[[VAL_11]] reset %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_12]], %[[VAL_15]] : i32
 // CHECK:           %[[VAL_16:.*]] = seq.compreg sym @p0_stage1_reg0 %[[VAL_15]], %[[CLOCK]] : i32
 // CHECK:           %[[VAL_17:.*]] = hw.constant false
 // CHECK:           %[[VAL_18:.*]] = seq.compreg sym @p0_stage2_enable  %[[VAL_11]], %[[CLOCK]] reset %[[VAL_3]], %[[VAL_17]]  : i1
-// CHECK:           %[[VAL_19:.*]] = sv.wire : !hw.inout<i32>
-// CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !hw.inout<i32>
+// CHECK:           %[[VAL_19:.*]] = sv.wire : !sv.net<i32>
+// CHECK:           %[[VAL_20:.*]] = sv.read_inout %[[VAL_19]] : !sv.net<i32>
 // CHECK:           %[[VAL_21:.*]] = comb.add %[[VAL_20]], %[[VAL_16]] : i32
 // CHECK:           %[[VAL_22:.*]] = seq.compreg.ce %[[VAL_21]], %[[CLOCK]], %[[VAL_18]] reset %[[VAL_3]], %[[VAL_4]]  : i32
 // CHECK:           sv.assign %[[VAL_19]], %[[VAL_22]] : i32
@@ -172,16 +172,16 @@ hw.module @testSingleWithExt(in %arg0: i32, in %ext1: i32, in %go : i1, in %clk:
 hw.module @testControlUsage(in %arg0: i32, in %go : i1, in %clk: !seq.clock, in %rst: i1, out out0: i32) {
   %0:2 = pipeline.scheduled(%a0 : i32 = %arg0) clock(%clk) reset(%rst) go(%go) entryEn(%s0_enable) -> (out: i32) {
     %zero = hw.constant 0 : i32
-    %reg_out_wire = sv.wire : !hw.inout<i32>
-    %reg_out = sv.read_inout %reg_out_wire : !hw.inout<i32>
+    %reg_out_wire = sv.wire : !sv.net<i32>
+    %reg_out = sv.read_inout %reg_out_wire : !sv.net<i32>
     %add0 = comb.add %reg_out, %a0 : i32
     %out = seq.compreg.ce %add0, %clk, %go reset %rst, %zero : i32
     sv.assign %reg_out_wire, %out : i32
     pipeline.stage ^bb1 regs(%out : i32)
 
   ^bb1(%6: i32, %s1_enable: i1):
-    %reg1_out_wire = sv.wire : !hw.inout<i32>
-    %reg1_out = sv.read_inout %reg1_out_wire : !hw.inout<i32>
+    %reg1_out_wire = sv.wire : !sv.net<i32>
+    %reg1_out = sv.read_inout %reg1_out_wire : !sv.net<i32>
     %add1 = comb.add %reg1_out, %6 : i32
     %out1 = seq.compreg.ce %add1, %clk, %s1_enable reset %rst, %zero : i32
     sv.assign %reg1_out_wire, %out1 : i32
@@ -189,8 +189,8 @@ hw.module @testControlUsage(in %arg0: i32, in %go : i1, in %clk: !seq.clock, in 
     pipeline.stage ^bb2 regs(%out1 : i32)
 
   ^bb2(%9 : i32, %s2_enable: i1):
-    %reg2_out_wire = sv.wire : !hw.inout<i32>
-    %reg2_out = sv.read_inout %reg2_out_wire : !hw.inout<i32>
+    %reg2_out_wire = sv.wire : !sv.net<i32>
+    %reg2_out = sv.read_inout %reg2_out_wire : !sv.net<i32>
     %add2 = comb.add %reg2_out, %9 : i32
     %out2 = seq.compreg.ce %add2, %clk, %s2_enable reset %rst, %zero : i32
     sv.assign %reg2_out_wire, %out2 : i32

--- a/test/Conversion/SeqToSV/compreg.mlir
+++ b/test/Conversion/SeqToSV/compreg.mlir
@@ -1,8 +1,8 @@
 // RUN: circt-opt %s --lower-seq-to-sv=lower-to-always-ff | FileCheck %s
 
 // CHECK-LABEL: hw.module @basic(in %clk : i1, in %d : i8, out q : i8) {
-// CHECK:         %[[REG:.*]] = sv.reg : !hw.inout<i8>
-// CHECK:         %[[RD:.*]] = sv.read_inout %[[REG]] : !hw.inout<i8>
+// CHECK:         %[[REG:.*]] = sv.var : !sv.var<i8>
+// CHECK:         %[[RD:.*]] = sv.read_inout %[[REG]] : !sv.var<i8>
 // CHECK:         sv.alwaysff(posedge %clk) {
 // CHECK-NEXT:      sv.passign %[[REG]], %d : i8
 // CHECK-NEXT:    }
@@ -17,8 +17,8 @@ hw.module @basic(in %clk: !seq.clock, in %d: i8, out q: i8) {
 // CHECK:         sv.initial {
 // CHECK:         }
 // CHECK:         %[[CST:.*]] = hw.constant 19 : i8
-// CHECK:         %[[REG:.*]] = sv.reg init %[[CST]] : !hw.inout<i8>
-// CHECK:         %[[RD:.*]] = sv.read_inout %[[REG]] : !hw.inout<i8>
+// CHECK:         %[[REG:.*]] = sv.var init %[[CST]] : !sv.var<i8>
+// CHECK:         %[[RD:.*]] = sv.read_inout %[[REG]] : !sv.var<i8>
 // CHECK:         sv.always posedge %clk {
 // CHECK-NEXT:      sv.passign %[[REG]], %d : i8
 // CHECK-NEXT:    }

--- a/test/Conversion/SimToSV/plusargs.mlir
+++ b/test/Conversion/SimToSV/plusargs.mlir
@@ -3,7 +3,7 @@
 // CHECK-LABEL: hw.module @plusargs_test
 hw.module @plusargs_test(out test: i1) {
   // CHECK-NEXT: [[FOO_STR:%.*]] = sv.constantStr "foo"
-  // CHECK-NEXT: [[FOO_DECL:%.*]] = sv.reg : !hw.inout<i1>
+  // CHECK-NEXT: [[FOO_DECL:%.*]] = sv.var : !sv.var<i1>
   // CHECK-NEXT: sv.initial {
   // CHECK-NEXT:   [[TMP:%.*]] = sv.system "test$plusargs"([[FOO_STR]])
   // CHECK-NEXT:   sv.bpassign [[FOO_DECL]], [[TMP]]
@@ -16,8 +16,8 @@ hw.module @plusargs_test(out test: i1) {
 
 // CHECK-LABEL: hw.module @plusargs_value
 hw.module @plusargs_value(out test: i1, out value: i5) {
-  // CHECK-NEXT: [[BAR_VALUE:%.*]] = sv.wire : !hw.inout<i5>
-  // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.wire : !hw.inout<i1>
+  // CHECK-NEXT: [[BAR_VALUE:%.*]] = sv.wire : !sv.net<i5>
+  // CHECK-NEXT: [[BAR_FOUND:%.*]] = sv.wire : !sv.net<i1>
   // CHECK-NEXT: sv.ifdef @SYNTHESIS {
   // CHECK-NEXT:   %false = hw.constant false
   // CHECK-NEXT:   %z_i5 = sv.constantZ : i5
@@ -26,15 +26,15 @@ hw.module @plusargs_value(out test: i1, out value: i5) {
   // CHECK-SAME:     emitAsComment
   // CHECK-NEXT:   sv.assign [[BAR_FOUND]], %false
   // CHECK-NEXT: } else {
-  // CHECK-NEXT:   [[FOUND_REG:%.*]] = sv.reg : !hw.inout<i32>
-  // CHECK-NEXT:   [[VALUE_REG:%.*]] = sv.reg : !hw.inout<i5>
+  // CHECK-NEXT:   [[FOUND_REG:%.*]] = sv.var : !sv.var<i32>
+  // CHECK-NEXT:   [[VALUE_REG:%.*]] = sv.var : !sv.var<i5>
   // CHECK-NEXT:   sv.initial {
   // CHECK-NEXT:     [[BAR_STR:%.*]] = sv.constantStr "bar"
   // CHECK-NEXT:     [[PLUSARG_FOUND:%.*]] = sv.system "value$plusargs"([[BAR_STR]], [[VALUE_REG]])
   // CHECK-NEXT:     sv.bpassign [[FOUND_REG]], [[PLUSARG_FOUND]]
   // CHECK-NEXT:   }
-  // CHECK-NEXT:   [[FOUND_READ:%.*]] = sv.read_inout [[FOUND_REG]] : !hw.inout<i32>
-  // CHECK-NEXT:   [[VALUE_READ:%.*]] = sv.read_inout [[VALUE_REG]] : !hw.inout<i5>
+  // CHECK-NEXT:   [[FOUND_READ:%.*]] = sv.read_inout [[FOUND_REG]] : !sv.var<i32>
+  // CHECK-NEXT:   [[VALUE_READ:%.*]] = sv.read_inout [[VALUE_REG]] : !sv.var<i5>
   // CHECK-NEXT:   %c1_i32 = hw.constant 1 : i32
   // CHECK-NEXT:   [[FOUND:%.*]] = comb.icmp ceq [[FOUND_READ]], %c1_i32 : i32
   // CHECK-NEXT:   sv.assign [[BAR_FOUND]], [[FOUND]] : i1

--- a/test/Conversion/VerifToSV/verif-to-sv.mlir
+++ b/test/Conversion/VerifToSV/verif-to-sv.mlir
@@ -5,7 +5,7 @@ hw.module @HasBeenResetAsync(in %clock: i1, in %reset: i1, out out: i1) {
   %0 = verif.has_been_reset %clock, async %reset
   hw.output %0 : i1
 
-  // CHECK:      %hasBeenResetReg = sv.reg : !hw.inout<i1>
+  // CHECK:      %hasBeenResetReg = sv.var : !sv.var<i1>
 
   // CHECK-NEXT: sv.initial {
   // CHECK-NEXT:   sv.if %reset {
@@ -35,7 +35,7 @@ hw.module @HasBeenResetSync(in %clock: i1, in %reset: i1, out out: i1) {
   %0 = verif.has_been_reset %clock, sync %reset
   hw.output %0 : i1
 
-  // CHECK:      %hasBeenResetReg = sv.reg : !hw.inout<i1>
+  // CHECK:      %hasBeenResetReg = sv.var : !sv.var<i1>
 
   // CHECK-NEXT: sv.initial {
   // CHECK-NEXT:   sv.bpassign %hasBeenResetReg, %x_i1 : i1

--- a/test/Dialect/Arc/add-taps.mlir
+++ b/test/Dialect/Arc/add-taps.mlir
@@ -21,13 +21,13 @@ hw.module @ObserveWires() {
   // CHECK-NEXT: arc.tap [[RD:%.+]] {names = ["x"]} : i4
   // CHECK-NEXT: %x = sv.wire
   // CHECK-NEXT: [[RD]] = sv.read_inout %x
-  %x = sv.wire : !hw.inout<i4>
-  %0 = sv.read_inout %x : !hw.inout<i4>
+  %x = sv.wire : !sv.net<i4>
+  %0 = sv.read_inout %x : !sv.net<i4>
 
   // CHECK-NEXT: [[RD:%.+]] = sv.read_inout %y
   // CHECK-NEXT: arc.tap [[RD]] {names = ["y"]} : i4
   // CHECK-NEXT: %y = sv.wire
-  %y = sv.wire : !hw.inout<i4>
+  %y = sv.wire : !sv.net<i4>
 
   // CHECK-NEXT: hw.constant
   // CHECK-NEXT: arc.tap %c0_i4 {names = ["z"]} : i4

--- a/test/Dialect/Arc/resolve-xmr-ref-bind.mlir
+++ b/test/Dialect/Arc/resolve-xmr-ref-bind.mlir
@@ -7,8 +7,8 @@ module {
   // CHECK-SAME: in %xmr_capture_src_{{[0-9]+}} : i8
   // CHECK: hw.output %{{.+}} : i8
   hw.module @Payload(out o : i8) {
-    %x = sv.xmr.ref @bindPath : !hw.inout<i8>
-    %r = sv.read_inout %x : !hw.inout<i8>
+    %x = sv.xmr.ref @bindPath : !sv.var<i8>
+    %r = sv.read_inout %x : !sv.var<i8>
     hw.output %r : i8
   }
 

--- a/test/Dialect/Arc/resolve-xmr-ref-blackbox-zero.mlir
+++ b/test/Dialect/Arc/resolve-xmr-ref-blackbox-zero.mlir
@@ -11,8 +11,8 @@ module {
   hw.module @Top(out o : i1) {
     // expected-warning @below {{internal to blackbox. Lowering to 0.}}
     hw.instance "bb" sym @bb @BlackBox() -> (out_clk: i1)
-    %x = sv.xmr.ref @bbInternal : !hw.inout<i1>
-    %r = sv.read_inout %x : !hw.inout<i1>
+    %x = sv.xmr.ref @bbInternal : !sv.var<i1>
+    %r = sv.read_inout %x : !sv.var<i1>
     hw.output %r : i1
   }
 }

--- a/test/Dialect/Arc/resolve-xmr-ref-errors.mlir
+++ b/test/Dialect/Arc/resolve-xmr-ref-errors.mlir
@@ -19,7 +19,7 @@ module {
   hw.module @Top() {
     hw.instance "mid" sym @mid @Mid() -> ()
     // expected-error @below {{unsupported sv.xmr.ref use by 'sv.assign'; only read-only uses (sv.read_inout) are supported}}
-    %x = sv.xmr.ref @p : !hw.inout<i1>
+    %x = sv.xmr.ref @p : !sv.net<i1>
     %t = hw.constant true
     sv.assign %x, %t : i1
     hw.output
@@ -45,7 +45,7 @@ module {
   hw.module @Top() {
     hw.instance "mid" sym @mid @Mid() -> ()
     // expected-error @below {{sv.xmr.ref has no read uses; write/other uses are not supported yet}}
-    %x = sv.xmr.ref @p : !hw.inout<i1>
+    %x = sv.xmr.ref @p : !sv.var<i1>
     hw.output
   }
 }
@@ -60,8 +60,8 @@ module {
   hw.module @Top(out o : i1) {
     hw.instance "bb" sym @bb @BlackBox() -> (out_clk: i1)
     // expected-error @below {{unable to resolve XMR into internal blackbox symbol; rerun with --arc-resolve-xmr=lower-blackbox-internal-to-zero to force zero-lowering}}
-    %x = sv.xmr.ref @bbInternal : !hw.inout<i1>
-    %r = sv.read_inout %x : !hw.inout<i1>
+    %x = sv.xmr.ref @bbInternal : !sv.var<i1>
+    %r = sv.read_inout %x : !sv.var<i1>
     hw.output %r : i1
   }
 }
@@ -74,8 +74,8 @@ module {
 
   hw.module @Payload(out o : i8) {
     // expected-error @below {{cannot resolve XMR through conditionally guarded sv.bind; only unconditional sv.bind is supported}}
-    %x = sv.xmr.ref @bindPath : !hw.inout<i8>
-    %r = sv.read_inout %x : !hw.inout<i8>
+    %x = sv.xmr.ref @bindPath : !sv.var<i8>
+    %r = sv.read_inout %x : !sv.var<i8>
     hw.output %r : i8
   }
 
@@ -97,8 +97,8 @@ module {
 
   hw.module @Payload(out o : i8) {
     // expected-error @below {{payload module has non-bind instances; refusing to resolve bind-context XMR ambiguously}}
-    %x = sv.xmr.ref @bindPath : !hw.inout<i8>
-    %r = sv.read_inout %x : !hw.inout<i8>
+    %x = sv.xmr.ref @bindPath : !sv.var<i8>
+    %r = sv.read_inout %x : !sv.var<i8>
     hw.output %r : i8
   }
 

--- a/test/Dialect/Arc/resolve-xmr-ref.mlir
+++ b/test/Dialect/Arc/resolve-xmr-ref.mlir
@@ -57,14 +57,14 @@ module {
                  out out_ext_port : i1, out out_ext_sig : i1) {
     hw.instance "mid_inst" sym @mid_inst @Mid() -> ()
 
-    %0 = sv.xmr.ref @intSigPath : !hw.inout<i32>
-    %1 = sv.read_inout %0 : !hw.inout<i32>
-    %2 = sv.xmr.ref @intPortPath : !hw.inout<i32>
-    %3 = sv.read_inout %2 : !hw.inout<i32>
-    %4 = sv.xmr.ref @extPortPath : !hw.inout<i1>
-    %5 = sv.read_inout %4 : !hw.inout<i1>
-    %6 = sv.xmr.ref @extSigPath : !hw.inout<i1>
-    %7 = sv.read_inout %6 : !hw.inout<i1>
+    %0 = sv.xmr.ref @intSigPath : !sv.var<i32>
+    %1 = sv.read_inout %0 : !sv.var<i32>
+    %2 = sv.xmr.ref @intPortPath : !sv.var<i32>
+    %3 = sv.read_inout %2 : !sv.var<i32>
+    %4 = sv.xmr.ref @extPortPath : !sv.var<i1>
+    %5 = sv.read_inout %4 : !sv.var<i1>
+    %6 = sv.xmr.ref @extSigPath : !sv.var<i1>
+    %7 = sv.read_inout %6 : !sv.var<i1>
 
     // CHECK: hw.output %[[MID_OUT_SIG]], %[[MID_OUT_PORT]], %[[MID_OUT_CLK]], %[[MID_OUT_SEC]] : i32, i32, i1, i1
     hw.output %1, %3, %5, %7 : i32, i32, i1, i1
@@ -98,14 +98,14 @@ module {
     hw.instance "mid_inst_0" sym @mid_inst_0 @MidReuse() -> ()
     hw.instance "mid_inst_1" sym @mid_inst_1 @MidReuse() -> ()
 
-    %ra0 = sv.xmr.ref @reusePathA : !hw.inout<i8>
-    %rb0 = sv.xmr.ref @reusePathB : !hw.inout<i8>
-    %ra1 = sv.xmr.ref @reusePathA : !hw.inout<i8>
-    %rb1 = sv.xmr.ref @reusePathB : !hw.inout<i8>
-    %va0 = sv.read_inout %ra0 : !hw.inout<i8>
-    %vb0 = sv.read_inout %rb0 : !hw.inout<i8>
-    %va1 = sv.read_inout %ra1 : !hw.inout<i8>
-    %vb1 = sv.read_inout %rb1 : !hw.inout<i8>
+    %ra0 = sv.xmr.ref @reusePathA : !sv.var<i8>
+    %rb0 = sv.xmr.ref @reusePathB : !sv.var<i8>
+    %ra1 = sv.xmr.ref @reusePathA : !sv.var<i8>
+    %rb1 = sv.xmr.ref @reusePathB : !sv.var<i8>
+    %va0 = sv.read_inout %ra0 : !sv.var<i8>
+    %vb0 = sv.read_inout %rb0 : !sv.var<i8>
+    %va1 = sv.read_inout %ra1 : !sv.var<i8>
+    %vb1 = sv.read_inout %rb1 : !sv.var<i8>
     hw.output %va0, %vb0, %va1, %vb1 : i8, i8, i8, i8
   }
 
@@ -144,10 +144,10 @@ module {
   // CHECK: hw.output %[[MC0]], %[[MC1]] : i1, i4
   hw.module @TopCollision(out out_a : i1, out out_b : i4) {
     hw.instance "mid_inst" sym @mid_inst @MidCollision() -> ()
-    %ca = sv.xmr.ref @collisionA : !hw.inout<i1>
-    %cb = sv.xmr.ref @collisionB : !hw.inout<i4>
-    %va = sv.read_inout %ca : !hw.inout<i1>
-    %vb = sv.read_inout %cb : !hw.inout<i4>
+    %ca = sv.xmr.ref @collisionA : !sv.var<i1>
+    %cb = sv.xmr.ref @collisionB : !sv.var<i4>
+    %va = sv.read_inout %ca : !sv.var<i1>
+    %vb = sv.read_inout %cb : !sv.var<i4>
     hw.output %va, %vb : i1, i4
   }
 
@@ -184,10 +184,10 @@ module {
   // CHECK: hw.output %[[TSA]], %[[TSB]] : i1, i1
   hw.module @TopSameTypeCollision(out out_a : i1, out out_b : i1) {
     hw.instance "mid_inst" sym @mid_inst @MidSameTypeCollision() -> ()
-    %ca = sv.xmr.ref @sameTypeCollisionA : !hw.inout<i1>
-    %cb = sv.xmr.ref @sameTypeCollisionB : !hw.inout<i1>
-    %va = sv.read_inout %ca : !hw.inout<i1>
-    %vb = sv.read_inout %cb : !hw.inout<i1>
+    %ca = sv.xmr.ref @sameTypeCollisionA : !sv.var<i1>
+    %cb = sv.xmr.ref @sameTypeCollisionB : !sv.var<i1>
+    %va = sv.read_inout %ca : !sv.var<i1>
+    %vb = sv.read_inout %cb : !sv.var<i1>
     hw.output %va, %vb : i1, i1
   }
 }

--- a/test/Dialect/Arc/strip-sv.mlir
+++ b/test/Dialect/Arc/strip-sv.mlir
@@ -13,9 +13,9 @@ sv.ifdef  @RANDOMIZE_REG_INIT {
 hw.module @Foo(in %clock: !seq.clock, in %a: i4, out z: i4) {
   // CHECK-NEXT: [[REG:%.+]] = seq.compreg %a, %clock
   %0 = seq.firreg %a clock %clock : i4
-  %1 = sv.wire : !hw.inout<i4>
+  %1 = sv.wire : !sv.net<i4>
   sv.assign %1, %0 : i4
-  %2 = sv.read_inout %1 : !hw.inout<i4>
+  %2 = sv.read_inout %1 : !sv.net<i4>
   // CHECK-NEXT: hw.output [[REG]]
   hw.output %2 : i4
 }

--- a/test/Dialect/ESI/manifest.mlir
+++ b/test/Dialect/ESI/manifest.mlir
@@ -135,12 +135,11 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1) {
 
 // HW-LABEL:    hw.module @__ESI_Manifest_ROM(in %clk : !seq.clock, in %address : i29, out data : i64) {
 // HW:            [[R0:%.+]] = hw.aggregate_constant
-// HW:            [[R1:%.+]] = sv.reg : !hw.inout<uarray<{{.*}}xi64>>
-// HW:            sv.assign [[R1]], [[R0]] : !hw.uarray<{{.*}}xi64>
+// HW:            [[R1:%.+]] = sv.var init [[R0]] : !sv.var<!hw.uarray<{{.*}}xi64>>
 // HW:            [[R2:%.+]] = comb.extract %address from 0 : (i29) -> i8
 // HW:            [[R3:%.+]] = seq.compreg  [[R2]], %clk : i8
-// HW:            [[R4:%.+]] = sv.array_index_inout [[R1]][[[R3]]] : !hw.inout<uarray<{{.*}}xi64>>, i8
-// HW:            [[R5:%.+]] = sv.read_inout [[R4]] : !hw.inout<i64>
+// HW:            [[R4:%.+]] = sv.array_index_inout [[R1]][[[R3]]] : !sv.var<!hw.uarray<{{.*}}xi64>>, i8
+// HW:            [[R5:%.+]] = sv.read_inout [[R4]] : !sv.var<i64>
 // HW:            [[R6:%.+]] = seq.compreg  [[R5]], %clk : i64
 // HW:            hw.output [[R6]] : i64
 

--- a/test/Dialect/ESI/services.mlir
+++ b/test/Dialect/ESI/services.mlir
@@ -123,7 +123,7 @@ esi.pure_module @LoopbackCosimPure {
 
 // CONN-LABEL: esi.mem.ram @MemA i64 x 20
 // CONN-LABEL: hw.module @MemoryAccess1(in %clk : !seq.clock, in %rst : i1, in %write : !esi.channel<!hw.struct<address: ui5, data: i64>>, in %readAddress : !esi.channel<ui5>, out readData : !esi.channel<i64>, out writeDone : !esi.channel<i0>) {
-// CONN:         %MemA = sv.reg  : !hw.inout<uarray<20xi64>>
+// CONN:         %MemA = sv.var  : !sv.var<!hw.uarray<20xi64>>
 // CONN:         %chanOutput, %ready = esi.wrap.vr %c0_i0, %write_done : i0
 // CONN:         %rawOutput, %valid = esi.unwrap.vr %write, %ready : !hw.struct<address: ui5, data: i64>
 // CONN:         %address = hw.struct_extract %rawOutput["address"] : !hw.struct<address: ui5, data: i64>
@@ -133,13 +133,13 @@ esi.pure_module @LoopbackCosimPure {
 // CONN:         %chanOutput_0, %ready_1 = esi.wrap.vr %[[MEMREAD:.*]], %valid_3 : i64
 // CONN:         %rawOutput_2, %valid_3 = esi.unwrap.vr %readAddress, %ready_1 : ui5
 // CONN:         %[[ADDR:.*]] = hw.bitcast %rawOutput_2 : (ui5) -> i5
-// CONN:         %[[MEMREADIO:.*]] = sv.array_index_inout %MemA[%[[ADDR]]] : !hw.inout<uarray<20xi64>>, i5
-// CONN:         %[[MEMREAD]] = sv.read_inout %[[MEMREADIO]] : !hw.inout<i64>
+// CONN:         %[[MEMREADIO:.*]] = sv.array_index_inout %MemA[%[[ADDR]]] : !sv.var<!hw.uarray<20xi64>>, i5
+// CONN:         %[[MEMREAD]] = sv.read_inout %[[MEMREADIO]] : !sv.var<i64>
 // CONN:         %[[CLOCK:.+]] = seq.from_clock %clk
 // CONN:         sv.alwaysff(posedge %[[CLOCK]]) {
 // CONN:           sv.if %[[ANDVR]] {
 // CONN:             %[[ADDR:.*]] = hw.bitcast %address : (ui5) -> i5
-// CONN:             %[[ARRIDX:.*]] = sv.array_index_inout %MemA[%[[ADDR]]] : !hw.inout<uarray<20xi64>>, i5
+// CONN:             %[[ARRIDX:.*]] = sv.array_index_inout %MemA[%[[ADDR]]] : !sv.var<!hw.uarray<20xi64>>, i5
 // CONN:             sv.passign %[[ARRIDX]], %data : i64
 // CONN:           }
 // CONN:         }(syncreset : posedge %rst) {
@@ -162,7 +162,7 @@ hw.module @MemoryAccess1(in %clk : !seq.clock, in %rst : i1, in %write : !esi.ch
 }
 
 // CONN-LABEL: hw.module @MemoryAccess2Read(in %clk : !seq.clock, in %rst : i1, in %write : !esi.channel<!hw.struct<address: ui5, data: i64>>, in %readAddress : !esi.channel<ui5>, in %readAddress2 : !esi.channel<ui5>, out readData : !esi.channel<i64>, out readData2 : !esi.channel<i64>, out writeDone : !esi.channel<i0>) {
-// CONN:         %MemA = sv.reg : !hw.inout<uarray<20xi64>>
+// CONN:         %MemA = sv.var : !sv.var<!hw.uarray<20xi64>>
 // CONN:         hw.output %chanOutput_0, %chanOutput_4, %chanOutput : !esi.channel<i64>, !esi.channel<i64>, !esi.channel<i0>
 
 hw.module @MemoryAccess2Read(in %clk: !seq.clock, in %rst: i1, in %write: !esi.channel<!write>, in %readAddress: !esi.channel<ui5>, in %readAddress2: !esi.channel<ui5>, out readData: !esi.channel<i64>, out readData2: !esi.channel<i64>, out writeDone: !esi.channel<i0>) {

--- a/test/Dialect/FIRRTL/SFCTests/directories.fir
+++ b/test/Dialect/FIRRTL/SFCTests/directories.fir
@@ -119,18 +119,18 @@ circuit TestHarness:
 
 
 ; CHECK:            module Foo(
-; MEMTOREG_DUT-NOT:   reg [7:0] foo_combmem
-; MEMTOREG_NODUT:     reg [7:0] foo_combmem
+; MEMTOREG_DUT-NOT:   logic [7:0] foo_combmem
+; MEMTOREG_NODUT:     logic [7:0] foo_combmem
 ; CHECK:            endmodule
 
 ; CHECK:            module Bar(
-; MEMTOREG_DUT:       reg [7:0] bar_combmem
-; MEMTOREG_NODUT:     reg [7:0] bar_combmem
+; MEMTOREG_DUT:       logic [7:0] bar_combmem
+; MEMTOREG_NODUT:     logic [7:0] bar_combmem
 ; CHECK:            endmodule
 
 ; CHECK:            module Baz(
-; MEMTOREG_DUT:       reg [7:0] baz_combmem
-; MEMTOREG_NODUT:     reg [7:0] baz_combmem
+; MEMTOREG_DUT:       logic [7:0] baz_combmem
+; MEMTOREG_NODUT:     logic [7:0] baz_combmem
 ; CHECK:            endmodule
 
 ; SITEST_DUT:       FILE "testbench.sitest.json"

--- a/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
+++ b/test/Dialect/FIRRTL/SFCTests/load-memory-from-file.fir
@@ -20,7 +20,7 @@ circuit Foo :
       connect MPORT, write.data
 
       ; CHECK:             module [[memoryModule:[a-zA-Z0-9_]+]](
-      ; CHECK:               reg [7:0] [[memory:[a-zA-Z0-9_]+]][0:31];
+      ; CHECK:               logic [7:0] [[memory:[a-zA-Z0-9_]+]][0:31];
 
       ; INIT_NONE-NOT:       readmem
 

--- a/test/Dialect/HW/basic.mlir
+++ b/test/Dialect/HW/basic.mlir
@@ -60,22 +60,22 @@ hw.module @test1(in %arg0: i3, in %arg1: i1, in %arg2: !hw.array<1000xi8>, out r
   // CHECK-NEXT: comb.icmp uge [[RES9]], [[RES10]] : i19
   %ugeq = comb.icmp uge %small1, %small2 : i19
 
-  // CHECK-NEXT: %w = sv.wire : !hw.inout<i4>
-  %w = sv.wire : !hw.inout<i4>
+  // CHECK-NEXT: %w = sv.wire : !sv.net<i4>
+  %w = sv.wire : !sv.net<i4>
 
-  // CHECK-NEXT: %after1 = sv.wire : !hw.inout<i4>
-  %before1 = sv.wire name "after1" : !hw.inout<i4>
+  // CHECK-NEXT: %after1 = sv.wire : !sv.net<i4>
+  %before1 = sv.wire name "after1" : !sv.net<i4>
 
-  // CHECK-NEXT: sv.read_inout %after1 : !hw.inout<i4>
-  %read_before1 = sv.read_inout %before1 : !hw.inout<i4>
+  // CHECK-NEXT: sv.read_inout %after1 : !sv.net<i4>
+  %read_before1 = sv.read_inout %before1 : !sv.net<i4>
 
-  // CHECK-NEXT: %after2_conflict = sv.wire : !hw.inout<i4>
-  // CHECK-NEXT: %after2_conflict_0 = sv.wire name "after2_conflict" : !hw.inout<i4>
-  %before2_0 = sv.wire name "after2_conflict" : !hw.inout<i4>
-  %before2_1 = sv.wire name "after2_conflict" : !hw.inout<i4>
+  // CHECK-NEXT: %after2_conflict = sv.wire : !sv.net<i4>
+  // CHECK-NEXT: %after2_conflict_0 = sv.wire name "after2_conflict" : !sv.net<i4>
+  %before2_0 = sv.wire name "after2_conflict" : !sv.net<i4>
+  %before2_1 = sv.wire name "after2_conflict" : !sv.net<i4>
 
-  // CHECK-NEXT: %after3 = sv.wire {someAttr = "foo"} : !hw.inout<i4>
-  %before3 = sv.wire name "after3" {someAttr = "foo"} : !hw.inout<i4>
+  // CHECK-NEXT: %after3 = sv.wire {someAttr = "foo"} : !sv.net<i4>
+  %before3 = sv.wire name "after3" {someAttr = "foo"} : !sv.net<i4>
 
   // CHECK-NEXT: %w2 = hw.wire [[RES2]] : i7
   %w2 = hw.wire %d : i7
@@ -163,8 +163,8 @@ hw.module @UnionOps(in %a: !hw.union<foo: i1, bar: i3>, out x: i3, out z: !hw.un
 // https://github.com/llvm/circt/issues/863
 // CHECK-LABEL: hw.module @signed_arrays
 hw.module @signed_arrays(in %arg0: si8, out out: !hw.array<2xsi8>) {
-  // CHECK-NEXT:  %wireArray = sv.wire  : !hw.inout<array<2xsi8>>
-  %wireArray = sv.wire : !hw.inout<!hw.array<2xsi8>>
+  // CHECK-NEXT:  %wireArray = sv.wire  : !sv.net<!hw.array<2xsi8>>
+  %wireArray = sv.wire : !sv.net<!hw.array<2xsi8>>
 
   // CHECK-NEXT: %0 = hw.array_create %arg0, %arg0 : si8
   %0 = hw.array_create %arg0, %arg0 : si8
@@ -172,7 +172,7 @@ hw.module @signed_arrays(in %arg0: si8, out out: !hw.array<2xsi8>) {
   // CHECK-NEXT: sv.assign %wireArray, %0 : !hw.array<2xsi8>
   sv.assign %wireArray, %0 : !hw.array<2xsi8>
 
-  %result = sv.read_inout %wireArray : !hw.inout<!hw.array<2xsi8>>
+  %result = sv.read_inout %wireArray : !sv.net<!hw.array<2xsi8>>
   hw.output %result : !hw.array<2xsi8>
 }
 
@@ -258,4 +258,14 @@ hw.module @aggregate_const(out o : !hw.array<1x!seq.clock>) {
   // CHECK-NEXT: hw.aggregate_constant [#seq<clock_constant high> : !seq.clock] : !hw.array<1x!seq.clock>
   %0 = hw.aggregate_constant [#seq<clock_constant high> : !seq.clock] : !hw.array<1x!seq.clock>
   hw.output %0 : !hw.array<1x!seq.clock>
+}
+
+// CHECK-LABEL: hw.module @VarOp
+hw.module @VarOp() {
+  // CHECK: %0 = hw.var : !hw.inout<i42>
+  %0 = hw.var : !hw.inout<i42>
+  // CHECK: %1 = hw.var sym @mySym : !hw.inout<i42>
+  %1 = hw.var sym @mySym : !hw.inout<i42>
+  // CHECK: %myVar = hw.var : !hw.inout<i42>
+  %2 = hw.var name "myVar" : !hw.inout<i42>
 }

--- a/test/Dialect/HW/canonicalization.mlir
+++ b/test/Dialect/HW/canonicalization.mlir
@@ -983,15 +983,15 @@ hw.module @replicate_and_one_bit(in %bit: i1, out a: i65, out b: i8, out c: i8) 
 // CHECK-LABEL: hw.module @wire0()
 // CHECK-NEXT:    hw.output
 hw.module @wire0() {
-  %0 = sv.wire : !hw.inout<i1>
+  %0 = sv.wire : !sv.net<i1>
   hw.output
 }
 
 // CHECK-LABEL: hw.module @wire1()
 // CHECK-NEXT:    hw.output
 hw.module @wire1() {
-  %0 = sv.wire : !hw.inout<i1>
-  %1 = sv.read_inout %0 : !hw.inout<i1>
+  %0 = sv.wire : !sv.net<i1>
+  %1 = sv.read_inout %0 : !sv.net<i1>
   hw.output
 }
 
@@ -999,7 +999,7 @@ hw.module @wire1() {
 // CHECK-NEXT:    hw.output
 hw.module @wire2() {
   %c = hw.constant 1 : i1
-  %0 = sv.wire : !hw.inout<i1>
+  %0 = sv.wire : !sv.net<i1>
   sv.assign %0, %c : i1
   hw.output
 }
@@ -1008,22 +1008,22 @@ hw.module @wire2() {
 // CHECK-NEXT:    hw.output
 hw.module @wire3() {
   %c = hw.constant 1 : i1
-  %0 = sv.wire : !hw.inout<i1>
-  %1 = sv.read_inout %0 : !hw.inout<i1>
+  %0 = sv.wire : !sv.net<i1>
+  %1 = sv.read_inout %0 : !sv.net<i1>
   sv.assign %0, %c :i1
   hw.output
 }
 
 // CHECK-LABEL: hw.module @wire4
 // CHECK-NEXT:   %true = hw.constant true
-// CHECK-NEXT:   %0 = sv.wire sym @symName : !hw.inout<i1>
-// CHECK-NEXT:   %1 = sv.read_inout %0 : !hw.inout<i1>
+// CHECK-NEXT:   %0 = sv.wire sym @symName : !sv.net<i1>
+// CHECK-NEXT:   %1 = sv.read_inout %0 : !sv.net<i1>
 // CHECK-NEXT:   sv.assign %0, %true : i1
 // CHECK-NEXT:   hw.output %1 : i1
 hw.module @wire4(out result : i1) {
   %true = hw.constant true
-  %0 = sv.wire sym @symName : !hw.inout<i1>
-  %1 = sv.read_inout %0 : !hw.inout<i1>
+  %0 = sv.wire sym @symName : !sv.net<i1>
+  %1 = sv.read_inout %0 : !sv.net<i1>
   sv.assign %0, %true : i1
   hw.output %1 : i1
 }
@@ -1033,17 +1033,17 @@ hw.module @wire4(out result : i1) {
 // CHECK-NEXT:   hw.output %true : i1
 hw.module @wire4_1(out result : i1) {
   %true = hw.constant true
-  %0 = sv.wire : !hw.inout<i1>
-  %1 = sv.read_inout %0 : !hw.inout<i1>
+  %0 = sv.wire : !sv.net<i1>
+  %1 = sv.read_inout %0 : !sv.net<i1>
   sv.assign %0, %true : i1
   hw.output %1 : i1
 }
 
 // CHECK-LABEL: hw.module @wire5()
-// CHECK-NEXT:   %wire_with_name = sv.wire sym @wire_with_name : !hw.inout<i1>
+// CHECK-NEXT:   %wire_with_name = sv.wire sym @wire_with_name : !sv.net<i1>
 // CHECK-NEXT:   hw.output
 hw.module @wire5() {
-  %wire_with_name = sv.wire sym @wire_with_name : !hw.inout<i1>
+  %wire_with_name = sv.wire sym @wire_with_name : !sv.net<i1>
   hw.output
 }
 
@@ -1340,8 +1340,8 @@ hw.module @Driver(out x: !hw.typealias<@__foo::@RecordTy, !hw.struct<a: i4, b: u
 
 hw.module @instance_ooo(in %arg0 : i2, in %arg1 : i2, in %arg2 : i3, out out0: i8) {
   %false = hw.constant false
-    %.in.wire = sv.wire  : !hw.inout<i1>
-    %0 = sv.read_inout %.in.wire : !hw.inout<i1>
+    %.in.wire = sv.wire  : !sv.net<i1>
+    %0 = sv.read_inout %.in.wire : !sv.net<i1>
     %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %0: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
     %1 = comb.concat %false, %arg0 : i1, i2
     %2 = comb.concat %false, %arg0 : i1, i2
@@ -1361,19 +1361,19 @@ hw.module.extern @MyParameterizedExtModule(in %in: i1, out out: i8) attributes {
 hw.module.extern @Simple(in %in1: i4, in %in2: i2, in %in3: i8)
 hw.module @TestInstance(in %u2: i2, in %s8: i8, in %clock: i1, in %reset: i1) {
   %c0_i2 = hw.constant 0 : i2
-  %.in1.wire = sv.wire  : !hw.inout<i4>
-  %0 = sv.read_inout %.in1.wire : !hw.inout<i4>
-  %.in2.wire = sv.wire  : !hw.inout<i2>
-  %1 = sv.read_inout %.in2.wire : !hw.inout<i2>
-  %.in3.wire = sv.wire  : !hw.inout<i8>
-  %2 = sv.read_inout %.in3.wire : !hw.inout<i8>
+  %.in1.wire = sv.wire  : !sv.net<i4>
+  %0 = sv.read_inout %.in1.wire : !sv.net<i4>
+  %.in2.wire = sv.wire  : !sv.net<i2>
+  %1 = sv.read_inout %.in2.wire : !sv.net<i2>
+  %.in3.wire = sv.wire  : !sv.net<i8>
+  %2 = sv.read_inout %.in3.wire : !sv.net<i8>
   hw.instance "xyz" @Simple(in1: %0: i4, in2: %1: i2, in3: %2: i8) -> ()
   %3 = comb.concat %c0_i2, %u2 : i2, i2
   sv.assign %.in1.wire, %3 : i4
   sv.assign %.in2.wire, %u2 : i2
   sv.assign %.in3.wire, %s8 : i8
-  %.in.wire = sv.wire  : !hw.inout<i1>
-  %4 = sv.read_inout %.in.wire : !hw.inout<i1>
+  %.in.wire = sv.wire  : !sv.net<i1>
+  %4 = sv.read_inout %.in.wire : !sv.net<i1>
   %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %4: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
   sv.assign %.in.wire, %reset : i1
   hw.output
@@ -1385,8 +1385,8 @@ hw.module @TestInstance(in %u2: i2, in %s8: i8, in %clock: i1, in %reset: i1) {
 // CHECK-NEXT:    hw.output
 // CHECK-NEXT:  }
 hw.module @instance_cyclic(in %arg0 : i2, in %arg1 : i2) {
-  %.in.wire = sv.wire  : !hw.inout<i1>
-  %0 = sv.read_inout %.in.wire : !hw.inout<i1>
+  %.in.wire = sv.wire  : !sv.net<i1>
+  %0 = sv.read_inout %.in.wire : !sv.net<i1>
   %myext.out = hw.instance "myext" @MyParameterizedExtModule(in: %0: i1) -> (out: i8)  {oldParameters = {DEFAULT = 0 : i64, DEPTH = 3.242000e+01 : f64, FORMAT = "xyz_timeout=%d\0A", WIDTH = 32 : i8}}
   %1 = comb.extract %myext.out from 2 : (i8) -> i1
   sv.assign %.in.wire, %1 : i1
@@ -1399,8 +1399,8 @@ hw.module @instance_cyclic(in %arg0 : i2, in %arg1 : i2) {
 // CHECK-NEXT:    hw.output %myinst.outa : i4
 // CHECK-NEXT:  }
 hw.module @ZeroWidthInstance(in %iA: i4, out oA: i4) {
-  %.inA.wire = sv.wire  : !hw.inout<i4>
-  %0 = sv.read_inout %.inA.wire : !hw.inout<i4>
+  %.inA.wire = sv.wire  : !sv.net<i4>
+  %0 = sv.read_inout %.inA.wire : !sv.net<i4>
   %myinst.outa = hw.instance "myinst" @ZeroWidthPorts(inA: %0: i4) -> (outa: i4)
   sv.assign %.inA.wire, %iA : i4
   hw.output %myinst.outa : i4
@@ -1417,65 +1417,65 @@ hw.module @unintializedWire(in %clock1: i1, in %clock2: i1, in %inpred: i1, in %
   %c0_i3 = hw.constant 0 : i3
   %true = hw.constant true
   %false = hw.constant false
-  %.read.clk.wire = sv.wire  : !hw.inout<i1>
-  %0 = sv.read_inout %.read.clk.wire : !hw.inout<i1>
-  %.read.en.wire = sv.wire  : !hw.inout<i1>
-  %1 = sv.read_inout %.read.en.wire : !hw.inout<i1>
-  %.read.addr.wire = sv.wire  : !hw.inout<i4>
-  %2 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
-  %.rw.clk.wire = sv.wire  : !hw.inout<i1>
-  %3 = sv.read_inout %.rw.clk.wire : !hw.inout<i1>
-  %.rw.en.wire = sv.wire  : !hw.inout<i1>
-  %4 = sv.read_inout %.rw.en.wire : !hw.inout<i1>
-  %.rw.addr.wire = sv.wire  : !hw.inout<i4>
-  %5 = sv.read_inout %.rw.addr.wire : !hw.inout<i4>
-  %.rw.wmode.wire = sv.wire  : !hw.inout<i1>
-  %6 = sv.read_inout %.rw.wmode.wire : !hw.inout<i1>
-  %.rw.wmask.wire = sv.wire  : !hw.inout<i1>
-  %7 = sv.read_inout %.rw.wmask.wire : !hw.inout<i1>
-  %.rw.wdata.wire = sv.wire : !hw.inout<i42>
-  %8 = sv.read_inout %.rw.wdata.wire : !hw.inout<i42>
-  %.write.clk.wire = sv.wire  : !hw.inout<i1>
-  %9 = sv.read_inout %.write.clk.wire : !hw.inout<i1>
-  %.write.en.wire = sv.wire  : !hw.inout<i1>
-  %10 = sv.read_inout %.write.en.wire : !hw.inout<i1>
-  %.write.addr.wire = sv.wire  : !hw.inout<i4>
-  %11 = sv.read_inout %.write.addr.wire : !hw.inout<i4>
-  %.write.mask.wire = sv.wire  : !hw.inout<i1>
-  %12 = sv.read_inout %.write.mask.wire : !hw.inout<i1>
-  %.write.data.wire = sv.wire  : !hw.inout<i42>
-  %13 = sv.read_inout %.write.data.wire : !hw.inout<i42>
+  %.read.clk.wire = sv.wire  : !sv.net<i1>
+  %0 = sv.read_inout %.read.clk.wire : !sv.net<i1>
+  %.read.en.wire = sv.wire  : !sv.net<i1>
+  %1 = sv.read_inout %.read.en.wire : !sv.net<i1>
+  %.read.addr.wire = sv.wire  : !sv.net<i4>
+  %2 = sv.read_inout %.read.addr.wire : !sv.net<i4>
+  %.rw.clk.wire = sv.wire  : !sv.net<i1>
+  %3 = sv.read_inout %.rw.clk.wire : !sv.net<i1>
+  %.rw.en.wire = sv.wire  : !sv.net<i1>
+  %4 = sv.read_inout %.rw.en.wire : !sv.net<i1>
+  %.rw.addr.wire = sv.wire  : !sv.net<i4>
+  %5 = sv.read_inout %.rw.addr.wire : !sv.net<i4>
+  %.rw.wmode.wire = sv.wire  : !sv.net<i1>
+  %6 = sv.read_inout %.rw.wmode.wire : !sv.net<i1>
+  %.rw.wmask.wire = sv.wire  : !sv.net<i1>
+  %7 = sv.read_inout %.rw.wmask.wire : !sv.net<i1>
+  %.rw.wdata.wire = sv.wire : !sv.net<i42>
+  %8 = sv.read_inout %.rw.wdata.wire : !sv.net<i42>
+  %.write.clk.wire = sv.wire  : !sv.net<i1>
+  %9 = sv.read_inout %.write.clk.wire : !sv.net<i1>
+  %.write.en.wire = sv.wire  : !sv.net<i1>
+  %10 = sv.read_inout %.write.en.wire : !sv.net<i1>
+  %.write.addr.wire = sv.wire  : !sv.net<i4>
+  %11 = sv.read_inout %.write.addr.wire : !sv.net<i4>
+  %.write.mask.wire = sv.wire  : !sv.net<i1>
+  %12 = sv.read_inout %.write.mask.wire : !sv.net<i1>
+  %.write.data.wire = sv.wire  : !sv.net<i42>
+  %13 = sv.read_inout %.write.data.wire : !sv.net<i42>
   %_M.ro_data_0, %_M.rw_rdata_0 = hw.instance "_M" @FIRRTLMem_1_1_1_42_12_0_1_0
      (ro_clock_0: %0: i1, ro_en_0: %1: i1, ro_addr_0: %2: i4) -> (ro_data_0: i42, rw_data_0: i42)
 
-  %14 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
+  %14 = sv.read_inout %.read.addr.wire : !sv.net<i4>
   %c0_i4 = hw.constant 0 : i4
   sv.assign %.read.addr.wire, %c0_i4 : i4
-  %15 = sv.read_inout %.read.en.wire : !hw.inout<i1>
+  %15 = sv.read_inout %.read.en.wire : !sv.net<i1>
   sv.assign %.read.en.wire, %true : i1
-  %16 = sv.read_inout %.read.clk.wire : !hw.inout<i1>
+  %16 = sv.read_inout %.read.clk.wire : !sv.net<i1>
   sv.assign %.read.clk.wire, %clock1 : i1
-  %17 = sv.read_inout %.rw.addr.wire : !hw.inout<i4>
+  %17 = sv.read_inout %.rw.addr.wire : !sv.net<i4>
   %c0_i4_0 = hw.constant 0 : i4
   sv.assign %.rw.addr.wire, %c0_i4_0 : i4
-  %18 = sv.read_inout %.rw.en.wire : !hw.inout<i1>
+  %18 = sv.read_inout %.rw.en.wire : !sv.net<i1>
   sv.assign %.rw.en.wire, %true : i1
-  %19 = sv.read_inout %.rw.clk.wire : !hw.inout<i1>
+  %19 = sv.read_inout %.rw.clk.wire : !sv.net<i1>
   sv.assign %.rw.clk.wire, %clock1 : i1
-  %20 = sv.read_inout %.rw.wmask.wire : !hw.inout<i1>
+  %20 = sv.read_inout %.rw.wmask.wire : !sv.net<i1>
   sv.assign %.rw.wmask.wire, %true : i1
-  %21 = sv.read_inout %.rw.wmode.wire : !hw.inout<i1>
+  %21 = sv.read_inout %.rw.wmode.wire : !sv.net<i1>
   sv.assign %.rw.wmode.wire, %true : i1
-  %22 = sv.read_inout %.write.addr.wire : !hw.inout<i4>
+  %22 = sv.read_inout %.write.addr.wire : !sv.net<i4>
   %c0_i4_1 = hw.constant 0 : i4
   sv.assign %.write.addr.wire, %c0_i4_1 : i4
-  %23 = sv.read_inout %.write.en.wire : !hw.inout<i1>
+  %23 = sv.read_inout %.write.en.wire : !sv.net<i1>
   sv.assign %.write.en.wire, %inpred : i1
-  %24 = sv.read_inout %.write.clk.wire : !hw.inout<i1>
+  %24 = sv.read_inout %.write.clk.wire : !sv.net<i1>
   sv.assign %.write.clk.wire, %clock2 : i1
-  %25 = sv.read_inout %.write.data.wire : !hw.inout<i42>
+  %25 = sv.read_inout %.write.data.wire : !sv.net<i42>
   sv.assign %.write.data.wire, %indata : i42
-  %26 = sv.read_inout %.write.mask.wire : !hw.inout<i1>
+  %26 = sv.read_inout %.write.mask.wire : !sv.net<i1>
   sv.assign %.write.mask.wire, %true : i1
   hw.output %_M.ro_data_0, %_M.rw_rdata_0 : i42, i42
 }
@@ -1484,10 +1484,10 @@ hw.module @unintializedWire(in %clock1: i1, in %clock2: i1, in %inpred: i1, in %
 hw.module @uninitializedWireAggregate(out result1: !hw.struct<a: i1, b: i1>,
                                       out result2: !hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>)
 {
-  %0 = sv.wire : !hw.inout<!hw.struct<a: i1, b: i1>>
-  %1 = sv.read_inout %0 : !hw.inout<!hw.struct<a: i1, b: i1>>
-  %2 = sv.wire : !hw.inout<!hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>>
-  %3 = sv.read_inout %2 :  !hw.inout<!hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>>
+  %0 = sv.wire : !sv.net<!hw.struct<a: i1, b: i1>>
+  %1 = sv.read_inout %0 : !sv.net<!hw.struct<a: i1, b: i1>>
+  %2 = sv.wire : !sv.net<!hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>>
+  %3 = sv.read_inout %2 :  !sv.net<!hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>>
 
   hw.output %1, %3 : !hw.struct<a: i1, b: i1>, !hw.struct<a: i1, b: !hw.array<10x!hw.struct<a: i1, b: i1>>>
   // CHECK-NEXT: %[[Z1:.*]] = sv.constantZ : !hw.struct<a: i1, b: i1>
@@ -1506,38 +1506,38 @@ hw.module @IncompleteRead(in %clock1: i1) {
   %c0_i3 = hw.constant 0 : i3
   %true = hw.constant true
   %false = hw.constant false
-  %.read.clk.wire = sv.wire  : !hw.inout<i1>
-  %0 = sv.read_inout %.read.clk.wire : !hw.inout<i1>
-  %.read.en.wire = sv.wire  : !hw.inout<i1>
-  %1 = sv.read_inout %.read.en.wire : !hw.inout<i1>
-  %.read.addr.wire = sv.wire  : !hw.inout<i4>
-  %2 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
+  %.read.clk.wire = sv.wire  : !sv.net<i1>
+  %0 = sv.read_inout %.read.clk.wire : !sv.net<i1>
+  %.read.en.wire = sv.wire  : !sv.net<i1>
+  %1 = sv.read_inout %.read.en.wire : !sv.net<i1>
+  %.read.addr.wire = sv.wire  : !sv.net<i4>
+  %2 = sv.read_inout %.read.addr.wire : !sv.net<i4>
   %_M.ro_data_0 = hw.instance "_M" @FIRRTLMem_1_0_0_42_12_0_1_0(ro_clock_0: %0: i1, ro_en_0: %1: i1, ro_addr_0: %2: i4) -> (ro_data_0: i42)
-  %3 = sv.read_inout %.read.addr.wire : !hw.inout<i4>
+  %3 = sv.read_inout %.read.addr.wire : !sv.net<i4>
   %c0_i4 = hw.constant 0 : i4
   sv.assign %.read.addr.wire, %c0_i4 : i4
-  %4 = sv.read_inout %.read.en.wire : !hw.inout<i1>
+  %4 = sv.read_inout %.read.en.wire : !sv.net<i1>
   sv.assign %.read.en.wire, %true : i1
-  %5 = sv.read_inout %.read.clk.wire : !hw.inout<i1>
+  %5 = sv.read_inout %.read.clk.wire : !sv.net<i1>
   sv.assign %.read.clk.wire, %clock1 : i1
   hw.output
 }
 
 // CHECK-LABEL:  hw.module @foo() {
-// CHECK-NEXT:    %io_cpu_flush.wire = sv.wire sym @io_cpu_flush.wire  : !hw.inout<i1>
+// CHECK-NEXT:    %io_cpu_flush.wire = sv.wire sym @io_cpu_flush.wire  : !sv.net<i1>
 // CHECK-NEXT:    hw.instance "fetch" @bar(io_cpu_flush: %0: i1) -> ()
 // CHECK-NEXT:    %0 = sv.read_inout %io_cpu_flush.wire {sv.namehint = ".io_cpu_flush.wire"}
 // CHECK-NEXT:    hw.output
 hw.module.extern @bar(in %io_cpu_flush: i1)
 hw.module @foo() {
-  %io_cpu_flush.wire = sv.wire sym @io_cpu_flush.wire  : !hw.inout<i1>
-  %.io_cpu_flush.wire = sv.wire  : !hw.inout<i1>
-  %0 = sv.read_inout %.io_cpu_flush.wire : !hw.inout<i1>
+  %io_cpu_flush.wire = sv.wire sym @io_cpu_flush.wire  : !sv.net<i1>
+  %.io_cpu_flush.wire = sv.wire  : !sv.net<i1>
+  %0 = sv.read_inout %.io_cpu_flush.wire : !sv.net<i1>
   hw.instance "fetch" @bar(io_cpu_flush: %0: i1) -> ()
-  %1 = sv.read_inout %io_cpu_flush.wire : !hw.inout<i1>
+  %1 = sv.read_inout %io_cpu_flush.wire : !sv.net<i1>
   sv.assign %.io_cpu_flush.wire, %1 : i1
-  %2 = sv.read_inout %io_cpu_flush.wire : !hw.inout<i1>
-  %hits_1_7 = sv.wire  : !hw.inout<i1>
+  %2 = sv.read_inout %io_cpu_flush.wire : !sv.net<i1>
+  %hits_1_7 = sv.wire  : !sv.net<i1>
   sv.assign %hits_1_7, %2 : i1
   hw.output
 }
@@ -1548,18 +1548,18 @@ hw.module @foo() {
 // CHECK-NEXT:  }
 hw.module.extern @FIRRTLMem_1_0_0_32_1_0_1_1(in %x: i1, in %y: i1, in %z: i1, out "": i32)
 hw.module @MemDepth1(in %clock: i1, in %en: i1, in %addr: i1, out data: i32) {
-  %.load0.clk.wire = sv.wire  : !hw.inout<i1>
-  %0 = sv.read_inout %.load0.clk.wire : !hw.inout<i1>
-  %.load0.en.wire = sv.wire  : !hw.inout<i1>
-  %1 = sv.read_inout %.load0.en.wire : !hw.inout<i1>
-  %.load0.addr.wire = sv.wire  : !hw.inout<i1>
-  %2 = sv.read_inout %.load0.addr.wire : !hw.inout<i1>
+  %.load0.clk.wire = sv.wire  : !sv.net<i1>
+  %0 = sv.read_inout %.load0.clk.wire : !sv.net<i1>
+  %.load0.en.wire = sv.wire  : !sv.net<i1>
+  %1 = sv.read_inout %.load0.en.wire : !sv.net<i1>
+  %.load0.addr.wire = sv.wire  : !sv.net<i1>
+  %2 = sv.read_inout %.load0.addr.wire : !sv.net<i1>
   %mem0.ro_data_0 = hw.instance "mem0" @FIRRTLMem_1_0_0_32_1_0_1_1("x": %0: i1, "y": %1: i1, "z": %2: i1) -> ("": i32)
-  %3 = sv.read_inout %.load0.clk.wire : !hw.inout<i1>
+  %3 = sv.read_inout %.load0.clk.wire : !sv.net<i1>
   sv.assign %.load0.clk.wire, %clock : i1
-  %4 = sv.read_inout %.load0.addr.wire : !hw.inout<i1>
+  %4 = sv.read_inout %.load0.addr.wire : !sv.net<i1>
   sv.assign %.load0.addr.wire, %addr : i1
-  %5 = sv.read_inout %.load0.en.wire : !hw.inout<i1>
+  %5 = sv.read_inout %.load0.en.wire : !sv.net<i1>
   sv.assign %.load0.en.wire, %en : i1
   hw.output %mem0.ro_data_0 : i32
 }

--- a/test/Dialect/HW/errors.mlir
+++ b/test/Dialect/HW/errors.mlir
@@ -75,14 +75,14 @@ hw.module private @invalidInout(in %arg0: !hw.inout<tensor<*xf32>>) { }
 // -----
 
 hw.module @inout(in %a: i42) {
-  // expected-error @+1 {{'input' must be InOutType, but got 'i42'}}
+  // expected-error @+1 {{'input' must be an SV net type or an SV variable type, but got 'i42'}}
   %aget = sv.read_inout %a: i42
 }
 
 // -----
 
 hw.module @wire(in %a: i42) {
-  // expected-error @+1 {{'sv.wire' op result #0 must be InOutType, but got 'i42'}}
+  // expected-error @+1 {{'sv.wire' op result #0 must be an SV net type, but got 'i42'}}
   %aget = sv.wire: i42
 }
 
@@ -554,4 +554,11 @@ hw.module @triggeredInTriggered(in %trigger : i1) {
     hw.triggered posedge %arg {
     }
   }
+}
+
+// -----
+
+hw.module @VarOpBadElementType() {
+  // expected-error @+1 {{invalid element for hw.inout type}}
+  %0 = hw.var : !hw.inout<!hw.inout<i1>>
 }

--- a/test/Dialect/HW/modules.mlir
+++ b/test/Dialect/HW/modules.mlir
@@ -28,8 +28,10 @@ hw.module @A(in %d: i1, inout %e: i1, out "": i1, out "": i1) {
   %r1, %r2 = hw.instance "b1" @B(a: %d: i1) -> (nameOfPortInSV: i1, "": i1)
   // Instantiate @C with a public symbol on the instance
   %f, %g = hw.instance "c1" sym @E @C(nameOfPortInSV: %d: i1) -> ("": i1, "": i1)
+  // Bridge the inout port to a net before assigning
+  %e_net = sv.net.from_inout %e : !hw.inout<i1> -> !sv.net<i1>
   // Connect the inout port with %f
-  sv.assign %e, %f : i1
+  sv.assign %e_net, %f : i1
   // Output values
   hw.output %g, %r1 : i1, i1
 }

--- a/test/Dialect/HW/parameters.mlir
+++ b/test/Dialect/HW/parameters.mlir
@@ -162,10 +162,10 @@ hw.module @parameterizedTypes<param: i32>
 // CHECK-SAME: out c : !hw.int<#hw.param.decl.ref<"param">>)
   out c: !hw.int<#hw.param.decl.ref<"param">>) {
 
-  // CHECK: %paramWire = sv.wire : !hw.inout<int<#hw.param.decl.ref<"param">>>
-  %paramWire = sv.wire : !hw.inout<!hw.int<#hw.param.decl.ref<"param">>>
-  // CHECK: %0 = sv.read_inout %paramWire : !hw.inout<int<#hw.param.decl.ref<"param">>>
-  %0 = sv.read_inout %paramWire : !hw.inout<!hw.int<#hw.param.decl.ref<"param">>>
+  // CHECK: %paramWire = sv.wire : !sv.net<!hw.int<#hw.param.decl.ref<"param">>>
+  %paramWire = sv.wire : !sv.net<!hw.int<#hw.param.decl.ref<"param">>>
+  // CHECK: %0 = sv.read_inout %paramWire : !sv.net<!hw.int<#hw.param.decl.ref<"param">>>
+  %0 = sv.read_inout %paramWire : !sv.net<!hw.int<#hw.param.decl.ref<"param">>>
   // CHECK: hw.output %0 : !hw.int<#hw.param.decl.ref<"param">>
   hw.output %0 : !hw.int<#hw.param.decl.ref<"param">>
 }

--- a/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports-errors.mlir
+++ b/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports-errors.mlir
@@ -10,6 +10,7 @@ hw.module @unsupported(inout %a: i42) {
 // expected-error @+1 {{multiple writers of inout port "a" is unsupported.}}
 hw.module @multipleWriters(inout %a: i42) {
   %0 = hw.constant 0 : i42
-  sv.assign %a, %0 : i42
-  sv.assign %a, %0 : i42
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  sv.assign %a_net, %0 : i42
+  sv.assign %a_net, %0 : i42
 }

--- a/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports-named.mlir
+++ b/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports-named.mlir
@@ -2,21 +2,24 @@
 
 // CHECK-LABEL:   hw.module @read(in %rd : i42, out out : i42)
 hw.module @read(inout %rd: i42, out out: i42) {
-  %aget = sv.read_inout %rd: !hw.inout<i42>
+  %rd_net = sv.net.from_inout %rd : !hw.inout<i42> -> !sv.net<i42>
+  %aget = sv.read_inout %rd_net: !sv.net<i42>
   hw.output %aget : i42
 }
 
 // CHECK-LABEL: hw.module @write(out wr : i42)
 hw.module @write(inout %wr: i42) {
   %0 = hw.constant 0 : i42
-  sv.assign %wr, %0 : i42
+  %wr_net = sv.net.from_inout %wr : !hw.inout<i42> -> !sv.net<i42>
+  sv.assign %wr_net, %0 : i42
 }
 
 // CHECK-LABEL: hw.module @oneLevel()
 // CHECK:           %[[x:.*]] = hw.instance "read" @read(rd: %[[x:.*]]: i42) -> (out: i42)
 // CHECK:           %[[x:.*]] = hw.instance "write" @write() -> (wr: i42)
 hw.module @oneLevel() {
-  %0 = sv.wire : !hw.inout<i42>
-  %read = hw.instance "read" @read(rd : %0 : !hw.inout<i42>) -> (out: i42)
-  hw.instance "write" @write(wr : %0 : !hw.inout<i42>) -> ()
+  %0 = sv.wire : !sv.net<i42>
+  %wire_io = sv.inout.from_net %0 : !sv.net<i42> -> !hw.inout<i42>
+  %read = hw.instance "read" @read(rd : %wire_io : !hw.inout<i42>) -> (out: i42)
+  hw.instance "write" @write(wr : %wire_io : !hw.inout<i42>) -> ()
 }

--- a/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports.mlir
+++ b/test/Dialect/SV/EliminateInOutPorts/hw-eliminate-inout-ports.mlir
@@ -5,7 +5,8 @@
 // CHECK:           hw.output %[[VAL_0]] : i42
 // CHECK:         }
 hw.module @read(inout %a: i42, out out: i42) {
-  %aget = sv.read_inout %a: !hw.inout<i42>
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  %aget = sv.read_inout %a_net: !sv.net<i42>
   hw.output %aget : i42
 }
 
@@ -15,7 +16,8 @@ hw.module @read(inout %a: i42, out out: i42) {
 // CHECK:         }
 hw.module @write(inout %a: i42) {
   %0 = hw.constant 0 : i42
-  sv.assign %a, %0 : i42
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  sv.assign %a_net, %0 : i42
 }
 
 // CHECK-LABEL:   hw.module @read_write(
@@ -23,32 +25,35 @@ hw.module @write(inout %a: i42) {
 // CHECK:           hw.output %[[VAL_0]], %[[VAL_0]] : i42, i42
 // CHECK:         }
 hw.module @read_write(inout %a: i42, out out: i42) {
-  %aget = sv.read_inout %a: !hw.inout<i42>
-  sv.assign %a, %aget : i42
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  %aget = sv.read_inout %a_net: !sv.net<i42>
+  sv.assign %a_net, %aget : i42
   hw.output %aget : i42
 }
 
 // CHECK-LABEL:   hw.module @oneLevel() {
-// CHECK:           %[[VAL_0:.*]] = sv.wire : !hw.inout<i42>
-// CHECK:           %[[VAL_1:.*]] = sv.read_inout %[[VAL_0]] : !hw.inout<i42>
-// CHECK:           %[[VAL_2:.*]] = hw.instance "read" @read(a_rd: %[[VAL_1]]: i42) -> (out: i42)
-// CHECK:           sv.assign %[[VAL_0]], %[[VAL_3:.*]] : i42
-// CHECK:           %[[VAL_3]] = hw.instance "write" @write() -> (a_wr: i42)
-// CHECK:           %[[VAL_4:.*]] = sv.read_inout %[[VAL_0]] : !hw.inout<i42>
-// CHECK:           sv.assign %[[VAL_0]], %[[VAL_5:.*]] : i42
-// CHECK:           %[[VAL_5]], %[[VAL_6:.*]] = hw.instance "readWrite" @read_write(a_rd: %[[VAL_4]]: i42) -> (a_wr: i42, out: i42)
+// CHECK:           %[[VAL_0:.*]] = sv.wire : !sv.net<i42>
+// CHECK:           %[[VAL_1:.*]] = sv.inout.from_net %[[VAL_0]] : !sv.net<i42> -> !hw.inout<i42>
+// CHECK:           %[[VAL_2:.*]] = sv.net.from_inout %[[VAL_1]] : !hw.inout<i42> -> !sv.net<i42>
+// CHECK:           %[[VAL_3:.*]] = sv.read_inout %[[VAL_2]] : !sv.net<i42>
+// CHECK:           %[[VAL_4:.*]] = hw.instance "read" @read(a_rd: %[[VAL_3]]: i42) -> (out: i42)
+// CHECK:           %[[VAL_5:.*]] = sv.net.from_inout %[[VAL_1]] : !hw.inout<i42> -> !sv.net<i42>
+// CHECK:           sv.assign %[[VAL_5]], %[[VAL_6:.*]] : i42
+// CHECK:           %[[VAL_6]] = hw.instance "write" @write() -> (a_wr: i42)
+// CHECK:           %[[VAL_7:.*]] = sv.net.from_inout %[[VAL_1]] : !hw.inout<i42> -> !sv.net<i42>
+// CHECK:           %[[VAL_8:.*]] = sv.read_inout %[[VAL_7]] : !sv.net<i42>
+// CHECK:           %[[VAL_9:.*]] = sv.net.from_inout %[[VAL_1]] : !hw.inout<i42> -> !sv.net<i42>
+// CHECK:           sv.assign %[[VAL_9]], %[[VAL_10:.*]] : i42
+// CHECK:           %[[VAL_10]], %[[VAL_11:.*]] = hw.instance "readWrite" @read_write(a_rd: %[[VAL_8]]: i42) -> (a_wr: i42, out: i42)
 // CHECK:           hw.output
 // CHECK:         }
 hw.module @oneLevel() {
-  // No error here, even though the inout is written in two places. The
-  // pass will only error upon the recursive case when it inspects a module
-  // and sees that there are multiple writers to an inout *port*.
-  %0 = sv.wire : !hw.inout<i42>
-  %read = hw.instance "read" @read(a : %0 : !hw.inout<i42>) -> (out: i42)
-  hw.instance "write" @write(a : %0 : !hw.inout<i42>) -> ()
-  %read_write = hw.instance "readWrite" @read_write(a : %0 : !hw.inout<i42>) -> (out: i42)
+  %0 = sv.wire : !sv.net<i42>
+  %wire_io = sv.inout.from_net %0 : !sv.net<i42> -> !hw.inout<i42>
+  %read = hw.instance "read" @read(a : %wire_io : !hw.inout<i42>) -> (out: i42)
+  hw.instance "write" @write(a : %wire_io : !hw.inout<i42>) -> ()
+  %read_write = hw.instance "readWrite" @read_write(a : %wire_io : !hw.inout<i42>) -> (out: i42)
 }
-
 
 // CHECK-LABEL:   hw.module @passthrough(out a_wr : i42) {
 // CHECK:           %[[VAL_0:.*]] = hw.instance "write" @write() -> (a_wr: i42)
@@ -59,23 +64,24 @@ hw.module @passthrough(inout %a : i42) {
 }
 
 // CHECK-LABEL:   hw.module @passthroughTwoLevels() {
-// CHECK:           %[[VAL_0:.*]] = sv.wire : !hw.inout<i42>
-// CHECK:           sv.assign %[[VAL_0]], %[[VAL_1:.*]] : i42
-// CHECK:           %[[VAL_1]] = hw.instance "passthrough" @passthrough() -> (a_wr: i42)
+// CHECK:           %[[VAL_0:.*]] = sv.wire : !sv.net<i42>
+// CHECK:           %[[VAL_1:.*]] = sv.inout.from_net %[[VAL_0]] : !sv.net<i42> -> !hw.inout<i42>
+// CHECK:           %[[VAL_2:.*]] = sv.net.from_inout %[[VAL_1]] : !hw.inout<i42> -> !sv.net<i42>
+// CHECK:           sv.assign %[[VAL_2]], %[[VAL_3:.*]] : i42
+// CHECK:           %[[VAL_3]] = hw.instance "passthrough" @passthrough() -> (a_wr: i42)
 // CHECK:           hw.output
 // CHECK:         }
 hw.module @passthroughTwoLevels() {
-  %0 = sv.wire : !hw.inout<i42>
-  hw.instance "passthrough" @passthrough(a : %0 : !hw.inout<i42>) -> ()
+  %0 = sv.wire : !sv.net<i42>
+  %wire_io = sv.inout.from_net %0 : !sv.net<i42> -> !hw.inout<i42>
+  hw.instance "passthrough" @passthrough(a : %wire_io : !hw.inout<i42>) -> ()
 }
 
 // CHECK-LABEL:   hw.module @writeInput(
 // CHECK-SAME:                          in %[[VAL_0:.*]] : i42, out a_wr : i42) {
 // CHECK:           hw.output %[[VAL_0]] : i42
 // CHECK:         }
-
-// Tests a bug where the inout was being eliminated which resulted in the
-// block argument list shifting, but the index of %in not being updated.
 hw.module @writeInput(inout %a: i42, in %in : i42) {
-  sv.assign %a, %in : i42
+  %a_net = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  sv.assign %a_net, %in : i42
 }

--- a/test/Dialect/SV/basic.mlir
+++ b/test/Dialect/SV/basic.mlir
@@ -189,14 +189,14 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
     }
   }
 
-  // CHECK-NEXT: %combWire = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<i1>
-  %combWire = sv.reg {sv.attributes=[#sv.attribute<"dont_merge">]} : !hw.inout<i1>
-  // CHECK-NEXT: %selReg = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime" = "true">]} : !hw.inout<i10>
-  %selReg = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime" ="true">]} : !hw.inout<i10>
-  // CHECK-NEXT: %combWire2 = sv.wire : !hw.inout<i1>
-  %combWire2 = sv.wire : !hw.inout<i1>
-  // CHECK-NEXT: %regForce = sv.reg : !hw.inout<i1>
-  %regForce = sv.reg  : !hw.inout<i1>
+  // CHECK-NEXT: %combWire = sv.var {sv.attributes = [#sv.attribute<"dont_merge">]} : !sv.var<i1>
+  %combWire = sv.var {sv.attributes=[#sv.attribute<"dont_merge">]} : !sv.var<i1>
+  // CHECK-NEXT: %selReg = sv.var {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime" = "true">]} : !sv.var<i10>
+  %selReg = sv.var {sv.attributes = [#sv.attribute<"dont_merge">, #sv.attribute<"dont_retime" ="true">]} : !sv.var<i10>
+  // CHECK-NEXT: %combWire2 = sv.wire : !sv.net<i1>
+  %combWire2 = sv.wire : !sv.net<i1>
+  // CHECK-NEXT: %regForce = sv.var : !sv.var<i1>
+  %regForce = sv.var : !sv.var<i1>
   // CHECK-NEXT: sv.alwayscomb {
   sv.alwayscomb {
     // CHECK-NEXT: %x_i1 = sv.constantX : i1
@@ -204,30 +204,30 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
     // CHECK-NEXT: sv.passign %combWire, %x_i1 : i1
     sv.passign %combWire, %tmpx : i1
     // CHECK-NEXT: %[[c2_i3:.+]] = hw.constant 2 : i3
-    // CHECK-NEXT: %[[v0:.+]] = sv.indexed_part_select_inout %selReg[%[[c2_i3]] : 1] : !hw.inout<i10>, i3
+    // CHECK-NEXT: %[[v0:.+]] = sv.indexed_part_select_inout %selReg[%[[c2_i3]] : 1] : !sv.var<i10>, i3
     // CHECK-NEXT: sv.passign %[[v0]], %x_i1 : i1
     %c2 = hw.constant 2 : i3
-    %xx1 = sv.indexed_part_select_inout %selReg[%c2:1] :  !hw.inout<i10>, i3
+    %xx1 = sv.indexed_part_select_inout %selReg[%c2:1] : !sv.var<i10>, i3
     sv.passign %xx1, %tmpx : i1
-    // CHECK-NEXT: sv.force %combWire2, %x_i1 : i1
-    sv.force %combWire2, %tmpx : i1
-    // CHECK-NEXT: sv.force %regForce, %x_i1 : i1
-    sv.force %regForce, %tmpx : i1
-    sv.release %combWire2 : !hw.inout<i1>
-    sv.release %regForce : !hw.inout<i1>
-    // CHECK-NEXT: sv.release %combWire2 : !hw.inout<i1>
-    // CHECK-NEXT: sv.release %regForce : !hw.inout<i1>
+    // CHECK-NEXT: sv.force %combWire2, %x_i1 : !sv.net<i1>
+    sv.force %combWire2, %tmpx : !sv.net<i1>
+    // CHECK-NEXT: sv.force %regForce, %x_i1 : !sv.var<i1>
+    sv.force %regForce, %tmpx : !sv.var<i1>
+    sv.release %combWire2 : !sv.net<i1>
+    sv.release %regForce : !sv.var<i1>
+    // CHECK-NEXT: sv.release %combWire2 : !sv.net<i1>
+    // CHECK-NEXT: sv.release %regForce : !sv.var<i1>
     // CHECK-NEXT: }
   }
 
-  // CHECK-NEXT: %reg23 = sv.reg : !hw.inout<i23>
-  // CHECK-NEXT: %regStruct23 = sv.reg : !hw.inout<struct<foo: i23>>
-  // CHECK-NEXT: %reg24 = sv.reg sym @regSym1 : !hw.inout<i23>
-  // CHECK-NEXT: %wire25 = sv.wire sym @wireSym1 : !hw.inout<i23>
-  %reg23       = sv.reg  : !hw.inout<i23>
-  %regStruct23 = sv.reg  : !hw.inout<struct<foo: i23>>
-  %reg24       = sv.reg sym @regSym1 : !hw.inout<i23>
-  %wire25      = sv.wire sym @wireSym1 : !hw.inout<i23>
+  // CHECK-NEXT: %reg23 = sv.var : !sv.var<i23>
+  // CHECK-NEXT: %regStruct23 = sv.var : !sv.var<!hw.struct<foo: i23>>
+  // CHECK-NEXT: %reg24 = sv.var sym @regSym1 : !sv.var<i23>
+  // CHECK-NEXT: %wire25 = sv.wire sym @wireSym1 : !sv.net<i23>
+  %reg23       = sv.var : !sv.var<i23>
+  %regStruct23 = sv.var : !sv.var<!hw.struct<foo: i23>>
+  %reg24       = sv.var sym @regSym1 : !sv.var<i23>
+  %wire25      = sv.wire sym @wireSym1 : !sv.net<i23>
 
   // Simulation Control Tasks
   // CHECK-NEXT: sv.initial {
@@ -299,14 +299,14 @@ hw.module @test1(in %arg0: i1, in %arg1: i1, in %arg8: i8) {
 
   // Tests for ReadMemOp ($readmemb/$readmemh)
   // CHECK-NEXT: sv.initial {
-  // CHECK-NEXT:   %memForReadMem = sv.reg
+  // CHECK-NEXT:   %memForReadMem = sv.var
   // CHECK-NEXT:   sv.readmem %memForReadMem, "file1.txt", MemBaseBin
   // CHECK-NEXT:   sv.readmem %memForReadMem, "file2.txt", MemBaseHex
   // CHECK-NEXT: }
   sv.initial {
-    %memForReadMem = sv.reg sym @MemForReadMem : !hw.inout<uarray<8xi32>>
-    sv.readmem %memForReadMem, "file1.txt", MemBaseBin : !hw.inout<uarray<8xi32>>
-    sv.readmem %memForReadMem, "file2.txt", MemBaseHex : !hw.inout<uarray<8xi32>>
+    %memForReadMem = sv.var sym @MemForReadMem : !sv.var<!hw.uarray<8xi32>>
+    sv.readmem %memForReadMem, "file1.txt", MemBaseBin : !sv.var<!hw.uarray<8xi32>>
+    sv.readmem %memForReadMem, "file2.txt", MemBaseHex : !sv.var<!hw.uarray<8xi32>>
   }
 
 
@@ -339,33 +339,33 @@ hw.module @AB(in %a: i1, in %b: i2) {
 
 //CHECK-LABEL: hw.module @XMR_src
 hw.module @XMR_src(in %a : i23) {
-  //CHECK-NEXT:   sv.xmr isRooted "a", "b", "c" : !hw.inout<i23>
-  %xmr1 = sv.xmr isRooted a,b,c : !hw.inout<i23>
-  //CHECK-NEXT:   sv.xmr "a", "b", "c" : !hw.inout<i3>
-  %xmr2 = sv.xmr "a",b,c : !hw.inout<i3>
-  %r = sv.read_inout %xmr1 : !hw.inout<i23>
+  //CHECK-NEXT:   sv.xmr isRooted "a", "b", "c" : !sv.net<i23>
+  %xmr1 = sv.xmr isRooted a,b,c : !sv.net<i23>
+  //CHECK-NEXT:   sv.xmr "a", "b", "c" : !sv.net<i3>
+  %xmr2 = sv.xmr "a",b,c : !sv.net<i3>
+  %r = sv.read_inout %xmr1 : !sv.net<i23>
   sv.assign %xmr1, %a : i23
 }
 
   hw.module @part_select(in %in4 : i4, in %in8 : i8, out a : i3, out b : i5) {
   // CHECK-LABEL: hw.module @part_select
 
-    %myReg2 = sv.reg : !hw.inout<i18>
+    %myReg2 = sv.wire : !sv.net<i18>
     %c2_i3 = hw.constant 7 : i4
-    // CHECK: = sv.indexed_part_select_inout %myReg2[%[[c7_i4:.+]] : 8] : !hw.inout<i18>, i4
-    %a1 = sv.indexed_part_select_inout %myReg2 [%c2_i3:8] : !hw.inout<i18>, i4
+    // CHECK: = sv.indexed_part_select_inout %myReg2[%[[c7_i4:.+]] : 8] : !sv.net<i18>, i4
+    %a1 = sv.indexed_part_select_inout %myReg2 [%c2_i3:8] : !sv.net<i18>, i4
     sv.assign %a1, %in8 : i8
-    // CHECK:  = sv.indexed_part_select_inout %myReg2[%[[c7_i4]] decrement : 8] : !hw.inout<i18>, i4
-    %b1 = sv.indexed_part_select_inout %myReg2 [%c2_i3 decrement:8] : !hw.inout<i18>, i4
+    // CHECK:  = sv.indexed_part_select_inout %myReg2[%[[c7_i4]] decrement : 8] : !sv.net<i18>, i4
+    %b1 = sv.indexed_part_select_inout %myReg2 [%c2_i3 decrement:8] : !sv.net<i18>, i4
     sv.assign %b1, %in8 : i8
     %c3_i3 = hw.constant 3 : i4
-    %rc = sv.read_inout %myReg2 : !hw.inout<i18>
+    %rc = sv.read_inout %myReg2 : !sv.net<i18>
     %c = sv.indexed_part_select %rc [%c3_i3:3] : i18, i4
-    // CHECK: %[[v2:.+]] = sv.read_inout %myReg2 : !hw.inout<i18>
+    // CHECK: %[[v2:.+]] = sv.read_inout %myReg2 : !sv.net<i18>
     // CHECK: = sv.indexed_part_select %[[v2]][%[[c3_i4:.+]] : 3] : i18, i4
-    %rd = sv.read_inout %myReg2 : !hw.inout<i18>
+    %rd = sv.read_inout %myReg2 : !sv.net<i18>
     %d = sv.indexed_part_select %rd [%in4 decrement:5] : i18, i4
-    // CHECK: %[[v4:.+]] = sv.read_inout %myReg2 : !hw.inout<i18>
+    // CHECK: %[[v4:.+]] = sv.read_inout %myReg2 : !sv.net<i18>
     // CHECK: = sv.indexed_part_select %[[v4]][%[[in4:.+]]  decrement : 5] : i18, i4
     hw.output %c, %d : i3, i5
 }
@@ -380,7 +380,7 @@ hw.module @nested_wire(in %a: i1) {
   // CHECK: sv.ifdef @foo
   sv.ifdef @foo {
     // CHECK: sv.wire
-    %wire = sv.wire : !hw.inout<i1>
+    %wire = sv.wire : !sv.net<i1>
     // CHECK: sv.assign
     sv.assign %wire, %a : i1
   }
@@ -394,13 +394,13 @@ hw.module @ordered_region(in %a: i1) {
     // CHECK: sv.ifdef @foo
     sv.ifdef @foo {
       // CHECK: sv.wire
-      %wire = sv.wire : !hw.inout<i1>
+      %wire = sv.wire : !sv.net<i1>
       // CHECK: sv.assign
       sv.assign %wire, %a : i1
     }
     sv.ifdef @bar {
       // CHECK: sv.wire
-      %wire = sv.wire : !hw.inout<i1>
+      %wire = sv.wire : !sv.net<i1>
       // CHECK: sv.assign
       sv.assign %wire, %a : i1
     }
@@ -412,15 +412,15 @@ hw.hierpath private @ref [@XMRRefOp::@foo, @XMRRefFoo::@a]
 hw.hierpath @ref2 [@XMRRefOp::@bar]
 hw.module.extern @XMRRefBar()
 hw.module @XMRRefFoo() {
-  %a = sv.wire sym @a : !hw.inout<i2>
+  %a = sv.wire sym @a : !sv.net<i2>
 }
 hw.module @XMRRefOp() {
   hw.instance "foo" sym @foo @XMRRefFoo() -> ()
   hw.instance "bar" sym @bar @XMRRefBar() -> ()
-  // CHECK: %0 = sv.xmr.ref @ref : !hw.inout<i2>
-  %0 = sv.xmr.ref @ref : !hw.inout<i2>
-  // CHECK: %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i8>
-  %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !hw.inout<i8>
+  // CHECK: %0 = sv.xmr.ref @ref : !sv.net<i2>
+  %0 = sv.xmr.ref @ref : !sv.net<i2>
+  // CHECK: %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !sv.net<i8>
+  %1 = sv.xmr.ref @ref2 ".x.y.z[42]" : !sv.net<i8>
 }
 
 // Functions.
@@ -540,3 +540,12 @@ hw.module @test_concat_str(out o : !hw.string) {
   %c = sv.concat_str (%a, %b) : !hw.string
   hw.output %c : !hw.string
 }
+
+hw.module @XMR_src_var(in %a : i23) {
+  %xmr3 = sv.xmr isRooted x,y,z : !sv.var<i23>
+  sv.alwayscomb {
+    sv.bpassign %xmr3, %a : i23
+  }
+}
+// CHECK: [[XMR:%.+]] = sv.xmr isRooted "x", "y", "z" : !sv.var<i23>
+// CHECK: sv.bpassign [[XMR]], %a : i23

--- a/test/Dialect/SV/canonicalization.mlir
+++ b/test/Dialect/SV/canonicalization.mlir
@@ -150,8 +150,8 @@ hw.module @assert_canonicalization(in %clock: i1) {
 
 // CHECK-LABEL: hw.module @svAttrPreventsCanonicalization(in %arg0 : i1) {
 hw.module @svAttrPreventsCanonicalization(in %arg0: i1) {
-  %0 = sv.wire : !hw.inout<i1>
-  // CHECK:      %0 = sv.wire : !hw.inout<i1>
+  %0 = sv.wire : !sv.net<i1>
+  // CHECK:      %0 = sv.wire : !sv.net<i1>
   // CHECK-NEXT: sv.assign %0, %arg0 {sv.attributes = [#sv.attribute<"attr">]} : i1
   sv.assign %0, %arg0 {sv.attributes = [#sv.attribute<"attr">]} : i1
 }
@@ -302,17 +302,17 @@ hw.module @MergeAssignments(in %a: !hw.array<4xi1>, in %clock: i1, out d: !hw.ar
   %v0 = hw.array_get %a[%c0_i2] : !hw.array<4xi1>, i2
   %v1 = hw.array_get %a[%c1_i2] : !hw.array<4xi1>, i2
   %v2 = hw.array_get %a[%c-2_i2] : !hw.array<4xi1>, i2
-  %r = sv.reg  : !hw.inout<array<4xi1>>
-  %i0 = sv.array_index_inout %r[%c0_i2] : !hw.inout<array<4xi1>>, i2
-  %i1 = sv.array_index_inout %r[%c1_i2] : !hw.inout<array<4xi1>>, i2
-  %i2 = sv.array_index_inout %r[%c-2_i2] : !hw.inout<array<4xi1>>, i2
-  %read = sv.read_inout %r : !hw.inout<array<4xi1>>
+  %r = sv.var  : !sv.var<!hw.array<4xi1>>
+  %i0 = sv.array_index_inout %r[%c0_i2] : !sv.var<!hw.array<4xi1>>, i2
+  %i1 = sv.array_index_inout %r[%c1_i2] : !sv.var<!hw.array<4xi1>>, i2
+  %i2 = sv.array_index_inout %r[%c-2_i2] : !sv.var<!hw.array<4xi1>>, i2
+  %read = sv.read_inout %r : !sv.var<!hw.array<4xi1>>
   sv.always posedge %clock {
     // CHECK: sv.always
-    // CHECK-NEXT:  %[[index:.+]] = sv.indexed_part_select_inout %r[%c0_i2 : 3] : !hw.inout<array<4xi1>>, i2
+    // CHECK-NEXT:  %[[index:.+]] = sv.indexed_part_select_inout %r[%c0_i2 : 3] : !sv.var<!hw.array<4xi1>>, i2
     // CHECK-NEXT:  %[[slice:.+]] = hw.array_slice %a[%c0_i2] : (!hw.array<4xi1>) -> !hw.array<3xi1>
     // CHECK-NEXT:  sv.passign %[[index]], %[[slice]]
-    // CHECK-NEXT:  %[[index:.+]] = sv.indexed_part_select_inout %r[%c0_i2 : 3] : !hw.inout<array<4xi1>>, i2
+    // CHECK-NEXT:  %[[index:.+]] = sv.indexed_part_select_inout %r[%c0_i2 : 3] : !sv.var<!hw.array<4xi1>>, i2
     // CHECK-NEXT:  %[[slice:.+]] = hw.array_slice %a[%c0_i2] : (!hw.array<4xi1>) -> !hw.array<3xi1>
     // CHECK-NEXT:  sv.bpassign %[[index]], %[[slice]]
     sv.passign %i0, %v0 : i1
@@ -335,7 +335,7 @@ hw.module @Sampled(in %in: i1) {
 // CHECK-LABEL: @Issue7563
 // CHECK-NEXT: hw.output
 hw.module @Issue7563(in %in: i8) {
-  %r = sv.reg : !hw.inout<i8>
+  %r = sv.wire : !sv.net<i8>
   sv.assign %r, %in : i8
   hw.output
 }

--- a/test/Dialect/SV/case.mlir
+++ b/test/Dialect/SV/case.mlir
@@ -41,12 +41,12 @@ hw.module @test_case_stmts() {
   }
 
   // Case expr pattern
-  %foo = sv.wire : !hw.inout<i1>
-  %bar = sv.wire : !hw.inout<i1>
-  // CHECK: [[FOO:%.*]] = sv.read_inout %foo : !hw.inout<i1>
-  // CHECK: [[BAR:%.*]] = sv.read_inout %bar : !hw.inout<i1>
-  %2 = sv.read_inout %foo : !hw.inout<i1>
-  %3 = sv.read_inout %bar : !hw.inout<i1>
+  %foo = sv.wire : !sv.net<i1>
+  %bar = sv.wire : !sv.net<i1>
+  // CHECK: [[FOO:%.*]] = sv.read_inout %foo : !sv.net<i1>
+  // CHECK: [[BAR:%.*]] = sv.read_inout %bar : !sv.net<i1>
+  %2 = sv.read_inout %foo : !sv.net<i1>
+  %3 = sv.read_inout %bar : !sv.net<i1>
   // CHECK-NEXT: sv.initial {
   // CHECK-NEXT:   sv.case [[COND]] : i1
   // CHECK-NEXT:   case [[FOO]]: {

--- a/test/Dialect/SV/errors.mlir
+++ b/test/Dialect/SV/errors.mlir
@@ -25,11 +25,15 @@ sv.interface @foo {
 hw.module @Aliasing(inout %a : i42, inout %b : i42,
                       inout %c : i42) {
 
+  %netA = sv.net.from_inout %a : !hw.inout<i42> -> !sv.net<i42>
+  %netB = sv.net.from_inout %b : !hw.inout<i42> -> !sv.net<i42>
+  %netC = sv.net.from_inout %c : !hw.inout<i42> -> !sv.net<i42>
+
   // ok
-  sv.alias %a, %b     : !hw.inout<i42>, !hw.inout<i42>
+  sv.alias %netA, %netB : !sv.net<i42>, !sv.net<i42>
 
   // expected-error @+1 {{'sv.alias' op alias must have at least two operands}}
-  sv.alias %a : !hw.inout<i42>
+  sv.alias %netA : !sv.net<i42>
 }
 
 // -----
@@ -41,30 +45,30 @@ hw.module @Fwrite() {
 
 // -----
 hw.module @Bpassign(in %arg0: i1) {
-  %reg = sv.reg : !hw.inout<i1>
+  %reg = sv.var : !sv.var<i1>
   // expected-error @+1 {{'sv.bpassign' op must not be in a non-procedural region}}
   sv.bpassign %reg, %arg0 : i1
 }
 
 // -----
 hw.module @Passign(in %arg0: i1) {
-  %reg = sv.reg : !hw.inout<i1>
+  %reg = sv.var : !sv.var<i1>
   // expected-error @+1 {{'sv.passign' op must not be in a non-procedural region}}
   sv.passign %reg, %arg0 : i1
 }
 
 // -----
 hw.module @ForcePassign(in %arg0: i1) {
-  %reg = sv.reg : !hw.inout<i1>
+  %reg = sv.var : !sv.var<i1>
   // expected-error @+1 {{'sv.force' op must not be in a non-procedural region}}
-  sv.force %reg, %arg0 : i1
+  sv.force %reg, %arg0 : !sv.var<i1>
 }
 
 // -----
 hw.module @ReleasePassign(in %arg0: i1) {
-  %reg = sv.reg : !hw.inout<i1>
+  %reg = sv.var : !sv.var<i1>
   // expected-error @+1 {{'sv.release' op must not be in a non-procedural region}}
-  sv.release %reg : !hw.inout<i1>
+  sv.release %reg : !sv.var<i1>
 }
 
 // -----
@@ -179,7 +183,7 @@ hw.module @AlwaysFF(in %arg0: i1) {
 hw.module @Wire() {
   sv.initial {
     // expected-error @+1 {{'sv.wire' op must not be in a procedural region}}
-    %wire = sv.wire : !hw.inout<i1>
+    %wire = sv.wire : !sv.net<i1>
   }
 }
 
@@ -231,18 +235,18 @@ hw.module @test() {
 // -----
 
 hw.module @part_select1() {
-  %selWire = sv.wire : !hw.inout<i10>
+  %selWire = sv.wire : !sv.net<i10>
   %c2 = hw.constant 2 : i3
   // expected-error @+1 {{slice width should not be greater than input width}}
-  %xx1 = sv.indexed_part_select_inout %selWire[%c2:11] :  !hw.inout<i10>, i3
+  %xx1 = sv.indexed_part_select_inout %selWire[%c2:11] :  !sv.net<i10>, i3
 }
 
 // -----
 
 hw.module @part_select1() {
-  %selWire = sv.wire : !hw.inout<i10>
+  %selWire = sv.wire : !sv.net<i10>
   %c2 = hw.constant 2 : i3
-  %r1 = sv.read_inout %selWire : !hw.inout<i10>
+  %r1 = sv.read_inout %selWire : !sv.net<i10>
   // expected-error @+1 {{slice width should not be greater than input width}}
   %c = sv.indexed_part_select %r1[%c2 : 20] : i10,i3
 }
@@ -379,4 +383,12 @@ hw.module @ConcatStrNoOperands(out o: i1) {
   %cat = sv.concat_str () : !hw.string
   %0 = sv.system "test$plusargs"(%cat) : (!hw.string) -> i1
   hw.output %0 : i1
+}
+
+// -----
+hw.module @XMRAssignToVar(in %a : i23) {
+  // expected-note @+1 {{prior use here}}
+  %xmr = sv.xmr isRooted x,y,z : !sv.var<i23>
+  // expected-error @+1 {{expects different type than prior uses}}
+  sv.assign %xmr, %a : i23
 }

--- a/test/Dialect/SV/hw-legalize-modules-packed-arrays.mlir
+++ b/test/Dialect/SV/hw-legalize-modules-packed-arrays.mlir
@@ -4,7 +4,7 @@ module attributes {circt.loweringOptions = "disallowPackedArrays"} {
 hw.module @reject_arrays(in %arg0: i8, in %arg1: i8, in %arg2: i8,
                          in %arg3: i8, in %sel: i2, in %clock: i1,
                          out a: !hw.array<4xi8>) {
-  %reg = sv.reg  : !hw.inout<array<4xi8>>
+  %reg = sv.var  : !sv.var<!hw.array<4xi8>>
   sv.alwaysff(posedge %clock)  {
     %0 = hw.array_create %arg0, %arg1, %arg2, %arg3 : i8
     sv.passign %reg, %0 : !hw.array<4xi8>
@@ -12,7 +12,7 @@ hw.module @reject_arrays(in %arg0: i8, in %arg1: i8, in %arg2: i8,
 
   // This needs full-on "legalize types" for the HW dialect.
   // expected-error @+1 {{unsupported packed array expression}}
-  %1 = sv.read_inout %reg : !hw.inout<array<4xi8>>
+  %1 = sv.read_inout %reg : !sv.var<!hw.array<4xi8>>
   hw.output %1 : !hw.array<4xi8>
 }
 }
@@ -22,7 +22,7 @@ module attributes {circt.loweringOptions = "disallowPackedArrays"} {
 // CHECK-LABEL: hw.module @array_create_get_comb
 hw.module @array_create_get_comb(in %arg0: i8, in %arg1: i8, in %arg2: i8, in %arg3: i8,
                                  in %sel: i2, out a: i8) {
-  // CHECK: %casez_tmp = sv.reg  : !hw.inout<i8>
+  // CHECK: %casez_tmp = sv.var  : !sv.var<i8>
   // CHECK: sv.alwayscomb  {
   // CHECK:   sv.case casez %sel : i2
   // CHECK:   case b00: {
@@ -40,7 +40,7 @@ hw.module @array_create_get_comb(in %arg0: i8, in %arg1: i8, in %arg2: i8, in %a
   // CHECK: }
   %0 = hw.array_create %arg3, %arg2, %arg1, %arg0 : i8
 
-  // CHECK: %0 = sv.read_inout %casez_tmp : !hw.inout<i8>
+  // CHECK: %0 = sv.read_inout %casez_tmp : !sv.var<i8>
   %1 = hw.array_get %0[%sel] : !hw.array<4xi8>, i2
 
   // CHECK: hw.output %0 : i8
@@ -52,7 +52,7 @@ hw.module @array_create_get_default(in %arg0: i8, in %arg1: i8, in %arg2: i8, in
                             in %sel: i2) {
   // CHECK: sv.initial  {
   sv.initial {
-    // CHECK: %casez_tmp = sv.reg  : !hw.inout<i8>
+    // CHECK: %casez_tmp = sv.var  : !sv.var<i8>
     // CHECK:   %x_i8 = sv.constantX : i8
     // CHECK:   sv.case casez %sel : i2
     // CHECK:   case b00: {
@@ -69,7 +69,7 @@ hw.module @array_create_get_default(in %arg0: i8, in %arg1: i8, in %arg2: i8, in
     // CHECK:   }
     %three_array = hw.array_create %arg2, %arg1, %arg0 : i8
 
-    // CHECK:   %0 = sv.read_inout %casez_tmp : !hw.inout<i8>
+    // CHECK:   %0 = sv.read_inout %casez_tmp : !sv.var<i8>
     %2 = hw.array_get %three_array[%sel] : !hw.array<3xi8>, i2
 
     // CHECK:   %1 = comb.icmp eq %0, %arg2 : i8
@@ -109,7 +109,7 @@ hw.module @array_muxed_create_get_default(in %arg0: i8, in %arg1: i8, in %arg2: 
     // CHECK:   sv.bpassign %casez_tmp, %x_i8 : i8
     // CHECK: }
 
-    // CHECK: %3 = sv.read_inout %casez_tmp : !hw.inout<i8>
+    // CHECK: %3 = sv.read_inout %casez_tmp : !sv.var<i8>
     %2 = hw.array_get %muxed[%index_sel] : !hw.array<3xi8>, i2
 
     // CHECK: %4 = comb.icmp eq %3, %arg2 : i8
@@ -126,7 +126,7 @@ hw.module @array_create_concat_get_default(in %arg0: i8, in %arg1: i8, in %arg2:
                             in %sel: i2) {
   // CHECK: sv.initial  {
   sv.initial {
-    // CHECK:   %casez_tmp = sv.reg : !hw.inout<i8>
+    // CHECK:   %casez_tmp = sv.var : !sv.var<i8>
     // CHECK:   %x_i8 = sv.constantX : i8
     // CHECK:   sv.case casez %sel : i2
     // CHECK:   case b00: {
@@ -145,7 +145,7 @@ hw.module @array_create_concat_get_default(in %arg0: i8, in %arg1: i8, in %arg2:
     %two_array = hw.array_create %arg1, %arg0 : i8
     %three_array = hw.array_concat %one_array, %two_array : !hw.array<1xi8>, !hw.array<2xi8>
 
-    // CHECK:   %0 = sv.read_inout %casez_tmp : !hw.inout<i8>
+    // CHECK:   %0 = sv.read_inout %casez_tmp : !sv.var<i8>
     %2 = hw.array_get %three_array[%sel] : !hw.array<3xi8>, i2
 
     // CHECK:   %1 = comb.icmp eq %0, %arg2 : i8
@@ -159,7 +159,7 @@ hw.module @array_create_concat_get_default(in %arg0: i8, in %arg1: i8, in %arg2:
 
 // CHECK-LABEL: hw.module @array_constant_get_comb
 hw.module @array_constant_get_comb(in %sel: i2, out a: i8) {
-  // CHECK: %casez_tmp = sv.reg  : !hw.inout<i8>
+  // CHECK: %casez_tmp = sv.var  : !sv.var<i8>
   // CHECK: sv.alwayscomb  {
   // CHECK:   sv.case casez %sel : i2
   // CHECK:   case b00: {
@@ -176,7 +176,7 @@ hw.module @array_constant_get_comb(in %sel: i2, out a: i8) {
   // CHECK:   }
   // CHECK: }
   %0 = hw.aggregate_constant [0 : i8, 1 : i8, 2 : i8, 3 : i8] : !hw.array<4xi8>
-  // CHECK: %0 = sv.read_inout %casez_tmp : !hw.inout<i8>
+  // CHECK: %0 = sv.read_inout %casez_tmp : !sv.var<i8>
   %1 = hw.array_get %0[%sel] : !hw.array<4xi8>, i2
 
   // CHECK: hw.output %0 : i8
@@ -189,7 +189,7 @@ hw.module @array_muxed_constant_get_comb(in %array_sel: i1, in %index_sel: i2, o
   // CHECK: %1 = comb.mux %array_sel, %c2_i8, %c6_i8 : i8
   // CHECK: %2 = comb.mux %array_sel, %c1_i8, %c5_i8 : i8
   // CHECK: %3 = comb.mux %array_sel, %c0_i8, %c4_i8 : i8
-  // CHECK: %casez_tmp = sv.reg : !hw.inout<i8>
+  // CHECK: %casez_tmp = sv.var : !sv.var<i8>
   // CHECK: sv.alwayscomb {
   // CHECK:  sv.case casez %index_sel : i2
   // CHECK:  case b00: {
@@ -208,7 +208,7 @@ hw.module @array_muxed_constant_get_comb(in %array_sel: i1, in %index_sel: i2, o
   %0 = hw.aggregate_constant [0 : i8, 1 : i8, 2 : i8, 3 : i8] : !hw.array<4xi8>
   %1 = hw.aggregate_constant [4 : i8, 5 : i8, 6 : i8, 7 : i8] : !hw.array<4xi8>
   %muxed = comb.mux %array_sel, %0, %1 : !hw.array<4xi8>
-  // CHECK: %4 = sv.read_inout %casez_tmp : !hw.inout<i8>
+  // CHECK: %4 = sv.read_inout %casez_tmp : !sv.var<i8>
   %3 = hw.array_get %muxed[%index_sel] : !hw.array<4xi8>, i2
 
   // CHECK: hw.output %4 : i8
@@ -217,9 +217,9 @@ hw.module @array_muxed_constant_get_comb(in %array_sel: i1, in %index_sel: i2, o
 
 // CHECK-LABEL: hw.module @array_reg_mux_2
 hw.module @array_reg_mux_2(in %clock: i1, in %arg0: i8, in %arg1: i8, in %sel: i1, out a: i8) {
-  // CHECK: %reg = sv.reg : !hw.inout<i8>
-  // CHECK: %reg_0 = sv.reg name "reg" : !hw.inout<i8>
-  %reg = sv.reg : !hw.inout<array<2xi8>>
+  // CHECK: %reg = sv.var : !sv.var<i8>
+  // CHECK: %reg_0 = sv.var name "reg" : !sv.var<i8>
+  %reg = sv.var : !sv.var<!hw.array<2xi8>>
   // CHECK: sv.alwaysff(posedge %clock) {
   sv.alwaysff(posedge %clock)  {
     // CHECK: sv.passign %reg, %arg1 : i8
@@ -229,9 +229,9 @@ hw.module @array_reg_mux_2(in %clock: i1, in %arg0: i8, in %arg1: i8, in %sel: i
   // CHECK: }
   }
 
-  // CHECK: %0 = sv.read_inout %reg : !hw.inout<i8>
-  // CHECK: %1 = sv.read_inout %reg_0 : !hw.inout<i8>
-  // CHECK: %casez_tmp = sv.reg : !hw.inout<i8>
+  // CHECK: %0 = sv.read_inout %reg : !sv.var<i8>
+  // CHECK: %1 = sv.read_inout %reg_0 : !sv.var<i8>
+  // CHECK: %casez_tmp = sv.var : !sv.var<i8>
   // CHECK: sv.alwayscomb {
   // CHECK:   sv.case casez %sel : i1
   // CHECK:   case b0: {
@@ -241,9 +241,9 @@ hw.module @array_reg_mux_2(in %clock: i1, in %arg0: i8, in %arg1: i8, in %sel: i
   // CHECK:     sv.bpassign %casez_tmp, %1 : i8
   // CHECK:   }
   // CHECK: }
-  %1 = sv.array_index_inout %reg[%sel] : !hw.inout<array<2xi8>>, i1
-  // CHECK: %2 = sv.read_inout %casez_tmp : !hw.inout<i8>
-  %2 = sv.read_inout %1 : !hw.inout<i8>
+  %1 = sv.array_index_inout %reg[%sel] : !sv.var<!hw.array<2xi8>>, i1
+  // CHECK: %2 = sv.read_inout %casez_tmp : !sv.var<i8>
+  %2 = sv.read_inout %1 : !sv.var<i8>
   // CHECK: hw.output %2 : i8
   hw.output %2 : i8
 }
@@ -252,11 +252,11 @@ hw.module @array_reg_mux_2(in %clock: i1, in %arg0: i8, in %arg1: i8, in %sel: i
 hw.module @array_reg_mux_4(in %arg0: i8, in %arg1: i8, in %arg2: i8,
                            in %arg3: i8, in %sel: i2, in %clock: i1,
                            out a: i8) {
-  // CHECK: %reg = sv.reg : !hw.inout<i8>
-  // CHECK: %reg_0 = sv.reg name "reg" : !hw.inout<i8>
-  // CHECK: %reg_1 = sv.reg name "reg" : !hw.inout<i8>
-  // CHECK: %reg_2 = sv.reg name "reg" : !hw.inout<i8>
-  %reg = sv.reg : !hw.inout<array<4xi8>>
+  // CHECK: %reg = sv.var : !sv.var<i8>
+  // CHECK: %reg_0 = sv.var name "reg" : !sv.var<i8>
+  // CHECK: %reg_1 = sv.var name "reg" : !sv.var<i8>
+  // CHECK: %reg_2 = sv.var name "reg" : !sv.var<i8>
+  %reg = sv.var : !sv.var<!hw.array<4xi8>>
   // CHECK: sv.alwaysff(posedge %clock) {
   sv.alwaysff(posedge %clock)  {
     // CHECK: sv.passign %reg, %arg3 : i8
@@ -267,11 +267,11 @@ hw.module @array_reg_mux_4(in %arg0: i8, in %arg1: i8, in %arg2: i8,
     sv.passign %reg, %0 : !hw.array<4xi8>
   // CHECK: }
   }
-  // CHECK: %0 = sv.read_inout %reg : !hw.inout<i8>
-  // CHECK: %1 = sv.read_inout %reg_0 : !hw.inout<i8>
-  // CHECK: %2 = sv.read_inout %reg_1 : !hw.inout<i8>
-  // CHECK: %3 = sv.read_inout %reg_2 : !hw.inout<i8>
-  // CHECK: %casez_tmp = sv.reg : !hw.inout<i8>
+  // CHECK: %0 = sv.read_inout %reg : !sv.var<i8>
+  // CHECK: %1 = sv.read_inout %reg_0 : !sv.var<i8>
+  // CHECK: %2 = sv.read_inout %reg_1 : !sv.var<i8>
+  // CHECK: %3 = sv.read_inout %reg_2 : !sv.var<i8>
+  // CHECK: %casez_tmp = sv.var : !sv.var<i8>
   // CHECK: sv.alwayscomb {
   // CHECK:   sv.case casez %sel : i2
   // CHECK:   case b00: {
@@ -287,9 +287,9 @@ hw.module @array_reg_mux_4(in %arg0: i8, in %arg1: i8, in %arg2: i8,
   // CHECK:     sv.bpassign %casez_tmp, %3 : i8
   // CHECK:   }
   // CHECK: }
-  %1 = sv.array_index_inout %reg[%sel] : !hw.inout<array<4xi8>>, i2
-  // CHECK: %4 = sv.read_inout %casez_tmp : !hw.inout<i8>
-  %2 = sv.read_inout %1 : !hw.inout<i8>
+  %1 = sv.array_index_inout %reg[%sel] : !sv.var<!hw.array<4xi8>>, i2
+  // CHECK: %4 = sv.read_inout %casez_tmp : !sv.var<i8>
+  %2 = sv.read_inout %1 : !sv.var<i8>
   // CHECK: hw.output %4 : i8
   hw.output %2 : i8
 }

--- a/test/Dialect/SV/prettify-verilog.mlir
+++ b/test/Dialect/SV/prettify-verilog.mlir
@@ -98,17 +98,17 @@ hw.module @sink_constants(in %clock :i1, out out : i1){
 // CHECK-LABEL: @sinkReadInOut
 // VERILOG-LABEL: sinkReadInOut
 hw.module @sinkReadInOut(in %clk: i1) {
-  %myreg = sv.reg  : !hw.inout<array<1xstruct<a: i48, b: i48>>>
+  %myreg = sv.var  : !sv.var<!hw.array<1x!hw.struct<a: i48, b: i48>>>
   %false = hw.constant false
-  %0 = sv.array_index_inout %myreg[%false]: !hw.inout<array<1xstruct<a: i48, b: i48>>>, i1
-  %a = sv.struct_field_inout %0["a"]: !hw.inout<struct<a: i48, b: i48>>
-  %b = sv.struct_field_inout %0["b"]: !hw.inout<struct<a: i48, b: i48>>
-  %2 = sv.read_inout %b : !hw.inout<i48>
+  %0 = sv.array_index_inout %myreg[%false]: !sv.var<!hw.array<1x!hw.struct<a: i48, b: i48>>>, i1
+  %a = sv.struct_field_inout %0["a"]: !sv.var<!hw.struct<a: i48, b: i48>>
+  %b = sv.struct_field_inout %0["b"]: !sv.var<!hw.struct<a: i48, b: i48>>
+  %2 = sv.read_inout %b : !sv.var<i48>
   sv.alwaysff(posedge %clk)  {
     sv.passign %a, %2 : i48
   }
 }
-// CHECK:  %myreg = sv.reg
+// CHECK:  %myreg = sv.var
 // CHECK:  sv.alwaysff(posedge %clk)
 // CHECK:    sv.array_index_inout
 // CHECK:    sv.struct_field_inout
@@ -248,16 +248,17 @@ hw.module @unary_sink_no_duplicate(in %arg0: i4, out result: i4) {
 
 // CHECK-LABEL: hw.module private @ConnectToAllFields
 hw.module private @ConnectToAllFields(in %clock: i1, in %reset: i1, in %value: i2, inout %base: !hw.struct<a: i2>) {
-  %r = sv.reg : !hw.inout<!hw.struct<a: i2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2>>
+  %r = sv.var : !sv.var<!hw.struct<a: i2>>
+  %val = sv.read_inout %r : !sv.var<!hw.struct<a: i2>>
   sv.always posedge %clock {
     sv.passign %r, %1 : !hw.struct<a: i2>
   }
 
-  %0 = sv.read_inout %base : !hw.inout<!hw.struct<a: i2>>
+  %base_net = sv.net.from_inout %base : !hw.inout<!hw.struct<a: i2>> -> !sv.net<!hw.struct<a: i2>>
+  %0 = sv.read_inout %base_net : !sv.net<!hw.struct<a: i2>>
   %1 = hw.struct_inject %0["a"], %value : !hw.struct<a: i2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2>>
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !sv.var<!hw.struct<a: i2>>
   // CHECK:   sv.passign [[FIELD_A]], %value : i2
   // CHECK: }
 
@@ -267,15 +268,15 @@ hw.module private @ConnectToAllFields(in %clock: i1, in %reset: i1, in %value: i
 
 // CHECK-LABEL: hw.module private @ConnectSubfield
 hw.module private @ConnectSubfield(in %clock: i1, in %reset: i1, in %value: i2) {
-  %r = sv.reg : !hw.inout<!hw.struct<a: i2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2>>
+  %r = sv.var : !sv.var<!hw.struct<a: i2>>
+  %val = sv.read_inout %r : !sv.var<!hw.struct<a: i2>>
   sv.always posedge %clock {
     sv.passign %r, %0 : !hw.struct<a: i2>
   }
 
   %0 = hw.struct_inject %val["a"], %value : !hw.struct<a: i2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2>>
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !sv.var<!hw.struct<a: i2>>
   // CHECK:   sv.passign [[FIELD_A]], %value : i2
   // CHECK: }
 
@@ -285,8 +286,8 @@ hw.module private @ConnectSubfield(in %clock: i1, in %reset: i1, in %value: i2) 
 
 // CHECK-LABEL: hw.module private @ConnectSubfields
 hw.module private @ConnectSubfields(in %clock: i1, in %reset: i1, in %value2: i2, in %value3: i3) {
-  %r = sv.reg : !hw.inout<!hw.struct<a: i2, b: i3>>
-  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2, b: i3>>
+  %r = sv.var : !sv.var<!hw.struct<a: i2, b: i3>>
+  %val = sv.read_inout %r : !sv.var<!hw.struct<a: i2, b: i3>>
   sv.always posedge %clock {
     sv.passign %r, %1 : !hw.struct<a: i2, b: i3>
   }
@@ -294,9 +295,9 @@ hw.module private @ConnectSubfields(in %clock: i1, in %reset: i1, in %value2: i2
   %0 = hw.struct_inject %val["a"], %value2 : !hw.struct<a: i2, b: i3>
   %1 = hw.struct_inject %0["b"], %value3 : !hw.struct<a: i2, b: i3>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2, b: i3>>
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !sv.var<!hw.struct<a: i2, b: i3>>
   // CHECK:   sv.passign [[FIELD_A]], %value2 : i2
-  // CHECK:   [[FIELD_B:%.+]] = sv.struct_field_inout %r["b"] : !hw.inout<struct<a: i2, b: i3>>
+  // CHECK:   [[FIELD_B:%.+]] = sv.struct_field_inout %r["b"] : !sv.var<!hw.struct<a: i2, b: i3>>
   // CHECK:   sv.passign [[FIELD_B]], %value3 : i3
   // CHECK: }
 
@@ -308,8 +309,8 @@ hw.module private @ConnectSubfields(in %clock: i1, in %reset: i1, in %value2: i2
 
 // CHECK-LABEL: hw.module private @ConnectSubfieldOverwrite
 hw.module private @ConnectSubfieldOverwrite(in %clock: i1, in %reset: i1, in %value2: i2, in %value3: i2) {
-  %r = sv.reg : !hw.inout<!hw.struct<a: i2, b: i3>>
-  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: i2, b: i3>>
+  %r = sv.var : !sv.var<!hw.struct<a: i2, b: i3>>
+  %val = sv.read_inout %r : !sv.var<!hw.struct<a: i2, b: i3>>
   sv.always posedge %clock {
     sv.passign %r, %1 : !hw.struct<a: i2, b: i3>
   }
@@ -317,7 +318,7 @@ hw.module private @ConnectSubfieldOverwrite(in %clock: i1, in %reset: i1, in %va
   %0 = hw.struct_inject %val["a"], %value2 : !hw.struct<a: i2, b: i3>
   %1 = hw.struct_inject %0["a"], %value3 : !hw.struct<a: i2, b: i3>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i2, b: i3>>
+  // CHECK:   [[FIELD:%.+]] = sv.struct_field_inout %r["a"] : !sv.var<!hw.struct<a: i2, b: i3>>
   // CHECK:   sv.passign [[FIELD]], %value3 : i2
   // CHECK: }
 
@@ -327,8 +328,8 @@ hw.module private @ConnectSubfieldOverwrite(in %clock: i1, in %reset: i1, in %va
 
 // CHECK-LABEL: hw.module private @ConnectNestedSubfield
 hw.module private @ConnectNestedSubfield(in %clock: i1, in %reset: i1, in %value: i2) {
-  %r = sv.reg : !hw.inout<!hw.struct<a: !hw.struct<b: i2>>>
-  %val = sv.read_inout %r : !hw.inout<!hw.struct<a: !hw.struct<b: i2>>>
+  %r = sv.var : !sv.var<!hw.struct<a: !hw.struct<b: i2>>>
+  %val = sv.read_inout %r : !sv.var<!hw.struct<a: !hw.struct<b: i2>>>
   sv.always posedge %clock {
     sv.passign %r, %2 : !hw.struct<a: !hw.struct<b: i2>>
   }
@@ -337,8 +338,8 @@ hw.module private @ConnectNestedSubfield(in %clock: i1, in %reset: i1, in %value
   %2 = hw.struct_inject %val["a"], %1 : !hw.struct<a: !hw.struct<b: i2>>
 
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: !hw.struct<b: i2>>>
-  // CHECK:   [[FIELD_B:%.+]] = sv.struct_field_inout [[FIELD_A]]["b"] : !hw.inout<struct<b: i2>>
+  // CHECK:   [[FIELD_A:%.+]] = sv.struct_field_inout %r["a"] : !sv.var<!hw.struct<a: !hw.struct<b: i2>>>
+  // CHECK:   [[FIELD_B:%.+]] = sv.struct_field_inout [[FIELD_A]]["b"] : !sv.var<!hw.struct<b: i2>>
   // CHECK:   sv.passign [[FIELD_B]], %value : i2
   // CHECK: }
 
@@ -351,8 +352,8 @@ hw.module private @ConnectNestedSubfield(in %clock: i1, in %reset: i1, in %value
 hw.module private @ConnectSubindexMid(in %clock: i1, in %reset: i1, in %value: i2) {
   %c0_i2 = hw.constant 0 : i2
   %c-2_i2 = hw.constant -2 : i2
-  %r = sv.reg : !hw.inout<!hw.array<3xi2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<3xi2>>
+  %r = sv.var : !sv.var<!hw.array<3xi2>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<3xi2>>
   sv.always posedge %clock {
     sv.passign %r, %3 : !hw.array<3xi2>
   }
@@ -362,7 +363,7 @@ hw.module private @ConnectSubindexMid(in %clock: i1, in %reset: i1, in %value: i
   %2 = hw.array_slice %val[%c-2_i2] : (!hw.array<3xi2>) -> !hw.array<1xi2>
   %3 = hw.array_concat %2, %1, %0 : !hw.array<1xi2>, !hw.array<1xi2>, !hw.array<1xi2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD:%.+]] = sv.array_index_inout %r[%c1_i2] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   [[FIELD:%.+]] = sv.array_index_inout %r[%c1_i2] : !sv.var<!hw.array<3xi2>>, i2
   // CHECK:   sv.passign [[FIELD]], %value : i2
   // CHECK: }
 
@@ -373,8 +374,8 @@ hw.module private @ConnectSubindexMid(in %clock: i1, in %reset: i1, in %value: i
 // CHECK-LABEL: hw.module private @ConnectSubindexSingleton
 hw.module private @ConnectSubindexSingleton(in %clock: i1, in %reset: i1, in %value: i2) {
   %none = hw.constant 0 : i0
-  %r = sv.reg : !hw.inout<!hw.array<1xi2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<1xi2>>
+  %r = sv.var : !sv.var<!hw.array<1xi2>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<1xi2>>
   sv.always posedge %clock {
     sv.passign %r, %1 : !hw.array<1xi2>
   }
@@ -389,8 +390,8 @@ hw.module private @ConnectSubindexSingleton(in %clock: i1, in %reset: i1, in %va
 hw.module private @ConnectSubindexLeft(in %clock: i1, in %reset: i1, in %value: i2) {
   %c0_i2 = hw.constant 0 : i2
 
-  %r = sv.reg : !hw.inout<!hw.array<3xi2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<3xi2>>
+  %r = sv.var : !sv.var<!hw.array<3xi2>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<3xi2>>
   sv.always posedge %clock {
     sv.passign %r, %2 : !hw.array<3xi2>
   }
@@ -399,7 +400,7 @@ hw.module private @ConnectSubindexLeft(in %clock: i1, in %reset: i1, in %value: 
   %1 = hw.array_create %value : i2
   %2 = hw.array_concat %1, %0 : !hw.array<1xi2>, !hw.array<2xi2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_1:%.+]] = sv.array_index_inout %r[%c-2_i2] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   [[FIELD_1:%.+]] = sv.array_index_inout %r[%c-2_i2] : !sv.var<!hw.array<3xi2>>, i2
   // CHECK:   sv.passign [[FIELD_1]], %value : i2
   // CHECK: }
 
@@ -410,8 +411,8 @@ hw.module private @ConnectSubindexLeft(in %clock: i1, in %reset: i1, in %value: 
 // CHECK-LABEL: hw.module private @ConnectSubindexRight
 hw.module private @ConnectSubindexRight(in %clock: i1, in %reset: i1, in %value: i2) {
   %c1_i2 = hw.constant 1 : i2
-  %r = sv.reg : !hw.inout<!hw.array<3xi2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<3xi2>>
+  %r = sv.var : !sv.var<!hw.array<3xi2>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<3xi2>>
   sv.always posedge %clock {
     sv.passign %r, %2 : !hw.array<3xi2>
   }
@@ -420,7 +421,7 @@ hw.module private @ConnectSubindexRight(in %clock: i1, in %reset: i1, in %value:
   %1 = hw.array_slice %val[%c1_i2] : (!hw.array<3xi2>) -> !hw.array<2xi2>
   %2 = hw.array_concat %1, %0 : !hw.array<2xi2>, !hw.array<1xi2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_0:%.+]] = sv.array_index_inout %r[%c0_i2] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   [[FIELD_0:%.+]] = sv.array_index_inout %r[%c0_i2] : !sv.var<!hw.array<3xi2>>, i2
   // CHECK:   sv.passign [[FIELD_0]], %value : i2
   // CHECK: }
 
@@ -434,8 +435,8 @@ hw.module private @ConnectSubindices(in %clock: i1, in %reset: i1, in %value: i2
   %c2_i3 = hw.constant 2 : i3
   %c3_i3 = hw.constant 3 : i3
 
-  %r = sv.reg : !hw.inout<!hw.array<5xi2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<5xi2>>
+  %r = sv.var : !sv.var<!hw.array<5xi2>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<5xi2>>
   sv.always posedge %clock {
     sv.passign %r, %8 : !hw.array<5xi2>
   }
@@ -450,11 +451,11 @@ hw.module private @ConnectSubindices(in %clock: i1, in %reset: i1, in %value: i2
   %7 = hw.array_slice %6[%c0_i3] : (!hw.array<5xi2>) -> !hw.array<4xi2>
   %8 = hw.array_concat %1, %7 : !hw.array<1xi2>, !hw.array<4xi2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[IDX_1:%.+]] = sv.array_index_inout %r[%c1_i3] : !hw.inout<array<5xi2>>, i3
-  // CHECK:   sv.passign [[IDX_1]], %value : i2
-  // CHECK:   [[IDX_2:%.+]] = sv.array_index_inout %r[%c2_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   [[IDX_1:%.+]] = sv.array_index_inout %r[%c1_i3] : !sv.var<!hw.array<5xi2>>, i3
+  // CHECK:   sv.passign [[IDX_1:%.+]], %value : i2
+  // CHECK:   [[IDX_2:%.+]] = sv.array_index_inout %r[%c2_i3] : !sv.var<!hw.array<5xi2>>, i3
   // CHECK:   sv.passign [[IDX_2:%.+]], %value : i2
-  // CHECK:   [[IDX_4:%.+]] = sv.array_index_inout %r[%c-4_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   [[IDX_4:%.+]] = sv.array_index_inout %r[%c-4_i3] : !sv.var<!hw.array<5xi2>>, i3
   // CHECK:   sv.passign [[IDX_4]], %value : i2
   // CHECK: }
 
@@ -469,8 +470,8 @@ hw.module private @ConnectSubindices(in %clock: i1, in %reset: i1, in %value: i2
 hw.module private @ConnectSubindicesOverwrite(in %clock: i1, in %reset: i1, in %value: i2, in %value2: i2) {
   %c0_i3 = hw.constant 0 : i3
   %c2_i3 = hw.constant 2 : i3
-  %r = sv.reg : !hw.inout<!hw.array<5xi2>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<5xi2>>
+  %r = sv.var : !sv.var<!hw.array<5xi2>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<5xi2>>
   sv.always posedge %clock {
     sv.passign %r,  %10 : !hw.array<5xi2>
   }
@@ -487,7 +488,7 @@ hw.module private @ConnectSubindicesOverwrite(in %clock: i1, in %reset: i1, in %
   %9 = hw.array_slice %6[%c2_i3] : (!hw.array<5xi2>) -> !hw.array<3xi2>
   %10 = hw.array_concat %9, %8, %7 : !hw.array<3xi2>, !hw.array<1xi2>, !hw.array<1xi2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[IDX:%.+]] = sv.array_index_inout %r[%c1_i3] : !hw.inout<array<5xi2>>, i3
+  // CHECK:   [[IDX:%.+]] = sv.array_index_inout %r[%c1_i3] : !sv.var<!hw.array<5xi2>>, i3
   // CHECK:   sv.passign [[IDX]], %value2 : i2
   // CHECK: }
 
@@ -502,8 +503,8 @@ hw.module private @ConnectNestedSubindex(in %clock: i1, in %reset: i1, in %value
   %c0_i2 = hw.constant 0 : i2
   %c-2_i2 = hw.constant -2 : i2
 
-  %r = sv.reg : !hw.inout<!hw.array<3xarray<3xi2>>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<3xarray<3xi2>>>
+  %r = sv.var : !sv.var<!hw.array<3xarray<3xi2>>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<3xarray<3xi2>>>
   sv.always posedge %clock {
     sv.passign %r, %8 : !hw.array<3xarray<3xi2>>
   }
@@ -517,8 +518,8 @@ hw.module private @ConnectNestedSubindex(in %clock: i1, in %reset: i1, in %value
   %7 = hw.array_slice %val[%c-2_i2] : (!hw.array<3xarray<3xi2>>) -> !hw.array<1xarray<3xi2>>
   %8 = hw.array_concat %7, %6, %1 : !hw.array<1xarray<3xi2>>, !hw.array<1xarray<3xi2>>, !hw.array<1xarray<3xi2>>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[FIELD_INNER:%.+]] = sv.array_index_inout %r[%c1_i2] : !hw.inout<array<3xarray<3xi2>>>, i2
-  // CHECK:   [[FIELD_OUTER:%.+]] = sv.array_index_inout [[FIELD_INNER]][%c1_i2_0] : !hw.inout<array<3xi2>>, i2
+  // CHECK:   [[FIELD_INNER:%.+]] = sv.array_index_inout %r[%c1_i2] : !sv.var<!hw.array<3xarray<3xi2>>>, i2
+  // CHECK:   [[FIELD_OUTER:%.+]] = sv.array_index_inout [[FIELD_INNER]][%c1_i2_0] : !sv.var<!hw.array<3xi2>>, i2
   // CHECK:   sv.passign [[FIELD_OUTER:%.+]], %value : i2
   // CHECK: }
 
@@ -535,8 +536,8 @@ hw.module private @ConnectNestedFieldsAndIndices(in %clock: i1, in %reset: i1, i
   %c1_i2 = hw.constant 1 : i2
   %c1_i3 = hw.constant 1 : i3
 
-  %r = sv.reg : !hw.inout<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>
-  %val = sv.read_inout %r : !hw.inout<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>
+  %r = sv.var : !sv.var<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>
+  %val = sv.read_inout %r : !sv.var<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>
   sv.always posedge %clock {
     sv.passign %r,  %17 : !hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>
   }
@@ -558,10 +559,10 @@ hw.module private @ConnectNestedFieldsAndIndices(in %clock: i1, in %reset: i1, i
   %17 = hw.array_concat %16, %15, %14 : !hw.array<3xstruct<a: !hw.array<3xstruct<b: i2>>>>, !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>, !hw.array<1xstruct<a: !hw.array<3xstruct<b: i2>>>>
 
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[ARR_1:%.+]] = sv.array_index_inout %r[%c1_i3] : !hw.inout<array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>, i3
-  // CHECK:   [[STRUCT_A:%.+]] = sv.struct_field_inout [[ARR_1]]["a"] : !hw.inout<struct<a: !hw.array<3xstruct<b: i2>>>>
-  // CHECK:   [[ARR_1:%.+]] = sv.array_index_inout [[STRUCT_A]][%c1_i2] : !hw.inout<array<3xstruct<b: i2>>>, i2
-  // CHECK:   [[STRUCT_B:%.+]] = sv.struct_field_inout [[ARR_1]]["b"] : !hw.inout<struct<b: i2>>
+  // CHECK:   [[ARR_1:%.+]] = sv.array_index_inout %r[%c1_i3] : !sv.var<!hw.array<5xstruct<a: !hw.array<3xstruct<b: i2>>>>>, i3
+  // CHECK:   [[STRUCT_A:%.+]] = sv.struct_field_inout [[ARR_1]]["a"] : !sv.var<!hw.struct<a: !hw.array<3xstruct<b: i2>>>>
+  // CHECK:   [[ARR_1:%.+]] = sv.array_index_inout [[STRUCT_A]][%c1_i2] : !sv.var<!hw.array<3xstruct<b: i2>>>, i2
+  // CHECK:   [[STRUCT_B:%.+]] = sv.struct_field_inout [[ARR_1]]["b"] : !sv.var<!hw.struct<b: i2>>
   // CHECK:   sv.passign [[STRUCT_B]], %value : i2
   // CHECK: }
 
@@ -572,19 +573,19 @@ hw.module private @ConnectNestedFieldsAndIndices(in %clock: i1, in %reset: i1, i
 
 // CHECK-LABEL: hw.module private @SelfConnect
 hw.module private @SelfConnect(in %clock: i1, in %reset: i1) {
-  %r = sv.reg : !hw.inout<i2>
-  %val = sv.read_inout %r : !hw.inout<i2>
+  %r = sv.var : !sv.var<i2>
+  %val = sv.read_inout %r : !sv.var<i2>
   sv.always posedge %clock {
     sv.passign %r, %val : i2
   }
 
-  // CHECK: %r = sv.reg  : !hw.inout<i2>
+  // CHECK: %r = sv.var  : !sv.var<i2>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[READ:%.+]] = sv.read_inout %r : !hw.inout<i2>
+  // CHECK:   [[READ:%.+]] = sv.read_inout %r : !sv.var<i2>
   // CHECK:   sv.passign %r, [[READ]] : i2
   // CHECK: }
 
-  //VERILOG: reg [1:0] r;
+  //VERILOG: logic [1:0] r;
   //VERILOG: always @(posedge clock)
   //VERILOG:   r <= r;
 }
@@ -625,9 +626,9 @@ hw.module @Issue4030(in %a: i1, in %clock: i1, in %in1: !hw.array<2xi1>, out b: 
   %c0_i3 = hw.constant 0 : i3
   %false = hw.constant false
   %0 = hw.array_get %in1[%false] : !hw.array<2xi1>, i1
-  %r = sv.reg  : !hw.inout<array<5xi1>>
-  %1 = sv.array_index_inout %r[%c0_i3] : !hw.inout<array<5xi1>>, i3
-  %2 = sv.read_inout %r : !hw.inout<array<5xi1>>
+  %r = sv.var  : !sv.var<!hw.array<5xi1>>
+  %1 = sv.array_index_inout %r[%c0_i3] : !sv.var<!hw.array<5xi1>>, i3
+  %2 = sv.read_inout %r : !sv.var<!hw.array<5xi1>>
   sv.always posedge %clock {
     sv.passign %1, %0 : i1
   }

--- a/test/Dialect/SV/type-errors.mlir
+++ b/test/Dialect/SV/type-errors.mlir
@@ -1,0 +1,63 @@
+// RUN: circt-opt %s -split-input-file -verify-diagnostics
+
+hw.module @illegal_net_element() {
+  // expected-error @+1 {{invalid element for sv.net type}}
+  %x = sv.wire : !sv.net<!hw.inout<i1>>
+}
+
+// -----
+
+hw.module @illegal_var_element() {
+  // expected-error @+1 {{invalid element for sv.var type}}
+  %x = sv.var : !sv.var<!hw.inout<i1>>
+}
+
+// -----
+
+hw.module @illegal_assign(in %input : i1) {
+  // expected-note @+1 {{prior use here}}
+  %var = sv.var : !sv.var<i1>
+  // expected-error @+1 {{use of value '%var' expects different type than prior uses: '!sv.net<i1>' vs '!sv.var<i1>'}}
+  sv.assign %var, %input : i1
+}
+
+// -----
+
+hw.module @illegal_procedural_assign(in %input : i1) {
+  // expected-note @+1 {{prior use here}}
+  %net = sv.wire : !sv.net<i1>
+  sv.alwayscomb {
+    // expected-error @+1 {{use of value '%net' expects different type than prior uses: '!sv.var<i1>' vs '!sv.net<i1>'}}
+    sv.bpassign %net, %input : i1
+  }
+}
+
+// -----
+
+hw.module @illegal_alias() {
+  %net = sv.wire : !sv.net<i1>
+  %var = sv.var : !sv.var<i1>
+  // expected-error @+1 {{'sv.alias' op operand #1 must be variadic of an SV net type, but got '!sv.var<i1>'}}
+  sv.alias %net, %var : !sv.net<i1>, !sv.var<i1>
+}
+
+// -----
+
+hw.module @illegal_force(in %input : i1, in %index : i1) {
+  %array = sv.var : !sv.var<!hw.array<2xi1>>
+  %element = sv.array_index_inout %array[%index] : !sv.var<!hw.array<2xi1>>, i1
+  sv.alwayscomb {
+    // expected-error @+1 {{cannot force a memory word or bit/part-select of a variable}}
+    sv.force %element, %input : !sv.var<i1>
+  }
+}
+
+// -----
+
+hw.module @illegal_readmem() {
+  %net = sv.wire : !sv.net<!hw.uarray<8xi32>>
+  sv.initial {
+    // expected-error @+1 {{'sv.readmem' op operand #0 must be an SV variable type, but got '!sv.net<!hw.uarray<8xi32>>'}}
+    sv.readmem %net, "memory.hex", MemBaseHex : !sv.net<!hw.uarray<8xi32>>
+  }
+}

--- a/test/Dialect/SV/types.mlir
+++ b/test/Dialect/SV/types.mlir
@@ -1,0 +1,17 @@
+// RUN: circt-opt %s | FileCheck %s
+
+hw.type_scope @SVtypes{
+  hw.typedecl @net_alias : !sv.net<i8>
+  hw.typedecl @var_alias : !sv.var<i8>
+}
+
+// CHECK: !sv.net<i8>
+// CHECK: !sv.var<i8>
+// CHECK: !sv.net<!hw.array<4xi8>>
+// CHECK: !sv.var<!hw.struct<a: i8, b: i1>>
+hw.module @types() {
+  %net = sv.wire : !sv.net<i8>
+  %var = sv.var : !sv.var<i8>
+  %array = sv.wire : !sv.net<!hw.array<4xi8>>
+  %struct = sv.var : !sv.var<!hw.struct<a: i8, b: i1>>
+}

--- a/test/Dialect/Seq/clock-gate.mlir
+++ b/test/Dialect/Seq/clock-gate.mlir
@@ -1,7 +1,7 @@
 // RUN: circt-opt --lower-seq-to-sv %s | FileCheck %s
 
 // CHECK:   hw.module @cg1(in %[[VAL_0:.*]] : i1, in %[[VAL_1:.*]] : i1, out gclk : i1) {
-// CHECK:           %[[VAL_2:.*]] = sv.reg : !hw.inout<i1>
+// CHECK:           %[[VAL_2:.*]] = sv.var : !sv.var<i1>
 // CHECK:           sv.always  {
 // CHECK:             %[[VAL_3:.*]] = hw.constant true
 // CHECK:             %[[VAL_4:.*]] = comb.xor %[[VAL_0]], %[[VAL_3]] : i1
@@ -9,7 +9,7 @@
 // CHECK:               sv.passign %[[VAL_2]], %[[VAL_1]] : i1
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_5:.*]] = sv.read_inout %[[VAL_2]] : !hw.inout<i1>
+// CHECK:           %[[VAL_5:.*]] = sv.read_inout %[[VAL_2]] : !sv.var<i1>
 // CHECK:           %[[VAL_6:.*]] = comb.and %[[VAL_0]], %[[VAL_5]] : i1
 // CHECK:           hw.output %[[VAL_6]] : i1
 // CHECK:         }
@@ -20,7 +20,7 @@ hw.module @cg1(in %clk : !seq.clock, in %enable : i1, out gclk : !seq.clock) {
 
 // CHECK:   hw.module @cg2(in %[[VAL_0:.*]] : i1, in %[[VAL_1:.*]] : i1, in %[[VAL_2:.*]] : i1, out gclk : i1) {
 // CHECK:           %[[VAL_3:.*]] = comb.or %[[VAL_1]], %[[VAL_2]] : i1
-// CHECK:           %[[VAL_4:.*]] = sv.reg : !hw.inout<i1>
+// CHECK:           %[[VAL_4:.*]] = sv.var : !sv.var<i1>
 // CHECK:           sv.always  {
 // CHECK:             %[[VAL_5:.*]] = hw.constant true
 // CHECK:             %[[VAL_6:.*]] = comb.xor %[[VAL_0]], %[[VAL_5]] : i1
@@ -28,7 +28,7 @@ hw.module @cg1(in %clk : !seq.clock, in %enable : i1, out gclk : !seq.clock) {
 // CHECK:               sv.passign %[[VAL_4]], %[[VAL_3]] : i1
 // CHECK:             }
 // CHECK:           }
-// CHECK:           %[[VAL_7:.*]] = sv.read_inout %[[VAL_4]] : !hw.inout<i1>
+// CHECK:           %[[VAL_7:.*]] = sv.read_inout %[[VAL_4]] : !sv.var<i1>
 // CHECK:           %[[VAL_8:.*]] = comb.and %[[VAL_0]], %[[VAL_7]] : i1
 // CHECK:           hw.output %[[VAL_8]] : i1
 // CHECK:         }

--- a/test/Dialect/Seq/compreg.mlir
+++ b/test/Dialect/Seq/compreg.mlir
@@ -7,19 +7,19 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !hw.struct<f
   seq.compreg %i, %clk : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk reset %rst, %c0_i32  : i32
   // CHECK: %{{.+}} = seq.compreg %i, %clk : i32
-  // SV: [[REG0:%.+]] = sv.reg  : !hw.inout<i32>
-  // SV: [[REG5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
+  // SV: [[REG0:%.+]] = sv.var  : !sv.var<i32>
+  // SV: [[REG5:%.+]] = sv.read_inout [[REG0]] : !sv.var<i32>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG0]], %i : i32
   // SV: }(syncreset : posedge %rst)  {
   // SV:   sv.passign [[REG0]], %c0_i32 : i32
   // SV: }
-  // SV: [[REG1:%.+]] = sv.reg  : !hw.inout<i32>
+  // SV: [[REG1:%.+]] = sv.var  : !sv.var<i32>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG1]], %i : i32
   // SV: }
-  // ALWAYS: [[R0:%.+]] = sv.reg : !hw.inout<i32>
-  // ALWAYS: [[R0_VAL:%.+]] = sv.read_inout [[R0]] : !hw.inout<i32>
+  // ALWAYS: [[R0:%.+]] = sv.var : !sv.var<i32>
+  // ALWAYS: [[R0_VAL:%.+]] = sv.read_inout [[R0]] : !sv.var<i32>
   // ALWAYS: sv.always posedge %clk {
   // ALWAYS:   sv.if %rst {
   // ALWAYS:     sv.passign [[R0]], %c0_i32 : i32
@@ -27,7 +27,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !hw.struct<f
   // ALWAYS:     sv.passign [[R0]], %i : i32
   // ALWAYS:   }
   // ALWAYS: }
-  // ALWAYS: [[R1:%.+]] = sv.reg : !hw.inout<i32>
+  // ALWAYS: [[R1:%.+]] = sv.var : !sv.var<i32>
   // ALWAYS: sv.always posedge %clk {
   // ALWAYS:   sv.passign [[R1]], %i : i32
   // ALWAYS: }
@@ -40,18 +40,18 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !hw.struct<f
   // CHECK: %{{.+}} = seq.compreg %s, %clk : !hw.struct<foo: i32>
 
   // SV: [[REGST:%.+]] = hw.struct_create ([[REG5]]) : !hw.struct<foo: i32>
-  // SV: %foo = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<struct<foo: i32>>
+  // SV: %foo = sv.var {sv.attributes = [#sv.attribute<"dont_merge">]} : !sv.var<!hw.struct<foo: i32>>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign %foo, %s : !hw.struct<foo: i32>
   // SV: }(syncreset : posedge %rst)  {
   // SV:   sv.passign %foo, [[REGST]] : !hw.struct<foo: i32>
   // SV: }
-  // SV: [[REG4:%.+]] = sv.reg : !hw.inout<struct<foo: i32>>
+  // SV: [[REG4:%.+]] = sv.var : !sv.var<!hw.struct<foo: i32>>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.passign [[REG4]], %s : !hw.struct<foo: i32>
   // SV: }
   // ALWAYS: [[FOO_NEXT:%.+]] = hw.struct_create ([[R0_VAL]]) : !hw.struct<foo: i32>
-  // ALWAYS: %foo = sv.reg {sv.attributes = [#sv.attribute<"dont_merge">]} : !hw.inout<struct<foo: i32>>
+  // ALWAYS: %foo = sv.var {sv.attributes = [#sv.attribute<"dont_merge">]} : !sv.var<!hw.struct<foo: i32>>
   // ALWAYS: sv.always posedge %clk {
   // ALWAYS:   sv.if %rst {
   // ALWAYS:     sv.passign %foo, [[FOO_NEXT]] : !hw.struct<foo: i32>
@@ -59,7 +59,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !hw.struct<f
   // ALWAYS:     sv.passign %foo, %s : !hw.struct<foo: i32>
   // ALWAYS:   }
   // ALWAYS: }
-  // ALWAYS: [[REG4:%.+]] = sv.reg : !hw.inout<struct<foo: i32>>
+  // ALWAYS: [[REG4:%.+]] = sv.var : !sv.var<!hw.struct<foo: i32>>
   // ALWAYS: sv.always posedge %clk {
   // ALWAYS:   sv.passign [[REG4]], %s : !hw.struct<foo: i32>
   // ALWAYS: }
@@ -69,8 +69,8 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !hw.struct<f
   // CHECK: %bar = seq.compreg sym @reg1
   // CHECK: seq.compreg sym @reg2
 
-  // SV: %bar = sv.reg sym @reg1
-  // SV: sv.reg sym @reg2
+  // SV: %bar = sv.var sym @reg1
+  // SV: sv.var sym @reg2
 
   %rv = seq.initial () {
     %c0_i32_0 = hw.constant 0 : i32
@@ -80,7 +80,7 @@ hw.module @top(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !hw.struct<f
   %c0_i32 = hw.constant 0 : i32
 
   %withinitial = seq.compreg sym @withinitial %i, %clk reset %rst, %c0_i32 initial %rv : i32
-  // SV: %withinitial = sv.reg init %{{c0_i32.*}} sym @withinitial : !hw.inout<i32>
+  // SV: %withinitial = sv.var init %{{c0_i32.*}} sym @withinitial : !sv.var<i32>
 }
 
 hw.module @top_ce(in %clk: !seq.clock, in %rst: i1, in %ce: i1, in %i: i32) {
@@ -92,8 +92,8 @@ hw.module @top_ce(in %clk: !seq.clock, in %rst: i1, in %ce: i1, in %i: i32) {
 
   %r0 = seq.compreg.ce %i, %clk, %ce reset %rst, %rv : i32
   // CHECK: %r0 = seq.compreg.ce %i, %clk, %ce reset %rst, %c0_i32  : i32
-  // SV: [[REG_CE0:%.+]] = sv.reg  : !hw.inout<i32>
-  // SV: [[REG_CE5:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i32>
+  // SV: [[REG_CE0:%.+]] = sv.var  : !sv.var<i32>
+  // SV: [[REG_CE5:%.+]] = sv.read_inout [[REG0]] : !sv.var<i32>
   // SV: sv.alwaysff(posedge %clk)  {
   // SV:   sv.if %ce {
   // SV:     sv.passign [[REG_CE0]], %i : i32
@@ -101,8 +101,8 @@ hw.module @top_ce(in %clk: !seq.clock, in %rst: i1, in %ce: i1, in %i: i32) {
   // SV: }(syncreset : posedge %rst)  {
   // SV:   sv.passign [[REG_CE0]], %c0_i32 : i32
   // SV: }
-  // ALWAYS: [[R0:%.+]] = sv.reg : !hw.inout<i32>
-  // ALWAYS: [[R0_VAL:%.+]] = sv.read_inout [[R0]] : !hw.inout<i32>
+  // ALWAYS: [[R0:%.+]] = sv.var : !sv.var<i32>
+  // ALWAYS: [[R0_VAL:%.+]] = sv.read_inout [[R0]] : !sv.var<i32>
   // ALWAYS: sv.always posedge %clk {
   // ALWAYS:   sv.if %rst {
   // ALWAYS:     sv.passign [[R0]], %c0_i32 : i32
@@ -114,20 +114,20 @@ hw.module @top_ce(in %clk: !seq.clock, in %rst: i1, in %ce: i1, in %i: i32) {
   // ALWAYS: }
 
   %withinitial = seq.compreg.ce sym @withinitial %i, %clk, %ce reset %rst, %rv initial %init : i32
-  // SV: %withinitial = sv.reg init %{{c0_i32.*}} sym @withinitial : !hw.inout<i32>
+  // SV: %withinitial = sv.var init %{{c0_i32.*}} sym @withinitial : !sv.var<i32>
 }
 
 // SV-LABEL: @reg_of_clock_type
 hw.module @reg_of_clock_type(in %clk: !seq.clock, in %rst: i1, in %i: !seq.clock, out out: !seq.clock) {
-  // SV: [[REG0:%.+]] = sv.reg : !hw.inout<i1>
-  // SV: [[REG0_VAL:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i1>
+  // SV: [[REG0:%.+]] = sv.var : !sv.var<i1>
+  // SV: [[REG0_VAL:%.+]] = sv.read_inout [[REG0]] : !sv.var<i1>
   // SV: sv.alwaysff(posedge %clk) {
   // SV:   sv.passign [[REG0]], %i : i1
   // SV: }
   %r0 = seq.compreg %i, %clk : !seq.clock
 
-  // SV: [[REG1:%.+]] = sv.reg : !hw.inout<i1>
-  // SV: [[REG1_VAL:%.+]] = sv.read_inout [[REG1]] : !hw.inout<i1>
+  // SV: [[REG1:%.+]] = sv.var : !sv.var<i1>
+  // SV: [[REG1_VAL:%.+]] = sv.read_inout [[REG1]] : !sv.var<i1>
   // SV: sv.alwaysff(posedge %clk) {
   // SV:   sv.passign [[REG1]], [[REG0_VAL]] : i1
   // SV: }
@@ -156,14 +156,14 @@ hw.module @init_with_call(in %clk: !seq.clock, in %rst: i1, in %i: i32, in %s: !
     seq.yield %0 : i32
   } : (!seq.immutable<i32>) -> !seq.immutable<i32>
 
-  // SV: %reg = sv.reg : !hw.inout<i32>
+  // SV: %reg = sv.var : !sv.var<i32>
   %c0_i32 = hw.constant 0 : i32
 
   %reg = seq.compreg %i, %clk initial %init : i32
   %reg2 = seq.compreg %i, %clk initial %add : i32
 
   %add_from_immut = seq.from_immutable %add: (!seq.immutable<i32>) -> i32
-  // SV:  [[REG]] = sv.reg
+  // SV:  [[REG]] = sv.var
   // SV-NEXT: [[RESULT:%.+]] = sv.read_inout [[REG]]
   // SV-NEXT: hw.output [[RESULT]]
 

--- a/test/Dialect/Seq/dividers.mlir
+++ b/test/Dialect/Seq/dividers.mlir
@@ -15,19 +15,19 @@ hw.module @divide_by_0(in %clock: !seq.clock, out by_2: !seq.clock) {
 // CHECK-LABEL: @divide_by_2
 hw.module @divide_by_2(in %clock: !seq.clock, out by_2: !seq.clock) {
 
-  // CHECK: [[REGISTER:%.+]] = sv.reg
+  // CHECK: [[REGISTER:%.+]] = sv.var
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[READ_ALWAYS:%.+]] = sv.read_inout [[REGISTER]] : !hw.inout<i1>
+  // CHECK:   [[READ_ALWAYS:%.+]] = sv.read_inout [[REGISTER]] : !sv.var<i1>
   // CHECK:   [[INVERTED:%.+]] = comb.xor [[READ_ALWAYS]], %true : i1
   // CHECK:   sv.bpassign [[REGISTER]], [[INVERTED]] : i1
   // CHECK: }
-  // CHECK: [[READ_OUTPUT:%.+]] = sv.read_inout [[REGISTER]] : !hw.inout<i1>
+  // CHECK: [[READ_OUTPUT:%.+]] = sv.read_inout [[REGISTER]] : !sv.var<i1>
   // CHECK: sv.initial {
   // CHECK:   sv.bpassign [[REGISTER]], %false : i1
   // CHECK: }
   // CHECK: hw.output [[READ_OUTPUT]] : i1
 
-  // VERILOG: reg clock_out_0;
+  // VERILOG: logic clock_out_0;
   // VERILOG: always @(posedge clock)
   // VERILOG:   clock_out_0 = ~clock_out_0;
   // VERILOG: assign by_2 = clock_out_0;
@@ -39,27 +39,27 @@ hw.module @divide_by_2(in %clock: !seq.clock, out by_2: !seq.clock) {
 // VERILOG-LABEL: module divide_by_8
 // CHECK-LABEL: @divide_by_8
 hw.module @divide_by_8(in %clock: !seq.clock, out by_8: !seq.clock) {
-  // CHECK: [[REGISTER_0:%.+]] = sv.reg : !hw.inout<i1>
+  // CHECK: [[REGISTER_0:%.+]] = sv.var : !sv.var<i1>
   // CHECK: sv.always posedge %clock {
-  // CHECK:   [[REGISTER_0_READ:%.+]] = sv.read_inout [[REGISTER_0]] : !hw.inout<i1>
+  // CHECK:   [[REGISTER_0_READ:%.+]] = sv.read_inout [[REGISTER_0]] : !sv.var<i1>
   // CHECK:   [[INVERTED_0:%.+]] = comb.xor [[REGISTER_0_READ]], %true : i1
   // CHECK:   sv.bpassign [[REGISTER_0]], [[INVERTED_0]] : i1
   // CHECK: }
-  // CHECK: [[REGISTER_0_OUT:%.+]] = sv.read_inout [[REGISTER_0]] : !hw.inout<i1>
-  // CHECK: [[REGISTER_1:%.+]] = sv.reg : !hw.inout<i1>
+  // CHECK: [[REGISTER_0_OUT:%.+]] = sv.read_inout [[REGISTER_0]] : !sv.var<i1>
+  // CHECK: [[REGISTER_1:%.+]] = sv.var : !sv.var<i1>
   // CHECK: sv.always posedge [[REGISTER_0_OUT]] {
-  // CHECK:   [[REGISTER_1_READ:%.+]] = sv.read_inout [[REGISTER_1]] : !hw.inout<i1>
+  // CHECK:   [[REGISTER_1_READ:%.+]] = sv.read_inout [[REGISTER_1]] : !sv.var<i1>
   // CHECK:   [[INVERTED_1:%.+]] = comb.xor [[REGISTER_1_READ]], %true : i1
   // CHECK:   sv.bpassign [[REGISTER_1]], [[INVERTED_1]] : i1
   // CHECK: }
-  // CHECK: [[REGISTER_1_OUT:%.+]] = sv.read_inout [[REGISTER_1]] : !hw.inout<i1>
-  // CHECK: [[REGISTER_2:%.+]] = sv.reg : !hw.inout<i1>
+  // CHECK: [[REGISTER_1_OUT:%.+]] = sv.read_inout [[REGISTER_1]] : !sv.var<i1>
+  // CHECK: [[REGISTER_2:%.+]] = sv.var : !sv.var<i1>
   // CHECK: sv.always posedge [[REGISTER_1_OUT]] {
-  // CHECK:   [[REGISTER_2_READ:%.+]] = sv.read_inout [[REGISTER_2]] : !hw.inout<i1>
+  // CHECK:   [[REGISTER_2_READ:%.+]] = sv.read_inout [[REGISTER_2]] : !sv.var<i1>
   // CHECK:   [[INVERTED_2:%.+]] = comb.xor [[REGISTER_2_READ]], %true : i1
   // CHECK:   sv.bpassign [[REGISTER_2]], [[INVERTED_2]] : i1
   // CHECK: }
-  // CHECK: [[REGISTER_2_OUT:%.+]] = sv.read_inout [[REGISTER_2]] : !hw.inout<i1>
+  // CHECK: [[REGISTER_2_OUT:%.+]] = sv.read_inout [[REGISTER_2]] : !sv.var<i1>
   // CHECK: sv.initial {
   // CHECK:   sv.bpassign [[REGISTER_0]], %false : i1
   // CHECK:   sv.bpassign [[REGISTER_1]], %false : i1
@@ -67,13 +67,13 @@ hw.module @divide_by_8(in %clock: !seq.clock, out by_8: !seq.clock) {
   // CHECK: }
   // CHECK: hw.output [[REGISTER_2_OUT]] : i1
 
-  // VERILOG: reg clock_out_0;
+  // VERILOG: logic clock_out_0;
   // VERILOG: always @(posedge clock)
   // VERILOG:   clock_out_0 = ~clock_out_0;
-  // VERILOG: reg clock_out_1;
+  // VERILOG: logic clock_out_1;
   // VERILOG: always @(posedge clock_out_0)
   // VERILOG:   clock_out_1 = ~clock_out_1;
-  // VERILOG: reg clock_out_2;
+  // VERILOG: logic clock_out_2;
   // VERILOG: always @(posedge clock_out_1)
   // VERILOG:   clock_out_2 = ~clock_out_2;
   // VERILOG: initial begin
@@ -86,4 +86,3 @@ hw.module @divide_by_8(in %clock: !seq.clock, out by_8: !seq.clock) {
   %by_8 = seq.clock_div %clock by 3
   hw.output %by_8 : !seq.clock
 }
-

--- a/test/Dialect/Seq/firreg.mlir
+++ b/test/Dialect/Seq/firreg.mlir
@@ -20,34 +20,34 @@ hw.module @fragment_ref(in %clk : !seq.clock) attributes {emit.fragments = [@Som
 hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i32, out b : i32, out c : i32, out d : i32, out e : i32, out f : i32) {
   %cst0 = hw.constant 0 : i32
 
-  // CHECK: %rA = sv.reg sym @regA : !hw.inout<i32>
-  // CHECK: [[VAL_A:%.+]] = sv.read_inout %rA : !hw.inout<i32>
+  // CHECK: %rA = sv.var sym @regA : !sv.var<i32>
+  // CHECK: [[VAL_A:%.+]] = sv.read_inout %rA : !sv.var<i32>
   %rA = seq.firreg %in clock %clk sym @regA : i32
 
-  // CHECK: %rB = sv.reg sym @regB : !hw.inout<i32>
-  // CHECK: [[VAL_B:%.+]] = sv.read_inout %rB : !hw.inout<i32>
+  // CHECK: %rB = sv.var sym @regB : !sv.var<i32>
+  // CHECK: [[VAL_B:%.+]] = sv.read_inout %rB : !sv.var<i32>
   %rB = seq.firreg %in clock %clk sym @regB reset sync %rst, %cst0 : i32
 
-  // CHECK: %rC = sv.reg sym @regC : !hw.inout<i32>
-  // CHECK: [[VAL_C:%.+]] = sv.read_inout %rC : !hw.inout<i32>
+  // CHECK: %rC = sv.var sym @regC : !sv.var<i32>
+  // CHECK: [[VAL_C:%.+]] = sv.read_inout %rC : !sv.var<i32>
   %rC = seq.firreg %in clock %clk sym @regC reset async %rst, %cst0 : i32
 
-  // CHECK: %rD = sv.reg sym @regD : !hw.inout<i32>
-  // CHECK: [[VAL_D:%.+]] = sv.read_inout %rD : !hw.inout<i32>
+  // CHECK: %rD = sv.var sym @regD : !sv.var<i32>
+  // CHECK: [[VAL_D:%.+]] = sv.read_inout %rD : !sv.var<i32>
   %rD = seq.firreg %in clock %clk sym @regD : i32
 
-  // CHECK: %rE = sv.reg sym @regE : !hw.inout<i32>
-  // CHECK: [[VAL_E:%.+]] = sv.read_inout %rE : !hw.inout<i32>
+  // CHECK: %rE = sv.var sym @regE : !sv.var<i32>
+  // CHECK: [[VAL_E:%.+]] = sv.read_inout %rE : !sv.var<i32>
   %rE = seq.firreg %in clock %clk sym @regE reset sync %rst, %cst0 : i32
 
-  // CHECK: %rF = sv.reg sym @regF : !hw.inout<i32>
-  // CHECK: [[VAL_F:%.+]] = sv.read_inout %rF : !hw.inout<i32>
+  // CHECK: %rF = sv.var sym @regF : !sv.var<i32>
+  // CHECK: [[VAL_F:%.+]] = sv.read_inout %rF : !sv.var<i32>
   %rF = seq.firreg %in clock %clk sym @regF reset async %rst, %cst0 : i32
 
-  // CHECK: %rGnamed = sv.reg sym @regG : !hw.inout<i32>
+  // CHECK: %rGnamed = sv.var sym @regG : !sv.var<i32>
   %r = seq.firreg %in clock %clk sym @regG { "name" = "rGnamed" }: i32
 
-  // CHECK: %rNoSym = sv.reg : !hw.inout<i32>
+  // CHECK: %rNoSym = sv.var : !sv.var<i32>
   %rNoSym = seq.firreg %in clock %clk : i32
 
   // CHECK:      sv.always posedge %clk {
@@ -127,36 +127,36 @@ hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i3
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
-  // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<8xi32>>
+  // CHECK-NEXT:         %_RANDOM = sv.var : !sv.var<!hw.uarray<8xi32>>
   // CHECK-NEXT:         sv.for %i = %c0_i4 to %c-8_i4 step %c1_i4 : i4 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %24 = comb.extract %i from 0 : (i4) -> i3
-  // CHECK-NEXT:           %25 = sv.array_index_inout %_RANDOM[%24] : !hw.inout<uarray<8xi32>>, i3
+  // CHECK-NEXT:           %25 = sv.array_index_inout %_RANDOM[%24] : !sv.var<!hw.uarray<8xi32>>, i3
   // CHECK-NEXT:           sv.bpassign %25, %RANDOM : i32
   // CHECK-NEXT:         }
-  // CHECK-NEXT:         %8 = sv.array_index_inout %_RANDOM[%c0_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %9 = sv.array_index_inout %_RANDOM[%c1_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %10 = sv.array_index_inout %_RANDOM[%c2_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %11 = sv.array_index_inout %_RANDOM[%c3_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %12 = sv.array_index_inout %_RANDOM[%c-4_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %13 = sv.array_index_inout %_RANDOM[%c-3_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %14 = sv.array_index_inout %_RANDOM[%c-2_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %15 = sv.array_index_inout %_RANDOM[%c-1_i3] : !hw.inout<uarray<8xi32>>, i3
-  // CHECK-NEXT:         %16 = sv.read_inout %8 : !hw.inout<i32>
+  // CHECK-NEXT:         %8 = sv.array_index_inout %_RANDOM[%c0_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %9 = sv.array_index_inout %_RANDOM[%c1_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %10 = sv.array_index_inout %_RANDOM[%c2_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %11 = sv.array_index_inout %_RANDOM[%c3_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %12 = sv.array_index_inout %_RANDOM[%c-4_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %13 = sv.array_index_inout %_RANDOM[%c-3_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %14 = sv.array_index_inout %_RANDOM[%c-2_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %15 = sv.array_index_inout %_RANDOM[%c-1_i3] : !sv.var<!hw.uarray<8xi32>>, i3
+  // CHECK-NEXT:         %16 = sv.read_inout %8 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rA, %16 : i32
-  // CHECK-NEXT:         %17 = sv.read_inout %9 : !hw.inout<i32>
+  // CHECK-NEXT:         %17 = sv.read_inout %9 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rB, %17 : i32
-  // CHECK-NEXT:         %18 = sv.read_inout %10 : !hw.inout<i32>
+  // CHECK-NEXT:         %18 = sv.read_inout %10 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rC, %18 : i32
-  // CHECK-NEXT:         %19 = sv.read_inout %11 : !hw.inout<i32>
+  // CHECK-NEXT:         %19 = sv.read_inout %11 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rD, %19 : i32
-  // CHECK-NEXT:         %20 = sv.read_inout %12 : !hw.inout<i32>
+  // CHECK-NEXT:         %20 = sv.read_inout %12 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rE, %20 : i32
-  // CHECK-NEXT:         %21 = sv.read_inout %13 : !hw.inout<i32>
+  // CHECK-NEXT:         %21 = sv.read_inout %13 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rF, %21 : i32
-  // CHECK-NEXT:         %22 = sv.read_inout %14 : !hw.inout<i32>
+  // CHECK-NEXT:         %22 = sv.read_inout %14 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rGnamed, %22 : i32
-  // CHECK-NEXT:         %23 = sv.read_inout %15 : !hw.inout<i32>
+  // CHECK-NEXT:         %23 = sv.read_inout %15 : !sv.var<i32>
   // CHECK-NEXT:         sv.bpassign %rNoSym, %23 : i32
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.if %rst {
@@ -178,8 +178,8 @@ hw.module @lowering(in %clk : !seq.clock, in %rst : i1, in %in : i32, out a : i3
 hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond : i1, in %value : i2) {
   // CHECK: %c0_i2 = hw.constant 0 : i2
   %c0_i2 = hw.constant 0 : i2
-  // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
-  // CHECK-NEXT: %0 = sv.read_inout %count : !hw.inout<i2>
+  // CHECK-NEXT: %count = sv.var sym @count : !sv.var<i2>
+  // CHECK-NEXT: %0 = sv.read_inout %count : !sv.var<i2>
   // CHECK-NEXT: %1 = comb.mux bin %cond, %value, %0 : i2
   // CHECK-NEXT: %2 = comb.mux bin %reset, %c0_i2, %1 : i2
   // CHECK-NEXT: sv.always posedge %clock {
@@ -208,15 +208,15 @@ hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond :
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
-  // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
+  // CHECK-NEXT:         %_RANDOM = sv.var : !sv.var<!hw.uarray<1xi32>>
   // CHECK:              sv.for %i = %{{false.*}} to %{{true.*}} step %{{true.*}} : i1 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %6 = comb.extract %i from 0 : (i1) -> i0
-  // CHECK-NEXT:           %7 = sv.array_index_inout %_RANDOM[%6] : !hw.inout<uarray<1xi32>>, i0
+  // CHECK-NEXT:           %7 = sv.array_index_inout %_RANDOM[%6] : !sv.var<!hw.uarray<1xi32>>, i0
   // CHECK-NEXT:           sv.bpassign %7, %RANDOM : i32
   // CHECK-NEXT:         }
-  // CHECK-NEXT:         %3 = sv.array_index_inout %_RANDOM[%c0_i0] : !hw.inout<uarray<1xi32>>, i0
-  // CHECK-NEXT:         %4 = sv.read_inout %3 : !hw.inout<i32>
+  // CHECK-NEXT:         %3 = sv.array_index_inout %_RANDOM[%c0_i0] : !sv.var<!hw.uarray<1xi32>>, i0
+  // CHECK-NEXT:         %4 = sv.read_inout %3 : !sv.var<i32>
   // CHECK-NEXT:         %5 = comb.extract %4 from 0 : (i32) -> i2
   // CHECK-NEXT:         sv.bpassign %count, %5 : i2
   // CHECK-NEXT:       }
@@ -235,8 +235,8 @@ hw.module private @UninitReg1(in %clock : !seq.clock, in %reset : i1, in %cond :
 hw.module private @UninitReg1_nonbin(in %clock : !seq.clock, in %reset : i1, in %cond : i1, in %value : i2) {
   // CHECK: %c0_i2 = hw.constant 0 : i2
   %c0_i2 = hw.constant 0 : i2
-  // CHECK-NEXT: %count = sv.reg sym @count : !hw.inout<i2>
-  // CHECK-NEXT: %0 = sv.read_inout %count : !hw.inout<i2>
+  // CHECK-NEXT: %count = sv.var sym @count : !sv.var<i2>
+  // CHECK-NEXT: %0 = sv.read_inout %count : !sv.var<i2>
   // CHECK-NEXT: %1 = comb.mux %cond, %value, %0 : i2
   // CHECK-NEXT: %2 = comb.mux %reset, %c0_i2, %1 : i2
   // CHECK-NEXT: sv.always posedge %clock {
@@ -279,12 +279,12 @@ hw.module private @InitReg1(in %clock: !seq.clock, in %reset: i1, in %io_d: i32,
   %4 = comb.mux bin %io_en, %io_d, %3 : i32
 
   // DISABLED-NOT: sv.ifdef.procedural @RANDOMIZE_REG
-  // COMMON:       %reg = sv.reg sym @[[reg_sym:.+]] : !hw.inout<i32>
-  // COMMON-NEXT:  %0 = sv.read_inout %reg : !hw.inout<i32>
-  // COMMON-NEXT:  %reg2 = sv.reg sym @[[reg2_sym:.+]] : !hw.inout<i32>
-  // COMMON-NEXT:  %1 = sv.read_inout %reg2 : !hw.inout<i32>
-  // COMMON-NEXT:  %reg3 = sv.reg sym @[[reg3_sym:.+]] : !hw.inout<i32
-  // COMMON-NEXT:  %2 = sv.read_inout %reg3 : !hw.inout<i32>
+  // COMMON:       %reg = sv.var sym @[[reg_sym:.+]] : !sv.var<i32>
+  // COMMON-NEXT:  %0 = sv.read_inout %reg : !sv.var<i32>
+  // COMMON-NEXT:  %reg2 = sv.var sym @[[reg2_sym:.+]] : !sv.var<i32>
+  // COMMON-NEXT:  %1 = sv.read_inout %reg2 : !sv.var<i32>
+  // COMMON-NEXT:  %reg3 = sv.var sym @[[reg3_sym:.+]] : !sv.var<i32
+  // COMMON-NEXT:  %2 = sv.read_inout %reg3 : !sv.var<i32>
   // COMMON-NEXT:  %3 = comb.concat %false, %0 : i1, i32
   // COMMON-NEXT:  %4 = comb.concat %false, %1 : i1, i32
   // COMMON-NEXT:  %5 = comb.add %3, %4 : i33
@@ -315,20 +315,20 @@ hw.module private @InitReg1(in %clock: !seq.clock, in %reset: i1, in %io_d: i32,
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
-  // CHECK-NEXT:          %_RANDOM = sv.logic : !hw.inout<uarray<3xi32>>
+  // CHECK-NEXT:          %_RANDOM = sv.var : !sv.var<!hw.uarray<3xi32>>
   // CHECK-NEXT:          sv.for %i = %c0_i2 to %c-1_i2 step %c1_i2 : i2 {
   // CHECK-NEXT:            %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
-  // CHECK-NEXT:            %14 = sv.array_index_inout %_RANDOM[%i] : !hw.inout<uarray<3xi32>>, i2
+  // CHECK-NEXT:            %14 = sv.array_index_inout %_RANDOM[%i] : !sv.var<!hw.uarray<3xi32>>, i2
   // CHECK-NEXT:            sv.bpassign %14, %RANDOM : i32
   // CHECK-NEXT:          }
-  // CHECK-NEXT:          %8 = sv.array_index_inout %_RANDOM[%c0_i2] : !hw.inout<uarray<3xi32>>, i2
-  // CHECK-NEXT:          %9 = sv.array_index_inout %_RANDOM[%c1_i2] : !hw.inout<uarray<3xi32>>, i2
-  // CHECK-NEXT:          %10 = sv.array_index_inout %_RANDOM[%c-2_i2] : !hw.inout<uarray<3xi32>>, i2
-  // CHECK-NEXT:          %11 = sv.read_inout %8 : !hw.inout<i32>
+  // CHECK-NEXT:          %8 = sv.array_index_inout %_RANDOM[%c0_i2] : !sv.var<!hw.uarray<3xi32>>, i2
+  // CHECK-NEXT:          %9 = sv.array_index_inout %_RANDOM[%c1_i2] : !sv.var<!hw.uarray<3xi32>>, i2
+  // CHECK-NEXT:          %10 = sv.array_index_inout %_RANDOM[%c-2_i2] : !sv.var<!hw.uarray<3xi32>>, i2
+  // CHECK-NEXT:          %11 = sv.read_inout %8 : !sv.var<i32>
   // CHECK-NEXT:          sv.bpassign %reg, %11 : i32
-  // CHECK-NEXT:          %12 = sv.read_inout %9 : !hw.inout<i32>
+  // CHECK-NEXT:          %12 = sv.read_inout %9 : !sv.var<i32>
   // CHECK-NEXT:          sv.bpassign %reg2, %12 : i32
-  // CHECK-NEXT:          %13 = sv.read_inout %10 : !hw.inout<i32>
+  // CHECK-NEXT:          %13 = sv.read_inout %10 : !sv.var<i32>
   // CHECK-NEXT:          sv.bpassign %reg3, %13 : i32
   // CHECK-NEXT:       }
   // COMMON-NEXT:      sv.if %reset {
@@ -353,7 +353,7 @@ hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i
   %1 = comb.mux %reset, %c0_i42, %0 : i42
 
   // DISABLED-NOT: sv.ifdef.procedural @RANDOMIZE_REG
-  // CHECK:      %count = sv.reg sym @count : !hw.inout<i42>
+  // CHECK:      %count = sv.var sym @count : !sv.var<i42>
   // CHECK:      sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
   // CHECK-NEXT:     sv.ifdef @FIRRTL_BEFORE_INITIAL {
@@ -364,17 +364,17 @@ hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
-  // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<2xi32>>
+  // CHECK-NEXT:         %_RANDOM = sv.var : !sv.var<!hw.uarray<2xi32>>
   // CHECK-NEXT:         sv.for %i = %c0_i2 to %c-2_i2 step %c1_i2 : i2 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %9 = comb.extract %i from 0 : (i2) -> i1
-  // CHECK-NEXT:           %10 = sv.array_index_inout %_RANDOM[%9] : !hw.inout<uarray<2xi32>>, i1
+  // CHECK-NEXT:           %10 = sv.array_index_inout %_RANDOM[%9] : !sv.var<!hw.uarray<2xi32>>, i1
   // CHECK-NEXT:           sv.bpassign %10, %RANDOM : i32
   // CHECK-NEXT:         }
-  // CHECK-NEXT:         %3 = sv.array_index_inout %_RANDOM[%false] : !hw.inout<uarray<2xi32>>, i1
-  // CHECK-NEXT:         %4 = sv.array_index_inout %_RANDOM[%true] : !hw.inout<uarray<2xi32>>, i1
-  // CHECK-NEXT:         %5 = sv.read_inout %3 : !hw.inout<i32>
-  // CHECK-NEXT:         %6 = sv.read_inout %4 : !hw.inout<i32>
+  // CHECK-NEXT:         %3 = sv.array_index_inout %_RANDOM[%false] : !sv.var<!hw.uarray<2xi32>>, i1
+  // CHECK-NEXT:         %4 = sv.array_index_inout %_RANDOM[%true] : !sv.var<!hw.uarray<2xi32>>, i1
+  // CHECK-NEXT:         %5 = sv.read_inout %3 : !sv.var<i32>
+  // CHECK-NEXT:         %6 = sv.read_inout %4 : !sv.var<i32>
   // CHECK-NEXT:         %7 = comb.extract %6 from 0 : (i32) -> i10
   // CHECK-NEXT:         %8 = comb.concat %5, %7 : i32, i10
   // CHECK-NEXT:         sv.bpassign %count, %8 : i42
@@ -393,7 +393,7 @@ hw.module private @UninitReg42(in %clock: !seq.clock, in %reset: i1, in %cond: i
 hw.module private @init1DVector(in %clock: !seq.clock, in %a: !hw.array<2xi1>, out b: !hw.array<2xi1>) {
   %r = seq.firreg %a clock %clock sym @__r__ : !hw.array<2xi1>
 
-  // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
+  // CHECK:      %r = sv.var sym @[[r_sym:[_A-Za-z0-9]+]]
 
   // CHECK:      sv.always posedge %clock  {
   // CHECK-NEXT:   sv.passign %r, %a : !hw.array<2xi1>
@@ -410,20 +410,20 @@ hw.module private @init1DVector(in %clock: !seq.clock, in %a: !hw.array<2xi1>, o
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
-  // CHECK-NEXT:       %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
+  // CHECK-NEXT:       %_RANDOM = sv.var : !sv.var<!hw.uarray<1xi32>>
   // CHECK-NEXT:       sv.for %i = %false to %true step %true : i1 {
   // CHECK-NEXT:         %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:         %8 = comb.extract %i from 0 : (i1) -> i0
-  // CHECK-NEXT:         %9 = sv.array_index_inout %_RANDOM[%8] : !hw.inout<uarray<1xi32>>, i0
+  // CHECK-NEXT:         %9 = sv.array_index_inout %_RANDOM[%8] : !sv.var<!hw.uarray<1xi32>>, i0
   // CHECK-NEXT:         sv.bpassign %9, %RANDOM : i32
   // CHECK-NEXT:       }
-  // CHECK-NEXT:       %1 = sv.array_index_inout %_RANDOM[%c0_i0] : !hw.inout<uarray<1xi32>>, i0
-  // CHECK-NEXT:       %2 = sv.read_inout %1 : !hw.inout<i32>
+  // CHECK-NEXT:       %1 = sv.array_index_inout %_RANDOM[%c0_i0] : !sv.var<!hw.uarray<1xi32>>, i0
+  // CHECK-NEXT:       %2 = sv.read_inout %1 : !sv.var<i32>
   // CHECK-NEXT:       %3 = comb.extract %2 from 0 : (i32) -> i2
-  // CHECK-NEXT:       %4 = sv.array_index_inout %r[%false] : !hw.inout<array<2xi1>>, i1
+  // CHECK-NEXT:       %4 = sv.array_index_inout %r[%false] : !sv.var<!hw.array<2xi1>>, i1
   // CHECK-NEXT:       %5 = comb.extract %3 from 1 : (i2) -> i1
   // CHECK-NEXT:       sv.bpassign %4, %5 : i1
-  // CHECK-NEXT:       %6 = sv.array_index_inout %r[%true] : !hw.inout<array<2xi1>>, i1
+  // CHECK-NEXT:       %6 = sv.array_index_inout %r[%true] : !sv.var<!hw.array<2xi1>>, i1
   // CHECK-NEXT:       %7 = comb.extract %3 from 0 : (i2) -> i1
   // CHECK-NEXT:       sv.bpassign %6, %7 : i1
 
@@ -457,18 +457,18 @@ hw.module private @init2DVector(in %clock: !seq.clock, in %a: !hw.array<1xarray<
   // CHECK-NEXT:         sv.verbatim "`INIT_RANDOM_PROLOG_"
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
-  // CHECK-NEXT:         %_RANDOM = sv.logic : !hw.inout<uarray<1xi32>>
+  // CHECK-NEXT:         %_RANDOM = sv.var : !sv.var<!hw.uarray<1xi32>>
   // CHECK-NEXT:         sv.for %i = %false to %true step %true : i1 {
   // CHECK-NEXT:           %RANDOM = sv.macro.ref.expr.se @RANDOM() : () -> i32
   // CHECK-NEXT:           %6 = comb.extract %i from 0 : (i1) -> i0
-  // CHECK-NEXT:           %7 = sv.array_index_inout %_RANDOM[%6] : !hw.inout<uarray<1xi32>>, i0
+  // CHECK-NEXT:           %7 = sv.array_index_inout %_RANDOM[%6] : !sv.var<!hw.uarray<1xi32>>, i0
   // CHECK-NEXT:           sv.bpassign %7, %RANDOM : i32
   // CHECK-NEXT:         }
-  // CHECK-NEXT:         %1 = sv.array_index_inout %_RANDOM[%c0_i0] : !hw.inout<uarray<1xi32>>, i0
-  // CHECK-NEXT:         %2 = sv.read_inout %1 : !hw.inout<i32>
+  // CHECK-NEXT:         %1 = sv.array_index_inout %_RANDOM[%c0_i0] : !sv.var<!hw.uarray<1xi32>>, i0
+  // CHECK-NEXT:         %2 = sv.read_inout %1 : !sv.var<i32>
   // CHECK-NEXT:         %3 = comb.extract %2 from 0 : (i32) -> i1
-  // CHECK-NEXT:         %4 = sv.array_index_inout %r[%c0_i0] : !hw.inout<array<1xarray<1xi1>>>, i0
-  // CHECK-NEXT:         %5 = sv.array_index_inout %4[%c0_i0] : !hw.inout<array<1xi1>>, i0
+  // CHECK-NEXT:         %4 = sv.array_index_inout %r[%c0_i0] : !sv.var<!hw.array<1xarray<1xi1>>>, i0
+  // CHECK-NEXT:         %5 = sv.array_index_inout %4[%c0_i0] : !sv.var<!hw.array<1xi1>>, i0
   // CHECK-NEXT:         sv.bpassign %5, %3 : i1
   // CHECK:            }
   // CHECK-NEXT:     }
@@ -486,7 +486,7 @@ hw.module private @init2DVector(in %clock: !seq.clock, in %a: !hw.array<1xarray<
 hw.module private @initStruct(in %clock: !seq.clock) {
   %r = seq.firreg %r clock %clock sym @__r__ : !hw.struct<a: i1>
 
-  // CHECK:      %r = sv.reg sym @[[r_sym:[_A-Za-z0-9]+]]
+  // CHECK:      %r = sv.var sym @[[r_sym:[_A-Za-z0-9]+]]
   // DISABLED-NOT: sv.ifdef.procedural @RANDOMIZE_REG
   // CHECK:      sv.ifdef @ENABLE_INITIAL_REG_ {
   // CHECK-NEXT:   sv.ordered {
@@ -499,7 +499,7 @@ hw.module private @initStruct(in %clock: !seq.clock) {
   // CHECK-NEXT:       }
   // CHECK-NEXT:       sv.ifdef.procedural @RANDOMIZE_REG_INIT {
   // CHECK:              %[[EXTRACT:.*]] = comb.extract %{{.*}} from 0 : (i32) -> i1
-  // CHECK-NEXT:         %[[INOUT:.*]] = sv.struct_field_inout %r["a"] : !hw.inout<struct<a: i1>>
+  // CHECK-NEXT:         %[[INOUT:.*]] = sv.struct_field_inout %r["a"] : !sv.var<!hw.struct<a: i1>>
   // CHECK-NEXT:         sv.bpassign %[[INOUT]], %[[EXTRACT]] : i1
   // CHECK:            }
   // CHECK-NEXT:     }
@@ -517,8 +517,8 @@ hw.module private @initStruct(in %clock: !seq.clock) {
 hw.module @issue1594(in %clock: !seq.clock, in %reset: i1, in %a: i1, out b: i1) {
   %true = hw.constant true
   %false = hw.constant false
-  %reset_n = sv.wire sym @__issue1594__reset_n  : !hw.inout<i1>
-  %0 = sv.read_inout %reset_n : !hw.inout<i1>
+  %reset_n = sv.wire sym @__issue1594__reset_n  : !sv.net<i1>
+  %0 = sv.read_inout %reset_n : !sv.net<i1>
   %1 = comb.xor %reset, %true : i1
   sv.assign %reset_n, %1 : i1
   %r = seq.firreg %a clock %clock sym @__r__ reset sync %0, %false : i1
@@ -602,8 +602,8 @@ hw.module @ArrayElements(in %a: !hw.array<2xi1>, in %clock: !seq.clock, in %cond
   %5 = comb.mux bin %cond, %0, %2 : i1
   %6 = hw.array_create %5, %4 : i1
   hw.output %r : !hw.array<2xi1>
-  // CHECK:      %[[r1:.+]] = sv.array_index_inout %r[%false] : !hw.inout<array<2xi1>>, i1
-  // CHECK-NEXT: %[[r2:.+]] = sv.array_index_inout %r[%true] : !hw.inout<array<2xi1>>, i1
+  // CHECK:      %[[r1:.+]] = sv.array_index_inout %r[%false] : !sv.var<!hw.array<2xi1>>, i1
+  // CHECK-NEXT: %[[r2:.+]] = sv.array_index_inout %r[%true] : !sv.var<!hw.array<2xi1>>, i1
   // CHECK:      sv.always posedge %clock {
   // CHECK-NEXT:   sv.if %cond {
   // CHECK-NEXT:     sv.passign %[[r2]], %0 : i1
@@ -650,7 +650,7 @@ hw.module @Subaccess(in %clock: !seq.clock, in %en: i1, in %addr: i2, in %data: 
   %11 = comb.mux bin %10, %data, %2 : i32
   %12 = hw.array_create %11, %8, %5 : i32
   hw.output %r : !hw.array<3xi32>
-  // CHECK:     %[[IDX:.+]] = sv.array_index_inout %r[%addr] : !hw.inout<array<3xi32>>, i2
+  // CHECK:     %[[IDX:.+]] = sv.array_index_inout %r[%addr] : !sv.var<!hw.array<3xi32>>, i2
   // CHECK:        sv.always posedge %clock {
   // CHECK-NEXT:     sv.if %en {
   // CHECK-NEXT:       sv.passign %[[IDX]], %data : i32
@@ -711,10 +711,10 @@ hw.module @NestedSubaccess(in %clock: !seq.clock, in %en_0: i1, in %en_1: i1, in
   %31 = comb.mux bin %en_1, %27, %30 : !hw.array<3xi32>
   %32 = hw.array_create %26, %24, %22 : i32
   %33 = comb.mux bin %en_0, %31, %32 : !hw.array<3xi32>
-  // CHECK:        %[[IDX3:.+]] = sv.array_index_inout %r[%addr_2] : !hw.inout<array<3xi32>>, i2
-  // CHECK:        %[[IDX2:.+]] = sv.array_index_inout %r[%addr_1] : !hw.inout<array<3xi32>>, i2
-  // CHECK:        %[[IDX1:.+]] = sv.array_index_inout %r[%addr_0] : !hw.inout<array<3xi32>>, i2
-  // CHECK:        %[[IDX4:.+]] = sv.array_index_inout %r[%addr_3] : !hw.inout<array<3xi32>>, i2
+  // CHECK:        %[[IDX3:.+]] = sv.array_index_inout %r[%addr_2] : !sv.var<!hw.array<3xi32>>, i2
+  // CHECK:        %[[IDX2:.+]] = sv.array_index_inout %r[%addr_1] : !sv.var<!hw.array<3xi32>>, i2
+  // CHECK:        %[[IDX1:.+]] = sv.array_index_inout %r[%addr_0] : !sv.var<!hw.array<3xi32>>, i2
+  // CHECK:        %[[IDX4:.+]] = sv.array_index_inout %r[%addr_3] : !sv.var<!hw.array<3xi32>>, i2
   // CHECK:        sv.always posedge %clock {
   // CHECK-NEXT:   sv.if %en_0 {
   // CHECK-NEXT:     sv.if %en_1 {
@@ -781,15 +781,15 @@ hw.module @with_preset(
 
 // CHECK-LABEL: @reg_of_clock_type
 hw.module @reg_of_clock_type(in %clk: !seq.clock, in %rst: i1, in %i: !seq.clock, out out: !seq.clock) {
-  // CHECK: [[REG0:%.+]] = sv.reg : !hw.inout<i1>
-  // CHECK: [[REG0_READ:%.+]] = sv.read_inout [[REG0]] : !hw.inout<i1>
+  // CHECK: [[REG0:%.+]] = sv.var : !sv.var<i1>
+  // CHECK: [[REG0_READ:%.+]] = sv.read_inout [[REG0]] : !sv.var<i1>
   %r0 = seq.firreg %i clock %clk : !seq.clock
 
   // CHECK: [[WIRE:%.+]] = hw.wire [[REG0_READ]]  : i1
   %r1 = hw.wire %r0 : !seq.clock
 
-  // CHECK: [[REG2:%.+]] = sv.reg : !hw.inout<i1>
-  // CHECK: [[REG2_READ:%.+]] = sv.read_inout [[REG2]] : !hw.inout<i1>
+  // CHECK: [[REG2:%.+]] = sv.var : !sv.var<i1>
+  // CHECK: [[REG2_READ:%.+]] = sv.read_inout [[REG2]] : !sv.var<i1>
   %r2 = seq.firreg %r1 clock %clk : !seq.clock
 
   // CHECK: sv.always posedge %clk {
@@ -810,7 +810,7 @@ hw.module @reg_of_clock_type(in %clk: !seq.clock, in %rst: i1, in %i: !seq.clock
 //
 // CHECK-LABEL: @FirregClockType
 hw.module @FirregClockType(in %a : !seq.clock) {
-  // CHECK: sv.reg : !hw.inout<i1>
+  // CHECK: sv.var : !sv.var<i1>
   // CHECK: sv.read_inout
   // CHECK-NOT: seq.from_clock
   %false = hw.constant false
@@ -839,10 +839,10 @@ hw.module @FirregClockType(in %a : !seq.clock) {
 //     connect r2, buzz
 // CHECK-LABEL: @RegMuxInlining1
 hw.module @RegMuxInlining1(in %clock: !seq.clock, in %reset: i1, in %a: i1, in %b: i1, in %c: i1, in %foo: i8, in %bar: i8, in %fizz: i8, in %buzz: i8, out out: i8) {
-  // CHECK: [[REG0:%.+]] = sv.reg : !hw.inout<i8>
+  // CHECK: [[REG0:%.+]] = sv.var : !sv.var<i8>
   %r1 = seq.firreg %3 clock %clock : i8
 
-  // CHECK: [[REG1:%.+]] = sv.reg : !hw.inout<i8>
+  // CHECK: [[REG1:%.+]] = sv.var : !sv.var<i8>
   %r2 = seq.firreg %4 clock %clock : i8
 
   // CHECK: [[VALUE:%.+]] = comb.mux bin %a, %foo, %bar
@@ -879,7 +879,7 @@ hw.module @RegMuxInlining1(in %clock: !seq.clock, in %reset: i1, in %a: i1, in %
 //     connect r1, z
 // CHECK-LABEL: @RegMuxInlining2
 hw.module @RegMuxInlining2(in %clock: !seq.clock, in %reset: i1, in %a: i1, in %b: i1, in %c: i1, in %x: i8, in %y: i8, in %z: i8, out out: i8) {
-  // CHECK: [[REG0:%.+]] = sv.reg : !hw.inout<i8>
+  // CHECK: [[REG0:%.+]] = sv.var : !sv.var<i8>
   %r1 = seq.firreg %2 clock %clock : i8
 
   // CHECK: sv.always posedge %clock {
@@ -911,14 +911,14 @@ hw.module @RegMuxInlining2(in %clock: !seq.clock, in %reset: i1, in %a: i1, in %
 //   r3 <= r1
 // CHECK-LABEL: @RegMuxInlining3
 hw.module @RegMuxInlining3(in %clock: !seq.clock, in %c: i1, out out: i8) {
-  // CHECK: [[REG0:%.+]] = sv.reg : !hw.inout<i8>
+  // CHECK: [[REG0:%.+]] = sv.var : !sv.var<i8>
   // CHECK: [[REG0_READ:%.+]] = sv.read_inout [[REG0]]
   %r1 = seq.firreg %0 clock %clock : i8
 
-  // CHECK: [[REG1:%.+]] = sv.reg : !hw.inout<i8>
+  // CHECK: [[REG1:%.+]] = sv.var : !sv.var<i8>
   %r2 = seq.firreg %r1 clock %clock : i8
 
-  // CHECK: [[REG2:%.+]] = sv.reg : !hw.inout<i8>
+  // CHECK: [[REG2:%.+]] = sv.var : !sv.var<i8>
   %r3 = seq.firreg %r1 clock %clock : i8
 
   // CHECK: [[MUX:%.+]] = comb.mux
@@ -937,10 +937,10 @@ hw.module @RegMuxInlining3(in %clock: !seq.clock, in %c: i1, out out: i8) {
     %r1 = seq.firreg %mux clock %clock : i2
     %r2 = seq.firreg %mux clock %clock : i2
     hw.output %r2: i2
-    //CHECK: %r1 = sv.reg : !hw.inout<i2>
-    //CHECK: %[[V1:.+]] = sv.read_inout %r1 : !hw.inout<i2>
-    //CHECK: %r2 = sv.reg : !hw.inout<i2>
-    //CHECK: %[[V2:.+]] = sv.read_inout %r2 : !hw.inout<i2>
+    //CHECK: %r1 = sv.var : !sv.var<i2>
+    //CHECK: %[[V1:.+]] = sv.read_inout %r1 : !sv.var<i2>
+    //CHECK: %r2 = sv.var : !sv.var<i2>
+    //CHECK: %[[V2:.+]] = sv.read_inout %r2 : !sv.var<i2>
     //CHECK: sv.always posedge %clock {
     //CHECK:   sv.if %cond {
     //CHECK:     sv.passign %r2, %[[V1]] : i2
@@ -960,7 +960,7 @@ sv.macro.decl @MyMacro
 hw.module @RegUnderIfdef(in %clock : !seq.clock, in %reset : i1, in %value : i1) {
   %c = hw.constant 0 : i1
   // CHECK: sv.ifdef @MyMacro {
-  // CHECK:   %reg = sv.reg sym @reg
+  // CHECK:   %reg = sv.var sym @reg
   // CHECK:   sv.if %reset {
   // CHECK:     sv.passign %reg, %false_0 : i1
   // CHECK:   } else {
@@ -973,8 +973,8 @@ hw.module @RegUnderIfdef(in %clock : !seq.clock, in %reset : i1, in %value : i1)
 
   // CHECK: sv.initial {
   // CHECK:   sv.ifdef.procedural @MyMacro {
-  // CHECK:     %[[REG:.*]] = sv.xmr.ref @RegUnderIfdef_reg : !hw.inout<i1>
-  // CHECK:     %[[RNG:.*]] = sv.read_inout %{{.*}} : !hw.inout<i32>
+  // CHECK:     %[[REG:.*]] = sv.xmr.ref @RegUnderIfdef_reg : !sv.var<i1>
+  // CHECK:     %[[RNG:.*]] = sv.read_inout %{{.*}} : !sv.var<i32>
   // CHECK:     %[[VAL:.*]] = comb.extract %[[RNG]] from 0 : (i32) -> i1
   // CHECK:     sv.bpassign %[[REG]], %[[VAL]] : i1
   // CHECK:   }
@@ -991,7 +991,7 @@ hw.module @RegUnderIfdefElse(in %clock : !seq.clock, in %reset : i1, in %value :
 
   // CHECK: sv.ifdef @MyMacro {
   // CHECK: } else {
-  // CHECK:   %reg = sv.reg sym @reg
+  // CHECK:   %reg = sv.var sym @reg
   // CHECK:   sv.if %reset {
   // CHECK:     sv.passign %reg, %false_0 : i1
   // CHECK:   } else {
@@ -1006,8 +1006,8 @@ hw.module @RegUnderIfdefElse(in %clock : !seq.clock, in %reset : i1, in %value :
   // CHECK: sv.initial {
   // CHECK:   sv.ifdef.procedural @MyMacro {
   // CHECK:   } else {
-  // CHECK:     %[[REG:.*]] = sv.xmr.ref @RegUnderIfdefElse_reg : !hw.inout<i1>
-  // CHECK:     %[[RNG:.*]] = sv.read_inout %{{.*}} : !hw.inout<i32>
+  // CHECK:     %[[REG:.*]] = sv.xmr.ref @RegUnderIfdefElse_reg : !sv.var<i1>
+  // CHECK:     %[[RNG:.*]] = sv.read_inout %{{.*}} : !sv.var<i32>
   // CHECK:     %[[VAL:.*]] = comb.extract %[[RNG]] from 0 : (i32) -> i1
   // CHECK:     sv.bpassign %[[REG]], %[[VAL]] : i1
   // CHECK:   }
@@ -1038,8 +1038,8 @@ hw.module @AsyncResetRegUnderIfdef(in %clock : !seq.clock, in %reset : i1, in %v
   %c = hw.constant 0 : i1
 
   // CHECK: sv.ifdef @MyMacro {
-  // CHECK:   %reg = sv.reg sym @reg : !hw.inout<i1>
-  // CHECK:   %0 = sv.read_inout %reg : !hw.inout<i1>
+  // CHECK:   %reg = sv.var sym @reg : !sv.var<i1>
+  // CHECK:   %0 = sv.read_inout %reg : !sv.var<i1>
   // CHECK:   sv.always posedge %clock, posedge %reset {
   // CHECK:     sv.if %reset {
   // CHECK:       sv.passign %reg, %false_0 : i1
@@ -1055,7 +1055,7 @@ hw.module @AsyncResetRegUnderIfdef(in %clock : !seq.clock, in %reset : i1, in %v
   // CHECK: sv.initial {
   // CHECK:   sv.if %reset {
   // CHECK:     sv.ifdef.procedural @MyMacro {
-  // CHECK:       %0 = sv.xmr.ref @[[reg_path]] : !hw.inout<i1>
+  // CHECK:       %0 = sv.xmr.ref @[[reg_path]] : !sv.var<i1>
   // CHECK:       sv.bpassign %0, %false_0 : i1
   // CHECK:     }
   // CHECK:   }
@@ -1070,8 +1070,8 @@ hw.module @PresetRegUnderIfdef(in %clock : !seq.clock, in %value : i1) {
   %c = hw.constant 0 : i1
 
   // CHECK: sv.ifdef @MyMacro {
-  // CHECK:   %reg = sv.reg sym @reg : !hw.inout<i1>
-  // CHECK:   %0 = sv.read_inout %reg : !hw.inout<i1>
+  // CHECK:   %reg = sv.var sym @reg : !sv.var<i1>
+  // CHECK:   %0 = sv.read_inout %reg : !sv.var<i1>
   // CHECK:   sv.always posedge %clock {
   // CHECK:     sv.passign %reg, %value : i1
   // CHECK:   }
@@ -1082,7 +1082,7 @@ hw.module @PresetRegUnderIfdef(in %clock : !seq.clock, in %value : i1) {
 
   // CHECK: sv.initial {
   // CHECK:   sv.ifdef.procedural @MyMacro {
-  // CHECK:     %0 = sv.xmr.ref @[[reg_path]] : !hw.inout<i1>
+  // CHECK:     %0 = sv.xmr.ref @[[reg_path]] : !sv.var<i1>
   // CHECK:     sv.bpassign %0, %false : i1
   // CHECK:   }
   // CHECK: }

--- a/test/Dialect/Seq/hw-memsim.mlir
+++ b/test/Dialect/Seq/hw-memsim.mlir
@@ -86,9 +86,9 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 
 //COMMON-LABEL: @FIRRTLMem_1_1_1_16_10_0_1_0_0
 //CHECK-SAME:  attributes {comment = "VCS coverage exclude_file"}
-//CHECK:       %Memory = sv.reg
+//CHECK:       %Memory = sv.var
 //VIVADO-SAME:  #sv.attribute<"ram_style" = "\22distributed\22">
-//CHECK-SAME:  !hw.inout<uarray<10xi16>>
+//CHECK-SAME:  !sv.var<!hw.uarray<10xi16>>
 //CHECK-NEXT:  %[[rslot:.+]] = sv.array_index_inout %Memory[%ro_addr_0]
 //CHECK-NEXT:  %[[read:.+]] = sv.read_inout %[[rslot]]
 //CHECK-NEXT:  %[[x:.+]] = sv.constantX
@@ -123,7 +123,7 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK-NEXT:  sv.ifdef @ENABLE_INITIAL_MEM_ {
 //CHECK-NEXT:    sv.ifdef @RANDOMIZE_REG_INIT {
 //CHECK-NEXT:    }
-//CHECK-NEXT:    %_RANDOM_MEM = sv.reg : !hw.inout<i32>
+//CHECK-NEXT:    %_RANDOM_MEM = sv.var : !sv.var<i32>
 //CHECK-NEXT:    sv.initial {
 //CHECK-NEXT:      sv.verbatim "`INIT_RANDOM_PROLOG_"
 //CHECK-NEXT:      sv.ifdef.procedural @RANDOMIZE_MEM_INIT {
@@ -131,11 +131,11 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK:               sv.for %j = %c0_i6 to %c-32_i6 step %c-32_i6_2 : i6 {
 //CHECK:                 %RANDOM = sv.macro.ref.expr.se @RANDOM
 //CHECK:                 %[[TRUNCATE_J:.+]] = comb.extract %j from 0 : (i6) -> i4
-//CHECK:                 %[[PART_SELECT:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%[[TRUNCATE_J]] : 32] : !hw.inout<i32>, i4
+//CHECK:                 %[[PART_SELECT:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%[[TRUNCATE_J]] : 32] : !sv.var<i32>, i4
 //CHECK:                 sv.bpassign %[[PART_SELECT]], %RANDOM : i32
 //CHECK:               }
-//CHECK:               %[[MEM_INDEX:.+]] = sv.array_index_inout %Memory[%i] : !hw.inout<uarray<10xi16>>, i4
-//CHECK:               %[[READ:.+]] = sv.read_inout %_RANDOM_MEM : !hw.inout<i32>
+//CHECK:               %[[MEM_INDEX:.+]] = sv.array_index_inout %Memory[%i] : !sv.var<!hw.uarray<10xi16>>, i4
+//CHECK:               %[[READ:.+]] = sv.read_inout %_RANDOM_MEM : !sv.var<i32>
 //CHECK:               %[[EXTRACT:.+]] = comb.extract %[[READ]] from 0 : (i32) -> i16
 //CHECK:               sv.bpassign %[[MEM_INDEX]], %[[EXTRACT]] : i16
 //CHECK:             }
@@ -146,13 +146,13 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4
 //CHECK-NEXT:  }
 //CHECK-NEXT:  hw.output %[[readres]], %[[rwres]]
 
-// IGNORE: %[[Memory:.+]] = sv.reg : !hw.inout<uarray<10xi16>>
-// IGNORE: %[[ro_slot:.+]] = sv.array_index_inout %[[Memory]][%ro_addr_0] : !hw.inout<uarray<10xi16>>, i4
-// IGNORE: %[[result_ro:.+]] = sv.read_inout %[[ro_slot]] : !hw.inout<i16>
-// IGNORE: %[[rw_wire:.+]] = sv.wire : !hw.inout<i16>
-// IGNORE: %[[wire_slot:.+]] = sv.read_inout %2 : !hw.inout<i16>
-// IGNORE: %[[rw_slot:.+]] = sv.array_index_inout %[[Memory]][%rw_addr_0] : !hw.inout<uarray<10xi16>>, i4
-// IGNORE: %[[rw_value:.+]] = sv.read_inout %[[rw_slot]] : !hw.inout<i16>
+// IGNORE: %[[Memory:.+]] = sv.var : !sv.var<!hw.uarray<10xi16>>
+// IGNORE: %[[ro_slot:.+]] = sv.array_index_inout %[[Memory]][%ro_addr_0] : !sv.var<!hw.uarray<10xi16>>, i4
+// IGNORE: %[[result_ro:.+]] = sv.read_inout %[[ro_slot]] : !sv.var<i16>
+// IGNORE: %[[rw_wire:.+]] = sv.wire : !sv.net<i16>
+// IGNORE: %[[wire_slot:.+]] = sv.read_inout %2 : !sv.net<i16>
+// IGNORE: %[[rw_slot:.+]] = sv.array_index_inout %[[Memory]][%rw_addr_0] : !sv.var<!hw.uarray<10xi16>>, i4
+// IGNORE: %[[rw_value:.+]] = sv.read_inout %[[rw_slot]] : !sv.var<i16>
 // IGNORE: sv.assign %[[rw_wire]], %[[rw_value]] : i16
 // IGNORE: hw.output %[[result_ro]], %[[wire_slot]] : i16, i16
 
@@ -160,22 +160,22 @@ hw.module.generated @FIRRTLMem_1_1_1_16_10_2_4_0_0, @FIRRTLMem(in %ro_addr_0: i4
 
 //COMMON-LABEL: @FIRRTLMem_1_1_1_16_10_2_4_0_0
 //COM: This produces a lot of output, we check one field's pipeline
-//CHECK:         %Memory = sv.reg
-//CHECK-NEXT:    [[EN_0:%.+]] = sv.reg {{.+}} : !hw.inout<i1>
-//CHECK-NEXT:    [[EN_1:%.+]] = sv.reg {{.+}} : !hw.inout<i1>
-//CHECK-NEXT:    [[ADDR_0:%.+]] = sv.reg {{.+}} : !hw.inout<i4>
-//CHECK-NEXT:    [[ADDR_1:%.+]] = sv.reg {{.+}} : !hw.inout<i4>
+//CHECK:         %Memory = sv.var
+//CHECK-NEXT:    [[EN_0:%.+]] = sv.var {{.+}} : !sv.var<i1>
+//CHECK-NEXT:    [[EN_1:%.+]] = sv.var {{.+}} : !sv.var<i1>
+//CHECK-NEXT:    [[ADDR_0:%.+]] = sv.var {{.+}} : !sv.var<i4>
+//CHECK-NEXT:    [[ADDR_1:%.+]] = sv.var {{.+}} : !sv.var<i4>
 //CHECK-NEXT:    sv.always posedge %ro_clock_0 {
 //CHECK-NEXT:      sv.passign [[EN_0]], %ro_en_0 : i1
-//CHECK-NEXT:      [[EN_0R:%.+]] = sv.read_inout [[EN_0]] : !hw.inout<i1>
+//CHECK-NEXT:      [[EN_0R:%.+]] = sv.read_inout [[EN_0]] : !sv.var<i1>
 //CHECK-NEXT:      sv.passign [[EN_1]], [[EN_0R]] : i1
 //CHECK-NEXT:      sv.passign [[ADDR_0]], %ro_addr_0 : i4
-//CHECK-NEXT:      [[ADDR_0R:%.+]] = sv.read_inout [[ADDR_0]] : !hw.inout<i4>
+//CHECK-NEXT:      [[ADDR_0R:%.+]] = sv.read_inout [[ADDR_0]] : !sv.var<i4>
 //CHECK-NEXT:      sv.passign [[ADDR_1]], [[ADDR_0R]] : i4
 //CHECK-NEXT:    }
-//CHECK-NEXT:    [[EN_1R:%.+]] = sv.read_inout [[EN_1]] : !hw.inout<i1>
-//CHECK-NEXT:    [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]] : !hw.inout<i4>
-//CHECK-NEXT:    {{%.+}} = sv.array_index_inout %Memory[[[ADDR_1R]]] : !hw.inout<uarray<10xi16>>, i4
+//CHECK-NEXT:    [[EN_1R:%.+]] = sv.read_inout [[EN_1]] : !sv.var<i1>
+//CHECK-NEXT:    [[ADDR_1R:%.+]] = sv.read_inout [[ADDR_1]] : !sv.var<i4>
+//CHECK-NEXT:    {{%.+}} = sv.array_index_inout %Memory[[[ADDR_1R]]] : !sv.var<!hw.uarray<10xi16>>, i4
 
 hw.module.generated @FIRRTLMem_1_1_1_16_1_0_1_0_0, @FIRRTLMem(in %ro_addr_0: i4, in %ro_en_0: i1, in %ro_clock_0: i1, in %rw_addr_0: i4, in %rw_en_0: i1,  in %rw_clock_0: i1, in %rw_wmode_0: i1, in %rw_wdata_0: i16, in %wo_addr_0: i4, in %wo_en_0: i1, in %wo_clock_0: i1, in %wo_data_0: i16, out ro_data_0: i16, out rw_rdata_0: i16) attributes {depth = 1 : i64, numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 1 : ui32, readLatency = 0 : ui32, readUnderWrite = 0 : i32, width = 16 : ui32, writeClockIDs = [], writeLatency = 1 : ui32, writeUnderWrite = 0 : i32, initFilename = "", initIsBinary = false, initIsInline = false}
 // COMMON-LABEL: @FIRRTLMem_1_1_1_16_1_0_1_0_0
@@ -208,9 +208,9 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( in %wo_addr_0: i4, in %wo_e
   // COMMON-LABEL: hw.module private @FIRRTLMem_1_1_0_32_16_1_1_0_1_a(
   // CHECK-SAME:    in %R0_addr : i4, in %R0_en : i1, in %R0_clk : i1,
   // CHECK-SAME:    in %W0_addr : i4, in %W0_en : i1, in %W0_clk : i1, in %W0_data : i32, in %W0_mask : i4, out R0_data : i32)
-  // CHECK-NEXT:   %[[Memory:.+]] = sv.reg
+  // CHECK-NEXT:   %[[Memory:.+]] = sv.var
   // VIVADO-SAME:  #sv.attribute<"rw_addr_collision" = "\22yes\22">
-  // CHECK-SAME: !hw.inout<uarray<16xi32>>
+  // CHECK-SAME: !sv.var<!hw.uarray<16xi32>>
   // CHECK:        %[[slot:.+]] = sv.array_index_inout %[[Memory]][%[[v3:.+]]] :
   // PRAMGAS: sv.attributes
   // CHECK-NEXT:   %[[v12:.+]] = sv.read_inout %[[slot]]
@@ -231,13 +231,13 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( in %wo_addr_0: i4, in %wo_e
   // CHECK-NEXT:   sv.always posedge %W0_clk {
   // CHECK-NEXT:     %[[v22:.+]] = comb.and %W0_en, %[[v14]] : i1
   // CHECK-NEXT:     sv.if %[[v22]]  {
-  // CHECK-NEXT:       %[[v26:.+]] = sv.array_index_inout %[[Memory]][%W0_addr] : !hw.inout<uarray<16xi32>>, i4
+  // CHECK-NEXT:       %[[v26:.+]] = sv.array_index_inout %[[Memory]][%W0_addr] : !sv.var<!hw.uarray<16xi32>>, i4
   // CHECK-NEXT:      %[[c0_i32:.+]] = hw.constant 0 : i32
-  // CHECK-NEXT:      %[[v220:.+]] = sv.indexed_part_select_inout %[[v26]][%[[c0_i32]] : 8] : !hw.inout<i32>, i32
+  // CHECK-NEXT:      %[[v220:.+]] = sv.indexed_part_select_inout %[[v26]][%[[c0_i32]] : 8] : !sv.var<i32>, i32
   // CHECK-NEXT:      sv.passign %[[v220]], %[[v15]] : i8
 
-  // IGNORE:      %[[Memory:.+]] = sv.reg : !hw.inout<uarray<16xi32>>
-  // IGNORE-NEXT: %[[read_addr_inout:.+]] = sv.reg {{.*}} : !hw.inout<i4>
+  // IGNORE:      %[[Memory:.+]] = sv.var : !sv.var<!hw.uarray<16xi32>>
+  // IGNORE-NEXT: %[[read_addr_inout:.+]] = sv.var {{.*}} : !sv.var<i4>
   // IGNORE-NEXT: sv.always posedge %R0_clk {
   // IGNORE-NEXT:   sv.if %R0_en {
   // IGNORE-NEXT:     sv.passign %[[read_addr_inout]], %R0_addr
@@ -257,22 +257,22 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( in %wo_addr_0: i4, in %wo_e
   // COMMON-LABEL:hw.module private @FIRRTLMem_1_1_0_32_16_1_1_0_1_b(
   // CHECK-SAME: in %R0_addr : i4, in %R0_en : i1, in %R0_clk : i1,
   // CHECK-SAME: in %W0_addr : i4, in %W0_en : i1, in %W0_clk : i1, in %W0_data : i32, in %W0_mask : i2, out R0_data : i32)
-  // CHECK:  %[[Memory0:.+]] = sv.reg : !hw.inout<uarray<16xi32>>
-  // CHECK:  %[[v8:.+]] = sv.array_index_inout %[[Memory0]][%[[v7:.+]]] : !hw.inout<uarray<16xi32>>, i4
+  // CHECK:  %[[Memory0:.+]] = sv.var : !sv.var<!hw.uarray<16xi32>>
+  // CHECK:  %[[v8:.+]] = sv.array_index_inout %[[Memory0]][%[[v7:.+]]] : !sv.var<!hw.uarray<16xi32>>, i4
   // CHECK:  %[[v9:.+]] = sv.read_inout
   // CHECK:  %[[x_i32:.+]] = sv.constantX : i32
   // ZERO:   %[[x_i32:.+]] = hw.constant 0 : i32
   // CHECK:  %[[v13:.+]] = comb.mux
-  // CHECK:  %[[v24:.+]] = sv.reg {{.+}} : !hw.inout<i32>
+  // CHECK:  %[[v24:.+]] = sv.var {{.+}} : !sv.var<i32>
   // CHECK:  sv.always posedge %W0_clk {
   // CHECK:    sv.passign %[[v22:.+]], %W0_data : i32
-  // CHECK:    %[[v23:.+]] = sv.read_inout %[[v22]] : !hw.inout<i32>
+  // CHECK:    %[[v23:.+]] = sv.read_inout %[[v22]] : !sv.var<i32>
   // CHECK:    sv.passign %[[v24:.+]], %[[v23]] : i32
   // CHECK:    sv.passign %[[v26:.+]], %W0_mask : i2
   // CHECK:    sv.passign %[[v28:.+]], %[[v27:.+]] : i2
   // CHECK:  }
-  // CHECK:  %[[v25:.+]] = sv.read_inout %[[v24]] : !hw.inout<i32>
-  // CHECK:  %[[v29:.+]] = sv.read_inout %[[v28]] : !hw.inout<i2>
+  // CHECK:  %[[v25:.+]] = sv.read_inout %[[v24]] : !sv.var<i32>
+  // CHECK:  %[[v29:.+]] = sv.read_inout %[[v28]] : !sv.var<i2>
   // CHECK:  %[[v30:.+]] = comb.extract %[[v29]] from 0 : (i2) -> i1
   // CHECK:  %[[v31:.+]] = comb.extract %[[v25]] from 0 : (i32) -> i16
   // CHECK:  %[[v32:.+]] = comb.extract %[[v29]] from 1 : (i2) -> i1
@@ -282,7 +282,7 @@ hw.module.generated @FIRRTLMemTwoAlways, @FIRRTLMem( in %wo_addr_0: i4, in %wo_e
   // CHECK:    sv.if %[[v34]]  {
   // CHECK:      %[[v36:.+]] = sv.array_index_inout %[[Memory0]][%[[v117:.+]]] :
   // CHECK:      %c0_i32 = hw.constant 0 : i32
-  // CHECK:      %[[v37:.+]] = sv.indexed_part_select_inout %[[v36]][%c0_i32 : 16] : !hw.inout<i32>, i32
+  // CHECK:      %[[v37:.+]] = sv.indexed_part_select_inout %[[v36]][%c0_i32 : 16] : !sv.var<i32>, i32
   // CHECK:      sv.passign %[[v37]], %[[v31]] : i16
   // CHECK:    }
   // CHECK:  hw.output %[[v13]] : i32
@@ -299,7 +299,7 @@ numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32,maskGran = 8 :ui32, numWri
 // CHECK-SAME: in %rw_wmask_0 : i2, in %wo_addr_0 : i4, in %wo_en_0 : i1, in %wo_clock_0 : i1,
 // CHECK-SAME: in %wo_data_0 : i16, in %wo_mask_0 : i2
 // CHECK-SAME: out ro_data_0 : i16, out rw_rdata_0 : i16)
-// CHECK:    %[[Memory0:.+]] = sv.reg : !hw.inout<uarray<10xi16>>
+// CHECK:    %[[Memory0:.+]] = sv.var : !sv.var<!hw.uarray<10xi16>>
 // CHECK:    %[[v8:.+]] = sv.array_index_inout %[[Memory0]][%[[v7:.+]]] :
 // CHECK:    %[[v12:.+]] = sv.read_inout %[[v8]]
 // CHECK:    sv.always posedge %rw_clock_0 {
@@ -322,13 +322,13 @@ numReadPorts = 1 : ui32, numReadWritePorts = 1 : ui32,maskGran = 8 :ui32, numWri
 // CHECK:      %[[v86:.+]] = comb.and %[[v69:.+]], %[[v82]] : i1
 // CHECK:      sv.if %[[v86]]  {
 // CHECK:        %[[v88:.+]] = sv.array_index_inout %[[Memory0]][%[[v63:.+]]] :
-// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c0_i32:.+]] : 8] : !hw.inout<i16>, i32
+// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c0_i32:.+]] : 8] : !sv.var<i16>, i32
 // CHECK:        sv.passign %[[vv83]], %[[v83]] : i8
 // CHECK:      }
 // CHECK:      sv.if %[[v87:.+]]  {
-// CHECK:        %[[v88:.+]] = sv.array_index_inout %[[Memory0]][%[[v63]]] : !hw.inout<uarray<10xi16>>, i4
+// CHECK:        %[[v88:.+]] = sv.array_index_inout %[[Memory0]][%[[v63]]] : !sv.var<!hw.uarray<10xi16>>, i4
 // CHECK:        %[[c8_i32:.+]] = hw.constant 8 : i32
-// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c8_i32]] : 8] : !hw.inout<i16>, i32
+// CHECK:        %[[vv83:.+]] = sv.indexed_part_select_inout %[[v88]][%[[c8_i32]] : 8] : !sv.var<i16>, i32
 // CHECK:        sv.passign %[[vv83]], %[[v85]] : i8
 // CHECK:      }
 // CHECK:    }
@@ -356,7 +356,7 @@ hw.module.generated @RandomizeWeirdWidths, @FIRRTLMem(
 
 // COMMON-LABEL: hw.module private @ReadWriteWithHighReadLatency
 hw.module.generated @ReadWriteWithHighReadLatency, @FIRRTLMem(in %rw_addr: i4, in %rw_en: i1,  in %rw_clock: i1, in %rw_wmode: i1, in %rw_wdata: i16, out rw_rdata: i16) attributes {depth = 16 : i64, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 4 : ui32, readUnderWrite = 0 : i32, width = 16 : ui32, writeClockIDs = [], writeLatency = 3 : ui32, writeUnderWrite = 0 : i32, initFilename = "", initIsBinary = false, initIsInline = false}
-// CHECK: [[MEM:%.+]] = sv.reg
+// CHECK: [[MEM:%.+]] = sv.var
 
 // Common pipeline stages (2x)
 // CHECK: sv.passign [[ADDR_0:%.+]], %rw_addr
@@ -407,7 +407,7 @@ hw.module.generated @ReadWriteWithHighReadLatency, @FIRRTLMem(in %rw_addr: i4, i
 
 // COMMON-LABEL: hw.module private @ReadWriteWithHighWriteLatency
 hw.module.generated @ReadWriteWithHighWriteLatency, @FIRRTLMem(in %rw_addr: i4, in %rw_en: i1,  in %rw_clock: i1, in %rw_wmode: i1, in %rw_wdata: i16, out rw_rdata: i16) attributes {depth = 16 : i64, numReadPorts = 0 : ui32, numReadWritePorts = 1 : ui32, numWritePorts = 0 : ui32, readLatency = 2 : ui32, readUnderWrite = 0 : i32, width = 16 : ui32, writeClockIDs = [], writeLatency = 5 : ui32, writeUnderWrite = 0 : i32, initFilename = "", initIsBinary = false, initIsInline = false}
-// CHECK: [[MEM:%.+]] = sv.reg
+// CHECK: [[MEM:%.+]] = sv.var
 
 // Common pipeline stages (2x)
 // CHECK: sv.passign [[ADDR_0:%.+]], %rw_addr
@@ -512,5 +512,5 @@ hw.module.generated @TestFragment, @FIRRTLMem(
 // CHECK-NEXT:   sv.for %[[J:.+]] = %[[c0_i6]] to %[[c_32_i6]] step %[[c_32_i6_0]] : i6 {
 // CHECK-NEXT:     %[[RANDOM:.+]] = sv.macro.ref.expr.se @RANDOM() : () -> i32
 // CHECK-NEXT:     %false = hw.constant false
-// CHECK-NEXT:     %[[V7:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%false : 32] : !hw.inout<i32>, i1
+// CHECK-NEXT:     %[[V7:.+]] = sv.indexed_part_select_inout %_RANDOM_MEM[%false : 32] : !sv.var<i32>, i1
 // CHECK-NEXT:     sv.bpassign %[[V7]], %RANDOM : i32

--- a/test/Dialect/Seq/lower-hlmem.mlir
+++ b/test/Dialect/Seq/lower-hlmem.mlir
@@ -3,11 +3,11 @@
 // CHECK-LABEL:   hw.module @d1(
 // CHECK-SAME:                  in %[[CLOCK:.*]] : !seq.clock,
 // CHECK-SAME:                  in %[[VAL_1:.*]] : i1) {
-// CHECK:           %[[VAL_2:.*]] = sv.reg  : !hw.inout<uarray<4xi32>>
+// CHECK:           %[[VAL_2:.*]] = sv.var  : !sv.var<!hw.uarray<4xi32>>
 // CHECK:           %[[CLK:.+]] = seq.from_clock %[[CLOCK]]
 // CHECK:           sv.alwaysff(posedge %[[CLK]]) {
 // CHECK:             sv.if %[[VAL_3:.*]] {
-// CHECK:               %[[VAL_4:.*]] = sv.array_index_inout %[[VAL_2]]{{\[}}%[[VAL_5:.*]]] : !hw.inout<uarray<4xi32>>, i2
+// CHECK:               %[[VAL_4:.*]] = sv.array_index_inout %[[VAL_2]]{{\[}}%[[VAL_5:.*]]] : !sv.var<!hw.uarray<4xi32>>, i2
 // CHECK:               sv.passign %[[VAL_4]], %[[VAL_6:.*]] : i32
 // CHECK:             }
 // CHECK:           }(syncreset : posedge %[[VAL_1]]) {
@@ -15,11 +15,11 @@
 // CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i2
 // CHECK:           %[[VAL_8:.*]] = hw.constant true
 // CHECK:           %[[VAL_9:.*]] = hw.constant 42 : i32
-// CHECK:           %[[VAL_10:.*]] = sv.array_index_inout %[[VAL_2]]{{\[}}%[[VAL_7]]] : !hw.inout<uarray<4xi32>>, i2
-// CHECK:           %[[VAL_11:.*]] = sv.read_inout %[[VAL_10]] : !hw.inout<i32>
+// CHECK:           %[[VAL_10:.*]] = sv.array_index_inout %[[VAL_2]]{{\[}}%[[VAL_7]]] : !sv.var<!hw.uarray<4xi32>>, i2
+// CHECK:           %[[VAL_11:.*]] = sv.read_inout %[[VAL_10]] : !sv.var<i32>
 // CHECK:           %[[VAL_12:.*]] = seq.compreg sym @myMemory_rdaddr0_dly0 %[[VAL_7]], %[[CLOCK]] : i2
-// CHECK:           %[[VAL_13:.*]] = sv.array_index_inout %[[VAL_2]]{{\[}}%[[VAL_12]]] : !hw.inout<uarray<4xi32>>, i2
-// CHECK:           %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !hw.inout<i32>
+// CHECK:           %[[VAL_13:.*]] = sv.array_index_inout %[[VAL_2]]{{\[}}%[[VAL_12]]] : !sv.var<!hw.uarray<4xi32>>, i2
+// CHECK:           %[[VAL_14:.*]] = sv.read_inout %[[VAL_13]] : !sv.var<i32>
 // CHECK:           %[[VAL_15:.*]] = seq.compreg sym @myMemory_rd0_reg %[[VAL_14]], %[[CLOCK]] : i32
 // CHECK:           hw.output
 // CHECK:         }

--- a/test/Dialect/Verif/lower-symbolic-values.mlir
+++ b/test/Dialect/Verif/lower-symbolic-values.mlir
@@ -8,7 +8,7 @@ hw.module @Foo() {
   // CHECK-YOSYS-NOT: verif.symbolic_value
 
   // CHECK-EXTMODULE: [[SYM:%.+]] = hw.instance {{.*}} @circt.symbolic_value.42<WIDTH: i32 = 42>
-  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<i42>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !sv.net<i42>
   // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
   // CHECK: dbg.variable "x0", [[SYM]] : i42
   %0 = verif.symbolic_value : i42
@@ -16,7 +16,7 @@ hw.module @Foo() {
 
   // CHECK-EXTMODULE: [[TMP:%.+]] = hw.instance {{.*}} @circt.symbolic_value.12<WIDTH: i32 = 12>
   // CHECK-EXTMODULE: [[SYM:%.+]] = hw.bitcast [[TMP]] : (i12) -> !hw.array<4xi3>
-  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<array<4xi3>>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !sv.net<!hw.array<4xi3>>
   // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
   // CHECK: dbg.variable "x1", [[SYM]] : !hw.array<4xi3>
   %1 = verif.symbolic_value : !hw.array<4xi3>
@@ -24,7 +24,7 @@ hw.module @Foo() {
 
   // Reuse existing extmodule for same i42 type.
   // CHECK-EXTMODULE: [[SYM:%.+]] = hw.instance {{.*}} @circt.symbolic_value.42<WIDTH: i32 = 42>
-  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<i42>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !sv.net<i42>
   // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
   // CHECK: dbg.variable "x2", [[SYM]] : i42
   %2 = verif.symbolic_value : i42
@@ -33,7 +33,7 @@ hw.module @Foo() {
   // Reuse existing extmodule for same 42 bit types, cast to array<6 x i7>.
   // CHECK-EXTMODULE: [[TMP:%.+]] = hw.instance {{.*}} @circt.symbolic_value.42<WIDTH: i32 = 42>
   // CHECK-EXTMODULE: [[SYM:%.+]] = hw.bitcast [[TMP]] : (i42) -> !hw.array<6xi7>
-  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !hw.inout<array<6xi7>>
+  // CHECK-YOSYS: [[TMP:%.+]] = sv.wire {sv.attributes = [#sv.attribute<"anyseq">]} : !sv.net<!hw.array<6xi7>>
   // CHECK-YOSYS: [[SYM:%.+]] = sv.read_inout [[TMP]]
   // CHECK: dbg.variable "x3", [[SYM]] : !hw.array<6xi7>
   %3 = verif.symbolic_value : !hw.array<6xi7>

--- a/test/Target/DebugInfo/emit-hgldd.mlir
+++ b/test/Target/DebugInfo/emit-hgldd.mlir
@@ -152,10 +152,10 @@ hw.module @EmptyAggregates() {
 // CHECK:         "value": {"opcode":"'{","operands":[{"sig_name":"bar"}]}
 // CHECK:         "type_name": "SingleElementAggregates_varBar"
 hw.module @SingleElementAggregates() {
-  %foo = sv.wire : !hw.inout<i1>
-  %bar = sv.wire : !hw.inout<i1>
-  %0 = sv.read_inout %foo : !hw.inout<i1>
-  %1 = sv.read_inout %bar : !hw.inout<i1>
+  %foo = sv.wire : !sv.net<i1>
+  %bar = sv.wire : !sv.net<i1>
+  %0 = sv.read_inout %foo : !sv.net<i1>
+  %1 = sv.read_inout %bar : !sv.net<i1>
   %2 = dbg.array [%0] : i1
   %3 = dbg.struct {"x": %1} : i1
   dbg.variable "varFoo", %2 : !dbg.array
@@ -228,22 +228,22 @@ hw.module @Expressions(in %a: i1, in %b: i1) {
   // CHECK-LABEL: "var_name": "readWire"
   // CHECK: "value": {"sig_name":"svWire"}
   // CHECK: "type_name": "logic"
-  %svWire = sv.wire : !hw.inout<i1>
-  %3 = sv.read_inout %svWire : !hw.inout<i1>
+  %svWire = sv.wire : !sv.net<i1>
+  %3 = sv.read_inout %svWire : !sv.net<i1>
   dbg.variable "readWire", %3 : i1
 
   // CHECK-LABEL: "var_name": "readReg"
   // CHECK: "value": {"sig_name":"svReg"}
   // CHECK: "type_name": "logic"
-  %svReg = sv.reg : !hw.inout<i1>
-  %4 = sv.read_inout %svReg : !hw.inout<i1>
+  %svReg = sv.var : !sv.var<i1>
+  %4 = sv.read_inout %svReg : !sv.var<i1>
   dbg.variable "readReg", %4 : i1
 
   // CHECK-LABEL: "var_name": "readLogic"
   // CHECK: "value": {"sig_name":"svLogic"}
   // CHECK: "type_name": "logic"
-  %svLogic = sv.logic : !hw.inout<i1>
-  %5 = sv.read_inout %svLogic : !hw.inout<i1>
+  %svLogic = sv.var : !sv.var<i1>
+  %5 = sv.read_inout %svLogic : !sv.var<i1>
   dbg.variable "readLogic", %5 : i1
 
   // CHECK-LABEL: "var_name": "myWire"
@@ -503,7 +503,7 @@ hw.module @Issue6735_Case1(out someOutput: i1) {
   // CHECK: "sig_name":"wireB"
   %b = hw.instance "instB" @SingleResult() -> (outPort: i1)
   dbg.variable "varB", %b : i1
-  %wireB = sv.wire : !hw.inout<i1>
+  %wireB = sv.wire : !sv.net<i1>
   sv.assign %wireB, %b : i1
   // CHECK: "var_name": "varC"
   // CHECK-NOT: "sig_name":"instC"
@@ -511,7 +511,7 @@ hw.module @Issue6735_Case1(out someOutput: i1) {
   // CHECK: "sig_name":"wireC"
   %c = hw.instance "instC" @SingleResult() -> (outPort: i1)
   dbg.variable "varC", %c : i1
-  %wireC = sv.logic : !hw.inout<i1>
+  %wireC = sv.wire : !sv.net<i1>
   sv.assign %wireC, %c : i1
   // CHECK: "var_name": "varD"
   // CHECK-NOT: "sig_name":"instD"
@@ -519,7 +519,7 @@ hw.module @Issue6735_Case1(out someOutput: i1) {
   // CHECK: "sig_name":"wireD"
   %d = hw.instance "instD" @SingleResult() -> (outPort: i1)
   dbg.variable "varD", %d : i1
-  %wireD = sv.logic : !hw.inout<i1>
+  %wireD = sv.wire : !sv.net<i1>
   sv.assign %wireD, %d : i1
 
   // Use module's output port name to refer to instance output.

--- a/test/firtool/dpi.fir
+++ b/test/firtool/dpi.fir
@@ -32,7 +32,7 @@ circuit DPI:
 
 ; CHECK-LABEL: module DPI(
 ; CHECK:        logic [7:0] [[TMP:_.+]];
-; CHECK-NEXT:   reg   [7:0] [[RESULT1:_.+]];
+; CHECK-NEXT:   logic   [7:0] [[RESULT1:_.+]];
 ; CHECK-NEXT:   wire [7:0] [[OPEN_ARRAY:_.+]][0:1];
 ; CHECK-NEXT:   assign [[OPEN_ARRAY]] = '{in_0, in_1};
 ; CHECK-NEXT:   always @(posedge clock) begin
@@ -42,7 +42,7 @@ circuit DPI:
 ; CHECK-NEXT:       clocked_void(in_0, in_1, [[OPEN_ARRAY]]);
 ; CHECK-NEXT:     end
 ; CHECK-NEXT:   end // always @(posedge)
-; CHECK-NEXT:   reg   [7:0] [[RESULT2:_.+]];
+; CHECK-NEXT:   logic   [7:0] [[RESULT2:_.+]];
 ; CHECK-NEXT:   always_comb begin
 ; CHECK-NEXT:     if (enable) begin
 ; CHECK-NEXT:       unclocked_result(in_0, in_1, [[RESULT2]]);

--- a/test/firtool/import-ref.fir
+++ b/test/firtool/import-ref.fir
@@ -70,7 +70,7 @@ circuit Inner:
     reg r : UInt<32>, clock
     define read = probe(r)
     define write = rwprobe(r)
-    ; CHECK: reg  [31:0] [[REG:.+]];
+    ; CHECK: logic  [31:0] [[REG:.+]];
 
 ; CHECK-LABEL: FILE "ref_Inner.sv"
 ; CHECK-EMPTY:

--- a/test/firtool/lower-layers-with-1dvec-preservation.fir
+++ b/test/firtool/lower-layers-with-1dvec-preservation.fir
@@ -6,7 +6,7 @@ FIRRTL version 5.1.0
 ; lower-layers and the vector subaccess op.
 
 ; CHECK: module Foo_Verification_Assert();
-; CHECK:   reg  hasBeenResetReg;
+; CHECK:   logic  hasBeenResetReg;
 ; CHECK:   initial
 ; CHECK:     hasBeenResetReg = 1'bx;
 ; CHECK:   always @(posedge Foo.clock) begin

--- a/test/firtool/lower-layers.fir
+++ b/test/firtool/lower-layers.fir
@@ -90,7 +90,7 @@ circuit TestHarness:
   layer Verification, bind:
 
   ; CHECK: module DUT_Verification();
-  ; CHECK:   reg  [31:0] pc_d;
+  ; CHECK:   logic  [31:0] pc_d;
   ; CHECK:   always @(posedge DUT.clock)
   ; CHECK:     pc_d <= DUT.a;
   ; CHECK: endmodule
@@ -100,7 +100,7 @@ circuit TestHarness:
   ; CHECK:   input  [31:0] a,
   ; CHECK:   output [31:0] b
   ; CHECK: );
-  ; CHECK:   reg [31:0] pc;
+  ; CHECK:   logic [31:0] pc;
   ; CHECK:   always @(posedge clock)
   ; CHECK:     pc <= a;
   ; CHECK:   assign b = pc;

--- a/test/firtool/plusargs.fir
+++ b/test/firtool/plusargs.fir
@@ -15,29 +15,29 @@ circuit PlusArgTest:
     connect bar_result, bar.result
 
     ; CHECK:      [[FORMAT_FOO:%.+]] = sv.constantStr "foo"
-    ; CHECK-NEXT: [[FOUND_FOO_REG:%.+]] = sv.reg : !hw.inout<i1>
+    ; CHECK-NEXT: [[FOUND_FOO_REG:%.+]] = sv.var : !sv.var<i1>
     ; CHECK-NEXT: sv.initial {
     ; CHECK-NEXT:   [[FOUND_FOO_VAL:%.+]] = sv.system "test$plusargs"([[FORMAT_FOO]]) : (!hw.string) -> i1
     ; CHECK-NEXT:   sv.bpassign [[FOUND_FOO_REG]], [[FOUND_FOO_VAL]] : i1
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: [[FOUND_FOO:%.+]] = sv.read_inout [[FOUND_FOO_REG]] : !hw.inout<i1>
+    ; CHECK-NEXT: [[FOUND_FOO:%.+]] = sv.read_inout [[FOUND_FOO_REG]] : !sv.var<i1>
 
-    ; CHECK:      [[BAR_VALUE:%.+]] = sv.wire : !hw.inout<i32>
-    ; CHECK-NEXT: [[BAR_FOUND:%.+]] = sv.wire : !hw.inout<i1>
+    ; CHECK:      [[BAR_VALUE:%.+]] = sv.wire : !sv.net<i32>
+    ; CHECK-NEXT: [[BAR_FOUND:%.+]] = sv.wire : !sv.net<i1>
     ; CHECK-NEXT: sv.ifdef @SYNTHESIS {
     ; CHECK-NEXT:   %z_i32 = sv.constantZ : i32
     ; CHECK-NEXT:   sv.assign [[BAR_VALUE]], %z_i32 {sv.attributes = [#sv.attribute<"This dummy assignment exists to avoid undriven lint warnings (e.g., Verilator UNDRIVEN).", emitAsComment>]} : i32
     ; CHECK-NEXT:   sv.assign [[BAR_FOUND]], %false : i1
     ; CHECK-NEXT: } else {
-    ; CHECK-NEXT:   [[FOUND_REG:%.*]] = sv.reg : !hw.inout<i32>
-    ; CHECK-NEXT:   [[VALUE_REG:%.*]] = sv.reg : !hw.inout<i32>
+    ; CHECK-NEXT:   [[FOUND_REG:%.*]] = sv.var : !sv.var<i32>
+    ; CHECK-NEXT:   [[VALUE_REG:%.*]] = sv.var : !sv.var<i32>
     ; CHECK-NEXT:   sv.initial {
     ; CHECK-NEXT:     [[FORMAT_BAR:%.+]] = sv.constantStr "foo=%d"
-    ; CHECK-NEXT:     [[PLUSARG_FOUND:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[VALUE_REG]]) : (!hw.string, !hw.inout<i32>) -> i32
+    ; CHECK-NEXT:     [[PLUSARG_FOUND:%.+]] = sv.system "value$plusargs"([[FORMAT_BAR]], [[VALUE_REG]]) : (!hw.string, !sv.var<i32>) -> i32
     ; CHECK-NEXT:     sv.bpassign [[FOUND_REG]], [[PLUSARG_FOUND]]
     ; CHECK-NEXT:   }
-    ; CHECK-NEXT:   [[FOUND_READ:%.*]] = sv.read_inout [[FOUND_REG]] : !hw.inout<i32>
-    ; CHECK-NEXT:   [[VALUE_READ:%.*]] = sv.read_inout [[VALUE_REG]] : !hw.inout<i32>
+    ; CHECK-NEXT:   [[FOUND_READ:%.*]] = sv.read_inout [[FOUND_REG]] : !sv.var<i32>
+    ; CHECK-NEXT:   [[VALUE_READ:%.*]] = sv.read_inout [[VALUE_REG]] : !sv.var<i32>
     ; CHECK-NEXT:   [[FOUND:%.*]] = comb.icmp ceq [[FOUND_READ]], %c1_i32 : i32
     ; CHECK-NEXT:   sv.assign [[BAR_FOUND]], [[FOUND]] : i1
     ; CHECK-NEXT:   sv.assign [[BAR_VALUE]], [[VALUE_READ]] : i32

--- a/test/firtool/reg-under-inline-layer.fir
+++ b/test/firtool/reg-under-inline-layer.fir
@@ -14,7 +14,7 @@ circuit RegUnderInlineLayer:
     output probe: Probe<UInt<1>, A>
 
     ; CHECK: `ifdef layer$A
-    ; CHECK:   reg  myreg;
+    ; CHECK:   logic  myreg;
     ; CHECK:   always @(posedge clock) begin
     ; CHECK:     if (reset)
     ; CHECK:       myreg <= 1'h0;
@@ -53,7 +53,7 @@ circuit RegUnderInlineLayer:
 
     ; CHECK: `ifdef layer$A
     ; CHECK:   `ifdef layer$A$B
-    ; CHECK:     reg  myreg;
+    ; CHECK:     logic  myreg;
     ; CHECK:     always @(posedge clock) begin
     ; CHECK:       if (reset)
     ; CHECK:         myreg <= 1'h0;
@@ -93,7 +93,7 @@ circuit RegUnderInlineLayer:
 
   ; CHECK: module RegUnderInlineLayer_A();
   ; CHECK:   `ifdef layer$A$B
-  ; CHECK:     reg  myreg;
+  ; CHECK:     logic  myreg;
   ; CHECK:     always @(posedge RegUnderInlineLayer.clock) begin
   ; CHECK:       if (RegUnderInlineLayer.reset)
   ; CHECK:         myreg <= 1'h0;

--- a/test/firtool/sv-attr.fir
+++ b/test/firtool/sv-attr.fir
@@ -31,7 +31,7 @@ circuit Foo: %[[{"class": "firrtl.AttributeAnnotation",
     ; CHECK-NEXT: wire n
     node n = w;
     ; CHECK:      (* keep = "true" *)
-    ; CHECK-NEXT: reg r
+    ; CHECK-NEXT: logic r
     reg r: UInt<1>, clock
     connect w, a
     connect b1, n

--- a/test/kanagawatool/output_format.mlir
+++ b/test/kanagawatool/output_format.mlir
@@ -18,8 +18,8 @@
 
 // CHECK-IR-LABEL:   hw.module @A_B(
 // CHECK-IR-SAME:              in %[[VAL_0:.*]] : i1, in %[[VAL_1:.*]] : i1, out p_out : i1) {
-// CHECK-IR:           %[[VAL_2:.*]] = sv.reg : !hw.inout<i1>
-// CHECK-IR:           %[[VAL_3:.*]] = sv.read_inout %[[VAL_2]] : !hw.inout<i1>
+// CHECK-IR:           %[[VAL_2:.*]] = sv.var : !sv.var<i1>
+// CHECK-IR:           %[[VAL_3:.*]] = sv.read_inout %[[VAL_2]] : !sv.var<i1>
 // CHECK-IR:           sv.alwaysff(posedge %[[VAL_0]]) {
 // CHECK-IR:             sv.passign %[[VAL_2]], %[[VAL_1]] : i1
 // CHECK-IR:           }


### PR DESCRIPTION
**Note to readers/reviewers etc**:

This PR is not intended for an immediate merge. The purpose of this PR is to open up a wider discussion on this potential RFC and the attached plan of attack. (mentioned below).  This PR isn't meant to be "reviewed" in the usual sense with an eye toward merging. We implement the core net/var type split discussed further in the points I have listed as phases:

**Work done**

**Phase 1** : We add  `!sv.net<T> / !sv.var<T>` as distinct SV lvalue types (additive, so no existing behaviour changes).

**Phase 2:** We collapse `sv.reg/sv.logic` into a single `sv.var op` with an emission-keyword attribute where logic is the default (building on the direction from @dtzSiFive's prior issue a couple years ago #6318).

  **Phase 3**:  We make `!hw.inout<T>` illegal on SV ops. To bridge HW's category-neutral inout ports at the SV boundary, we added `sv.net.from_inout` and its reverse `sv.inout.from_net` for cases where a net-typed value needs to be fed into ops/ports still expecting `!hw.inout<T>.` Both bridge ops fold away when chained back-to-back.

**Phase 5** : We add `XMR/xmr.ref `category tests covering both net-producer and var-producer cases, plus the negative test for assigning into a var-typed XMR.

**Phase 6** :  We add `hw.var`, a generic, category-neutral lvalue storage op at the HW level (mirrors `hw.wire's` declaration handling but as a true lvalue declaration rather than a pass-through), with round-trip and element-type-rejection tests.


**A couple notes for readers/reviewers/etc**


1. The `sv.assign net/var` mismatch is caught at parse time via TypesMatchWith on the destination operand, not in AssignOp::verify. This is perhaps relevant when reading error tests.

2. Fixed a pre-existing bug in `getVerilogDeclWord` found while working through this: struct/union/enum-typed `sv.vars` were suppressing automatic unconditionally, even in procedural regions (correct me if i have the wrong understanding of such)

3. Byte-identical Verilog diff: not run against a pre-change baseline. As a partial check, confirmed no crashes/assertions across all `test/firtool/*.fir` tests, and `ninja -C build check-circt` passes in full (except a weird `test/Conversion/AffineToLoopSchedule/loops.mlir` failure which is unrelated for sure).

**Not Included, follow-up work required**

**Phase 4**:  Packed/unpacked type legality on` SV` ops, net-kind modelling (tri0/tri1/pullup/pulldown).

**Phases 7–9** : `hw.read_var/hw.write_var`, the `HWToSV` storage-classification lattice, and final InOutType cleanup.



Assisted-by: Claude-Code>:Opus-5 
Assisted-by: Claude-Code>:Sonnet-5
