### PR TITLE
[HWToLLVM] Use correctly typed constant attributes

### DIFF
--- a/lib/Conversion/HWToLLVM/HWToLLVM.cpp
+++ b/lib/Conversion/HWToLLVM/HWToLLVM.cpp
@@ -302,9 +302,9 @@ struct ArrayInjectOpConversion
       // Clamp index to prevent OOB access. We add an extra element to the
       // array so that OOB access modifies this element, leaving the original
       // array intact.
-      auto maxIndex =
-          LLVM::ConstantOp::create(rewriter, op->getLoc(), zextIndex.getType(),
-                                   rewriter.getI32IntegerAttr(arrElems));
+      auto maxIndex = LLVM::ConstantOp::create(
+          rewriter, op->getLoc(), zextIndex.getType(),
+          rewriter.getIntegerAttr(zextIndex.getType(), arrElems));
       zextIndex =
           LLVM::UMinOp::create(rewriter, op->getLoc(), zextIndex, maxIndex);
 

--- a/test/Conversion/HWToLLVM/convert_aggregates.mlir
+++ b/test/Conversion/HWToLLVM/convert_aggregates.mlir
@@ -48,7 +48,7 @@ func.func @convertArrayInject(
 
   // CHECK-NEXT: %[[ONE1:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT1:.*]] = llvm.zext %arg6 : i1 to i2
-  // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(1 : i32) : i2
+  // CHECK-NEXT: %[[MAX1:.*]] = llvm.mlir.constant(1 : i2) : i2
   // CHECK-NEXT: %[[UMIN1:.*]] = llvm.intr.umin(%[[ZEXT1]], %[[MAX1]]) : (i2, i2) -> i2
   // CHECK-NEXT: %[[ALLOCA1:.*]] = llvm.alloca %[[ONE1]] x !llvm.array<2 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %arg1, %[[ALLOCA1]] : !llvm.array<1 x i32>, !llvm.ptr
@@ -68,7 +68,7 @@ func.func @convertArrayInject(
 
   // CHECK-NEXT: %[[ONE3:.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK-NEXT: %[[ZEXT3:.*]] = llvm.zext %arg7 : i3 to i4
-  // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(5 : i32) : i4
+  // CHECK-NEXT: %[[MAX3:.*]] = llvm.mlir.constant(5 : i4) : i4
   // CHECK-NEXT: %[[UMIN3:.*]] = llvm.intr.umin(%[[ZEXT3]], %[[MAX3]]) : (i4, i4) -> i4
   // CHECK-NEXT: %[[ALLOCA3:.*]] = llvm.alloca %[[ONE3]] x !llvm.array<6 x i32> {alignment = 4 : i64} : (i32) -> !llvm.ptr
   // CHECK-NEXT: llvm.store %arg3, %[[ALLOCA3]] : !llvm.array<5 x i32>, !llvm.ptr


### PR DESCRIPTION
Recent LLVM started to verify type for llvm.constant. 

Assisted-by: codex: gpt 5.6 sol
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
