### PR TITLE
[FIRRTL][LowerToHW] Remove stale attribute `firrt.extractl.do_not_extract`, NFC

### DIFF
--- a/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
+++ b/lib/Conversion/FIRRTLToHW/LowerToHW.cpp
@@ -1401,8 +1401,6 @@ FIRRTLModuleLowering::lowerModule(FModuleOp oldModule, Block *topLevelModule,
     if (loweringState.isInTestHarness(oldModule)) {
       if (!newModule->hasAttr("output_file"))
         newModule->setAttr("output_file", testBenchDir);
-      newModule->setAttr("firrtl.extract.do_not_extract",
-                         builder.getUnitAttr());
       newModule.setCommentAttr(
           builder.getStringAttr("VCS coverage exclude_file"));
     }

--- a/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
+++ b/test/Conversion/FIRRTLToHW/module-hierarchy-file.mlir
@@ -57,7 +57,7 @@ firrtl.circuit "MyDUT" {
 
 // -----
 
-// Check that "firrtl.extract.do_not_extract" is added to modules in test harness.
+// Check that test harness modules retain their coverage exclusion comment.
 firrtl.circuit "MyTestHarness" attributes {annotations = [ {class = "sifive.enterprise.firrtl.TestBenchDirAnnotation", dirname = "tb"}]}
 {
   // CHECK-LABEL: hw.module private @MyDUT() {
@@ -66,12 +66,10 @@ firrtl.circuit "MyTestHarness" attributes {annotations = [ {class = "sifive.ente
 
   // CHECK-LABEL: hw.module private @Testbench
   // CHECK-SAME:  comment = "VCS coverage exclude_file"
-  // CHECK-SAME:  firrtl.extract.do_not_extract
   firrtl.module private @Testbench() {}
 
   // CHECK-LABEL: hw.module @MyTestHarness
   // CHECK-SAME:  comment = "VCS coverage exclude_file"
-  // CHECK-SAME:  firrtl.extract.do_not_extract
   firrtl.module @MyTestHarness() {
     firrtl.instance myDUT @MyDUT()
     firrtl.instance myTestBench @Testbench()


### PR DESCRIPTION
This discardable attribute was used to interact with ExtractTestCode which was already deleted. There is no consumer for this. 


Assisted-by: pi.dev: gpt 5.6 luna
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
