### PR TITLE
[ImportVerilog] Emit labeled concurrent assertions outside a procedure

### DIFF
--- a/lib/Conversion/ImportVerilog/Structure.cpp
+++ b/lib/Conversion/ImportVerilog/Structure.cpp
@@ -896,6 +896,13 @@ struct ModuleVisitor : public BaseVisitor {
   }
 
   LogicalResult visit(const slang::ast::ProceduralBlockSymbol &procNode) {
+    // Slang wraps module-level concurrent assertions in a synthetic `always`
+    // procedure. The assertion is self-clocked, so it needs no process.
+    if (auto *syntax = procNode.getSyntax();
+        syntax &&
+        syntax->kind == slang::syntax::SyntaxKind::ConcurrentAssertionMember)
+      return context.convertStatement(procNode.getBody());
+
     // Detect `always @(*) <stmt>` and convert to `always_comb <stmt>` if
     // requested by the user.
     if (context.options.lowerAlwaysAtStarAsComb) {

--- a/test/Conversion/ImportVerilog/builtins.sv
+++ b/test/Conversion/ImportVerilog/builtins.sv
@@ -468,8 +468,7 @@ module SampleValueBuiltins #() (
   // CHECK: [[CLKWIRE:%.+]] = moore.net name "clk_i" wire : <l1>
   // CHECK: [[DATAWIRE:%.+]] = moore.net name "data_i" wire : <l8>
   // CHECK: [[DATABITWIRE:%.+]] = moore.net name "data_bit_i" wire : <i8>
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
   // CHECK-NEXT: [[CB:%.+]] = moore.to_builtin_int [[C_INT]] : i1
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
@@ -479,9 +478,13 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[C2_INT:%.+]] = moore.logic_to_int [[C2]] : l1
   // CHECK-NEXT: [[CURRENT:%.+]] = moore.to_builtin_int [[C2_INT]] : i1
   // CHECK-NEXT: [[SAMPLED:%.+]] = ltl.sampled [[CURRENT]] : i1
+  // CHECK: [[DELAY:%.+]] = ltl.delay [[CB]], 1, 0 : i1
+  // CHECK: [[ANTECEDENT:%.+]] = ltl.concat [[DELAY]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[IMPL:%.+]] = ltl.implication [[ANTECEDENT]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[IMPL]], posedge {{%.+}} : !ltl.property
+  // CHECK: verif.assert [[PROP]] : !ltl.property
   sampled_clk: assert property (@(posedge clk_i) clk_i |=> $sampled(clk_i));
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
   // CHECK-NEXT: [[CB:%.+]] = moore.to_builtin_int [[C_INT]] : i1
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
@@ -492,10 +495,14 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[CURRENT:%.+]] = moore.to_builtin_int [[C2_INT]] : i1
   // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[CURRENT]], 1 clk [[CLK_I1]] : i1
   // CHECK-NEXT: [[ROSE:%.+]] = comb.icmp ult [[PAST]], [[CURRENT]] : i1
+  // CHECK: [[DELAY:%.+]] = ltl.delay [[CB]], 1, 0 : i1
+  // CHECK: [[ANTECEDENT:%.+]] = ltl.concat [[DELAY]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[IMPL:%.+]] = ltl.implication [[ANTECEDENT]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[IMPL]], posedge {{%.+}} : !ltl.property
+  // CHECK: verif.assert [[PROP]] : !ltl.property
   rising_clk: assert property (@(posedge clk_i) clk_i |=> $rose(clk_i));
   // Check that the output of rose can be used by non-LTL ops
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -507,9 +514,12 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[ROSE_INT:%.+]] = moore.from_builtin_int [[ROSE]] : i1
   // CHECK-NEXT: [[ROSE_LOGIC:%.+]] = moore.int_to_logic [[ROSE_INT]] : i1
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[C1]], [[ROSE_LOGIC]] : l1 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   rose_eq: assert property (@(posedge clk_i) clk_i == $rose(clk_i));
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
   // CHECK-NEXT: [[CB:%.+]] = moore.to_builtin_int [[C_INT]] : i1
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
@@ -520,10 +530,14 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[CURRENT:%.+]] = moore.to_builtin_int [[C2_INT]] : i1
   // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[CURRENT]], 1 clk [[CLK_I1]] : i1
   // CHECK-NEXT: [[FELL:%.+]] = comb.icmp ugt [[PAST]], [[CURRENT]] : i1
+  // CHECK: [[DELAY:%.+]] = ltl.delay [[CB]], 1, 0 : i1
+  // CHECK: [[ANTECEDENT:%.+]] = ltl.concat [[DELAY]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[IMPL:%.+]] = ltl.implication [[ANTECEDENT]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[IMPL]], posedge {{%.+}} : !ltl.property
+  // CHECK: verif.assert [[PROP]] : !ltl.property
   falling_clk: assert property (@(posedge clk_i) clk_i |=> $fell(clk_i));
   // Check that the output of fell can be used by non-LTL ops
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -535,9 +549,12 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[FELL_INT:%.+]] = moore.from_builtin_int [[FELL]] : i1
   // CHECK-NEXT: [[FELL_LOGIC:%.+]] = moore.int_to_logic [[FELL_INT]] : i1
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[C1]], [[FELL_LOGIC]] : l1 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   fell_eq: assert property (@(posedge clk_i) clk_i == $fell(clk_i));
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
   // CHECK-NEXT: [[CB:%.+]] = moore.to_builtin_int [[C_INT]] : i1
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
@@ -548,10 +565,14 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[CURRENT:%.+]] = moore.to_builtin_int [[C2_INT]] : i1
   // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[CURRENT]], 1 clk [[CLK_I1]] : i1
   // CHECK-NEXT: [[STABLE:%.+]] = comb.icmp eq [[PAST]], [[CURRENT]] : i1
+  // CHECK: [[DELAY:%.+]] = ltl.delay [[CB]], 1, 0 : i1
+  // CHECK: [[ANTECEDENT:%.+]] = ltl.concat [[DELAY]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[IMPL:%.+]] = ltl.implication [[ANTECEDENT]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[IMPL]], posedge {{%.+}} : !ltl.property
+  // CHECK: verif.assert [[PROP]] : !ltl.property
   stable_clk: assert property (@(posedge clk_i) clk_i |=> $stable(clk_i));
   // Check that the output of stable can be used by non-LTL ops
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -563,9 +584,12 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[STABLE_INT:%.+]] = moore.from_builtin_int [[STABLE]] : i1
   // CHECK-NEXT: [[STABLE_LOGIC:%.+]] = moore.int_to_logic [[STABLE_INT]] : i1
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[C1]], [[STABLE_LOGIC]] : l1 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   stable_eq: assert property (@(posedge clk_i) clk_i == $stable(clk_i));
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
   // CHECK-NEXT: [[CB:%.+]] = moore.to_builtin_int [[C_INT]] : i1
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
@@ -576,10 +600,14 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[CURRENT:%.+]] = moore.to_builtin_int [[C2_INT]] : i1
   // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[CURRENT]], 1 clk [[CLK_I1]] : i1
   // CHECK-NEXT: [[CHANGED:%.+]] = comb.icmp ne [[PAST]], [[CURRENT]] : i1
+  // CHECK: [[DELAY:%.+]] = ltl.delay [[CB]], 1, 0 : i1
+  // CHECK: [[ANTECEDENT:%.+]] = ltl.concat [[DELAY]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[IMPL:%.+]] = ltl.implication [[ANTECEDENT]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[IMPL]], posedge {{%.+}} : !ltl.property
+  // CHECK: verif.assert [[PROP]] : !ltl.property
   changed_clk: assert property (@(posedge clk_i) clk_i |=> $changed(clk_i));
   // Check that the output of changed can be used by non-LTL ops
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -591,9 +619,12 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[CHANGED_INT:%.+]] = moore.from_builtin_int [[CHANGED]] : i1
   // CHECK-NEXT: [[CHANGED_LOGIC:%.+]] = moore.int_to_logic [[CHANGED_INT]] : i1
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[C1]], [[CHANGED_LOGIC]] : l1 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   changed_eq: assert property (@(posedge clk_i) clk_i == $changed(clk_i));
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[C_INT:%.+]] = moore.logic_to_int [[C]] : l1
   // CHECK-NEXT: [[CB:%.+]] = moore.to_builtin_int [[C_INT]] : i1
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
@@ -603,10 +634,14 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[C2_INT:%.+]] = moore.logic_to_int [[C2]] : l1
   // CHECK-NEXT: [[CURRENT:%.+]] = moore.to_builtin_int [[C2_INT]] : i1
   // CHECK-NEXT: [[PAST:%.+]] = ltl.past [[CURRENT]], 1 clk [[CLK_I1]] : i1
+  // CHECK: [[DELAY:%.+]] = ltl.delay [[CB]], 1, 0 : i1
+  // CHECK: [[ANTECEDENT:%.+]] = ltl.concat [[DELAY]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[IMPL:%.+]] = ltl.implication [[ANTECEDENT]], {{%.+}} : !ltl.sequence, i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[IMPL]], posedge {{%.+}} : !ltl.property
+  // CHECK: verif.assert [[PROP]] : !ltl.property
   past_clk: assert property (@(posedge clk_i) clk_i |=> $past(clk_i));
   // Check that the output of past can be used by non-LTL ops
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
+  // CHECK: [[C1:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -617,10 +652,13 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i1
   // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i1
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[C1]], [[PAST_LOGIC]] : l1 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   past_eq: assert property (@(posedge clk_i) clk_i == $past(clk_i));
   // Test $past on wider bitvectors
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -631,11 +669,14 @@ module SampleValueBuiltins #() (
   // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
   // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   past_data: assert property (@(posedge clk_i) data_i == $past(data_i));
 
   // Test $past in a process
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: moore.wait_event {
+  // CHECK: moore.wait_event {
   // CHECK-NEXT:   [[CLKEDGE:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT:   moore.detect_event posedge [[CLKEDGE]] : l1
   // CHECK-NEXT: }
@@ -652,16 +693,15 @@ module SampleValueBuiltins #() (
   logic [7:0] past_data_i;
   always @(posedge clk_i) past_data_i <= $past(data_i);
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK: [[RED:%.+]] = moore.reduce_xor [[D]] : l8 -> l1
   // CHECK: [[X:%.+]] = moore.constant bX : l1
   // CHECK: [[CEQ:%.+]] = moore.case_eq [[RED]], [[X]] : l1
   // CHECK: [[CEQ_I1:%.+]] = moore.to_builtin_int [[CEQ]] : i1
-  // CHECK: ltl.clock [[CEQ_I1]]
+  // CHECK: [[PROP:%.+]] = ltl.clock [[CEQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   isunknown_data: assert property (@(posedge clk_i) $isunknown(data_i));
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK: [[RED:%.+]] = moore.reduce_xor [[D]] : l8 -> l1
   // CHECK: [[X:%.+]] = moore.constant bX : l1
@@ -679,10 +719,10 @@ module SampleValueBuiltins #() (
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[MUX]] : i1
   // CHECK: [[RES_LOGIC:%.+]] = moore.int_to_logic [[RES_INT]] : i1
   // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1
-  // CHECK: ltl.clock [[RES_BUILTIN]]
+  // CHECK: [[PROP:%.+]] = ltl.clock [[RES_BUILTIN]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   onehot0_data: assert property (@(posedge clk_i) $onehot0(data_i));
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK: [[RED:%.+]] = moore.reduce_xor [[D]] : l8 -> l1
   // CHECK: [[X:%.+]] = moore.constant bX : l1
@@ -702,10 +742,10 @@ module SampleValueBuiltins #() (
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[MUX]] : i1
   // CHECK: [[RES_LOGIC:%.+]] = moore.int_to_logic [[RES_INT]] : i1
   // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1
-  // CHECK: ltl.clock [[RES_BUILTIN]]
+  // CHECK: [[PROP:%.+]] = ltl.clock [[RES_BUILTIN]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   onehot_data: assert property (@(posedge clk_i) $onehot(data_i));
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATABITWIRE]] : <i8>
   // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D]] : i8
   // CHECK: [[ONE:%.+]] = hw.constant 1 : i8
@@ -715,10 +755,10 @@ module SampleValueBuiltins #() (
   // CHECK: [[EQ:%.+]] = comb.icmp eq [[AND]], [[ZERO]] : i8
   // CHECK: [[EQ_INT:%.+]] = moore.from_builtin_int [[EQ]] : i1
   // CHECK: [[EQ_BUILTIN:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
-  // CHECK: ltl.clock [[EQ_BUILTIN]]
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_BUILTIN]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   onehot0_bit_data: assert property (@(posedge clk_i) $onehot0(data_bit_i));
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATABITWIRE]] : <i8>
   // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D]] : i8
   // CHECK: [[ONE:%.+]] = hw.constant 1 : i8
@@ -730,10 +770,10 @@ module SampleValueBuiltins #() (
   // CHECK: [[AND2:%.+]] = comb.and [[EQ]], [[NE]] : i1
   // CHECK: [[RES_INT:%.+]] = moore.from_builtin_int [[AND2]] : i1
   // CHECK: [[RES_BUILTIN:%.+]] = moore.to_builtin_int [[RES_INT]] : i1
-  // CHECK: ltl.clock [[RES_BUILTIN]]
+  // CHECK: [[PROP:%.+]] = ltl.clock [[RES_BUILTIN]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   onehot_bit_data: assert property (@(posedge clk_i) $onehot(data_bit_i));
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK: [[D_L2I:%.+]] = moore.logic_to_int [[D]] : l8
   // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D_L2I]] : i8
@@ -746,10 +786,12 @@ module SampleValueBuiltins #() (
   // CHECK: [[SEXT:%.+]] = moore.zext [[RES_INT]] : i4 -> i32
   // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
   // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   countones_data:
     assert property (@(posedge clk_i) $countones(data_i) == 0);
 
-  // CHECK: moore.procedure always {
   // CHECK: [[D:%.+]] = moore.read [[DATABITWIRE]] : <i8>
   // CHECK: [[DB:%.+]] = moore.to_builtin_int [[D]] : i8
   // CHECK: [[Z3:%.+]] = hw.constant 0 : i3
@@ -762,6 +804,9 @@ module SampleValueBuiltins #() (
   // CHECK: [[SEXT:%.+]] = moore.zext [[RES_INT]] : i4 -> i32
   // CHECK: [[ZERO:%.+]] = moore.constant 0 : i32
   // CHECK: [[EQ:%.+]] = moore.eq [[SEXT]], [[ZERO]] : i32 -> i1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge {{%.+}} : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   countones_bit_data:
     assert property (@(posedge clk_i) $countones(data_bit_i) == 0);
 endmodule
@@ -783,8 +828,7 @@ module SampleValueBuiltinsDefaultClocking #() (
   default clocking @(posedge clk_i); endclocking
 
   // Test default clocking inference for $past in an assertion
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLKWIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -795,11 +839,13 @@ module SampleValueBuiltinsDefaultClocking #() (
   // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
   // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: verif.assert [[EQ_I1]]
   assert_past: assert property (data_i == $past(data_i));
 
   // Test overriden clock in an assertion
-  // CHECK: moore.procedure always {
-  // CHECK-NEXT: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
+  // CHECK: [[D1:%.+]] = moore.read [[DATAWIRE]] : <l8>
   // CHECK-NEXT: [[CLK:%.+]] = moore.read [[CLK2WIRE]] : <l1>
   // CHECK-NEXT: [[CLK_INT:%.+]] = moore.logic_to_int [[CLK]] : l1
   // CHECK-NEXT: [[CLK_I1:%.+]] = moore.to_builtin_int [[CLK_INT]] : i1
@@ -810,6 +856,13 @@ module SampleValueBuiltinsDefaultClocking #() (
   // CHECK-NEXT: [[PAST_INT:%.+]] = moore.from_builtin_int [[PAST]] : i8
   // CHECK-NEXT: [[PAST_LOGIC:%.+]] = moore.int_to_logic [[PAST_INT]] : i8
   // CHECK-NEXT: [[EQ:%.+]] = moore.eq [[D1]], [[PAST_LOGIC]] : l8 -> l1
+  // CHECK: [[EQ_INT:%.+]] = moore.logic_to_int [[EQ]] : l1
+  // CHECK: [[EQ_I1:%.+]] = moore.to_builtin_int [[EQ_INT]] : i1
+  // CHECK: [[ACLK:%.+]] = moore.read [[CLK2WIRE]] : <l1>
+  // CHECK: [[ACLK_INT:%.+]] = moore.logic_to_int [[ACLK]] : l1
+  // CHECK: [[ACLK_I1:%.+]] = moore.to_builtin_int [[ACLK_INT]] : i1
+  // CHECK: [[PROP:%.+]] = ltl.clock [[EQ_I1]], posedge [[ACLK_I1]] : i1
+  // CHECK: verif.assert [[PROP]] : !ltl.sequence
   assert_past_clk2: assert property (@(posedge clk2_i) data_i == $past(data_i));
 
   // Test default clocking inference for $past in a continuous assignment

--- a/test/Conversion/ImportVerilog/concurrent-assertions.sv
+++ b/test/Conversion/ImportVerilog/concurrent-assertions.sv
@@ -1,0 +1,67 @@
+// RUN: circt-translate --import-verilog %s | FileCheck %s
+// REQUIRES: slang
+
+// Internal issue in Slang v3 about jump depending on uninitialized value.
+// UNSUPPORTED: valgrind
+
+// Slang models a labeled statement as a sequential block wrapped around the
+// statement itself. A labeled concurrent assertion must still be emitted
+// directly into the module body, the same way an unlabeled one is, instead of
+// being buried in an `always` procedure that no later pass can dissolve.
+
+// CHECK-LABEL: moore.module @Unlabeled
+// CHECK-NOT: moore.procedure
+// CHECK: verif.assert
+module Unlabeled(input logic clk, input logic a, input logic b);
+  assert property (@(posedge clk) a |-> b);
+endmodule
+
+// CHECK-LABEL: moore.module @Labeled
+// CHECK-NOT: moore.procedure
+// CHECK: verif.assert
+module Labeled(input logic clk, input logic a, input logic b);
+  my_assert: assert property (@(posedge clk) a |-> b);
+endmodule
+
+// CHECK-LABEL: moore.module @LabeledAssume
+// CHECK-NOT: moore.procedure
+// CHECK: verif.assume
+module LabeledAssume(input logic clk, input logic a, input logic b);
+  my_assume: assume property (@(posedge clk) a |-> b);
+endmodule
+
+// Several labeled assertions in one module all land in the module body.
+// CHECK-LABEL: moore.module @ManyLabeled
+// CHECK-NOT: moore.procedure
+// CHECK: verif.assert
+// CHECK: verif.assert
+// CHECK: verif.assert
+module ManyLabeled(input logic clk, input logic a, input logic b);
+  first:  assert property (@(posedge clk) a |-> b);
+  second: assert property (@(posedge clk) b |-> a);
+  third:  assert property (@(posedge clk) a);
+endmodule
+
+// A procedure that is not a concurrent assertion keeps its procedure.
+// CHECK-LABEL: moore.module @OrdinaryProcedure
+// CHECK: moore.procedure always_comb
+module OrdinaryProcedure(input logic a, output logic b);
+  always_comb begin
+    b = a;
+  end
+endmodule
+
+// Slang wraps a module-level deferred immediate assertion in the same synthetic
+// `always` procedure. Check that this isn't stripped.
+// CHECK-LABEL: moore.module @DeferredImmediate
+// CHECK: moore.procedure always {
+// CHECK: moore.assert final
+// CHECK: moore.procedure always {
+// CHECK: moore.assume final
+// CHECK: moore.procedure always {
+// CHECK: moore.cover final
+module DeferredImmediate(input logic a, input logic b);
+  assert final (a);
+  assume final (b);
+  cover final (a && b);
+endmodule


### PR DESCRIPTION
A concurrent assertion with a label would not get stripped properly and would end up in an `llhd.process` that has only `cf.br` loop. The process would get through all the way to the `hw-to-btor2` which then rightfully rejects it.

Claude-Opus was used for the fix, checked by me.