### PR TITLE
[AXI4] Add concurrent read/write count to subordinate-like ops

### DIFF
--- a/include/circt/Dialect/AXI4/AXI4Ops.td
+++ b/include/circt/Dialect/AXI4/AXI4Ops.td
@@ -67,18 +67,25 @@ def AbstractSubordinateOp : AXI4Op<"abstract_subordinate"> {
   let summary = "A stand-alone AXI4 subordinate endpoint";
   let description = [{
     Models a subordinate endpoint with no concrete implementation, for abstract
-    network modelling. Takes the upstream `!axi4.port` it responds to.
+    network modelling. Takes the upstream `!axi4.port` it responds to, and the
+    number of writes and reads it can handle concurrently.
 
     Example:
     ```mlir
-    axi4.abstract_subordinate %clk, %rst_ni, %mgr : !axi4.port<...>
+    axi4.abstract_subordinate %clk, %rst_ni, %mgr
+      concurrent_writes 4 concurrent_reads 4 : !axi4.port<...>
     ```
   }];
 
-  let arguments = (ins ClockType:$clock, I1:$reset, PortType:$upstream);
+  let arguments = (ins ClockType:$clock, I1:$reset, PortType:$upstream,
+                       I32Attr:$concurrent_writes, I32Attr:$concurrent_reads);
 
-  let assemblyFormat =
-      "$clock `,` $reset `,` $upstream attr-dict `:` qualified(type($upstream))";
+  let assemblyFormat = [{
+    $clock `,` $reset `,` $upstream
+      `concurrent_writes` $concurrent_writes
+      `concurrent_reads` $concurrent_reads
+      attr-dict `:` qualified(type($upstream))
+  }];
 }
 
 def ChannelStructsToPortOp : AXI4ChannelStructOp<"channel_structs_to_port",
@@ -124,8 +131,9 @@ def PortToChannelStructsOp : AXI4ChannelStructOp<"port_to_channel_structs"> {
   let summary = "Converts an AXI4 port to a HW expression of an AXI4 interface";
   let description = [{
     Bridges from an `!axi4.port` to a HW dialect expression of an AXI4
-    interface. Takes the port, the AW, W and AR channel readys, and the B and R
-    payloads and valids; returns the AW, W and AR payloads and valids, and the
+    interface. Takes the port, the AW, W and AR channel readys, the B and R
+    payloads and valids, and the number of writes and reads the interface can
+    handle concurrently; returns the AW, W and AR payloads and valids, and the
     B and R readys.
 
     Example:
@@ -134,6 +142,7 @@ def PortToChannelStructsOp : AXI4ChannelStructOp<"port_to_channel_structs"> {
       axi4.port_to_channel_structs %clk, %rst_ni, %port
         aw %aw_ready w %w_ready b %b, %b_valid
         ar %ar_ready r %r, %r_valid
+        concurrent_writes 4 concurrent_reads 4
       : !axi4.port<...>
     ```
   }];
@@ -142,7 +151,9 @@ def PortToChannelStructsOp : AXI4ChannelStructOp<"port_to_channel_structs"> {
                        I1:$aw_ready, I1:$w_ready,
                        StructType:$b, I1:$b_valid,
                        I1:$ar_ready,
-                       StructType:$r, I1:$r_valid);
+                       StructType:$r, I1:$r_valid,
+                       I32Attr:$concurrent_writes,
+                       I32Attr:$concurrent_reads);
   let results = (outs StructType:$aw, I1:$aw_valid,
                       StructType:$w, I1:$w_valid,
                       I1:$b_ready,
@@ -153,6 +164,8 @@ def PortToChannelStructsOp : AXI4ChannelStructOp<"port_to_channel_structs"> {
     $clock `,` $reset `,` $port
       `aw` $aw_ready `w` $w_ready `b` $b `,` $b_valid
       `ar` $ar_ready `r` $r `,` $r_valid
+      `concurrent_writes` $concurrent_writes
+      `concurrent_reads` $concurrent_reads
       attr-dict `:` qualified(type($port))
   }];
 }

--- a/test/Dialect/AXI4/basic.mlir
+++ b/test/Dialect/AXI4/basic.mlir
@@ -99,8 +99,8 @@
 hw.module @AbstractEndpoints(in %clk : !seq.clock, in %rst_ni : i1) {
   // CHECK: %[[MGR:.+]] = axi4.abstract_manager %clk, %rst_ni {a} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
   %mgr = axi4.abstract_manager %clk, %rst_ni {a} : !port
-  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[MGR]] {b} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
-  axi4.abstract_subordinate %clk, %rst_ni, %mgr {b} : !port
+  // CHECK: axi4.abstract_subordinate %clk, %rst_ni, %[[MGR]] concurrent_writes 2 concurrent_reads 3 {b} : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  axi4.abstract_subordinate %clk, %rst_ni, %mgr concurrent_writes 2 concurrent_reads 3 {b} : !port
 }
 
 // CHECK-LABEL: hw.module @Subordinate
@@ -123,9 +123,10 @@ hw.module @Manager(in %clk : !seq.clock, in %rst_ni : i1, in %port : !port,
                    in %b : !b, in %b_valid : i1,
                    in %ar_ready : i1,
                    in %r : !r, in %r_valid : i1) {
-  // CHECK: %aw, %aw_valid, %w, %w_valid, %b_ready, %ar, %ar_valid, %r_ready = axi4.port_to_channel_structs %clk, %rst_ni, %port aw %aw_ready w %w_ready b %b, %b_valid ar %ar_ready r %r, %r_valid : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
+  // CHECK: %aw, %aw_valid, %w, %w_valid, %b_ready, %ar, %ar_valid, %r_ready = axi4.port_to_channel_structs %clk, %rst_ni, %port aw %aw_ready w %w_ready b %b, %b_valid ar %ar_ready r %r, %r_valid concurrent_writes 2 concurrent_reads 3 : !axi4.port<addr_width = 32, data_width = 64, write_id_width = 5, read_id_width = 3, user_width = 4, windows = <<base = 0x0, last = 0xfff, burst_specs = <<fixed, len = 4>>>>, outstanding_writes = 4, outstanding_reads = 4>
   %aw, %aw_valid, %w, %w_valid, %b_ready, %ar, %ar_valid, %r_ready =
     axi4.port_to_channel_structs %clk, %rst_ni, %port
       aw %aw_ready w %w_ready b %b, %b_valid
-      ar %ar_ready r %r, %r_valid : !port
+      ar %ar_ready r %r, %r_valid
+      concurrent_writes 2 concurrent_reads 3 : !port
 }

--- a/test/Dialect/AXI4/errors.mlir
+++ b/test/Dialect/AXI4/errors.mlir
@@ -100,8 +100,8 @@
 hw.module @Fanout(in %clk : !seq.clock, in %rst_ni : i1) {
   // expected-error @below {{'axi4.abstract_manager' op port result must have at most one use; route through an 'axi4.xbar' to fan out to multiple endpoints}}
   %mgr = axi4.abstract_manager %clk, %rst_ni : !port
-  axi4.abstract_subordinate %clk, %rst_ni, %mgr : !port
-  axi4.abstract_subordinate %clk, %rst_ni, %mgr : !port
+  axi4.abstract_subordinate %clk, %rst_ni, %mgr concurrent_writes 4 concurrent_reads 4 : !port
+  axi4.abstract_subordinate %clk, %rst_ni, %mgr concurrent_writes 4 concurrent_reads 4 : !port
 }
 
 // -----


### PR DESCRIPTION
The outstanding read/write capacity story is slightly muddy at the moment, since the information is now encoded in the types - in the case of subordinate-like ops especially (abstract_subordinate and port_to_channel_structs), it's not semantically clear whether the outstanding counts refer to what the subordinate can handle or what can come down the port.

To clarify this, this PR adds explicit counts to the subordinate-like ops to specify how many concurrent reads/writes they can handle, so the port type can specifically refer to the number of concurrent requests that can actually come down that port. This should make it cleaner to identify potential bottlenecks (and allows us to be stricter with typechecking when we start adding other adaptors etc. since we previously had to account for changes in outstanding read/write counts due to a subordinate setting the type downstream)

AI-assisted-by: Claude Opus 5
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
