### PR TITLE
[FIRRTL] Preserve register initial values in optimizer

### DIFF
--- a/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
+++ b/include/circt/Dialect/FIRRTL/FIRRTLUtils.h
@@ -17,6 +17,7 @@
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
+#include <optional>
 
 namespace circt {
 namespace hw {
@@ -41,6 +42,13 @@ IntegerAttr getIntZerosAttr(Type type);
 
 /// Utility for generating a constant all ones attribute.
 IntegerAttr getIntOnesAttr(Type type);
+
+/// Return true if replacing a register carrying the time-zero `initial` value
+/// `initial` with `foldedValue` does not change the register's time-zero
+/// behavior.  A register with no `initial` attribute can always be folded; a
+/// register with one can only be folded into a constant that matches it.
+bool preservesInitial(IntegerAttr initial,
+                      std::optional<APInt> foldedValue = std::nullopt);
 
 /// Return the single assignment to a Property value.
 PropAssignOp getPropertyAssignment(FIRRTLPropertyValue value);

--- a/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLFolds.cpp
@@ -2325,6 +2325,13 @@ static LogicalResult canonicalizeSingleSetConnect(MatchingConnectOp op,
       return failure();
     if (srcValueOp->getBlock() != declBlock)
       return failure();
+    // A register with a time-zero `initial` value only reaches the constant on
+    // the first edge; until then it holds `initial`.  Forwarding the constant
+    // would change its value at time zero, so bail unless the two agree.
+    if (auto reg = dyn_cast<RegOp>(connectedDecl))
+      if (!preservesInitial(reg.getInitialAttr(),
+                            cast<ConstantOp>(srcValueOp).getValue()))
+        return failure();
   }
 
   // Ok, we know we are doing the transformation.
@@ -2731,17 +2738,6 @@ OpFoldResult UninferredResetCastOp::fold(FoldAdaptor adaptor) {
 }
 
 namespace {
-// Returns true if replacing a register that has an initial value with a
-// foldedValue does not change the initial behavior.
-bool preservesInitial(Operation *reg, IntegerAttr initial,
-                      std::optional<APInt> foldedValue = std::nullopt) {
-  if (!initial)
-    return true;
-  if (!foldedValue)
-    return false;
-  return initial.getValue() == *foldedValue;
-}
-
 // A register with constant reset and all connection to either itself or the
 // same constant, must be replaced by the constant.
 struct FoldResetMux : public mlir::OpRewritePattern<RegResetOp> {
@@ -2785,7 +2781,7 @@ struct FoldResetMux : public mlir::OpRewritePattern<RegResetOp> {
 
     // Bail if replacing the register with the constant would change its
     // time-zero simulation value.
-    if (!preservesInitial(reg, reg.getInitialAttr(), constOp.getValue()))
+    if (!preservesInitial(reg.getInitialAttr(), constOp.getValue()))
       return failure();
 
     // Make sure the constant dominates all users.
@@ -2821,9 +2817,9 @@ canonicalizeRegResetWithOneReset(RegResetOp reg, PatternRewriter &rewriter) {
   // Bail if replacing the register with the constant would change its
   // time-zero simulation value.
   if (auto constOp = dyn_cast_or_null<ConstantOp>(resetValue.getDefiningOp())) {
-    if (!preservesInitial(reg, reg.getInitialAttr(), constOp.getValue()))
+    if (!preservesInitial(reg.getInitialAttr(), constOp.getValue()))
       return failure();
-  } else if (!preservesInitial(reg, reg.getInitialAttr())) {
+  } else if (!preservesInitial(reg.getInitialAttr())) {
     return failure();
   }
 
@@ -3679,8 +3675,7 @@ static LogicalResult foldHiddenReset(RegOp reg, PatternRewriter &rewriter) {
 
   // If we would fold the register to a constant, ensure the time-zero
   // simulation value is preserved.
-  if (constReg &&
-      !preservesInitial(reg, reg.getInitialAttr(), constOp.getValue()))
+  if (constReg && !preservesInitial(reg.getInitialAttr(), constOp.getValue()))
     return failure();
 
   // Make sure the constant dominates all users.

--- a/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
+++ b/lib/Dialect/FIRRTL/FIRRTLUtils.cpp
@@ -234,6 +234,17 @@ IntegerAttr circt::firrtl::getIntOnesAttr(Type type) {
       type, APInt(width, -1, /*isSigned=*/false, /*implicitTrunc=*/true));
 }
 
+/// Return true if replacing a register with `foldedValue` preserves the
+/// register's time-zero (`initial`) value.
+bool circt::firrtl::preservesInitial(IntegerAttr initial,
+                                     std::optional<APInt> foldedValue) {
+  if (!initial)
+    return true;
+  if (!foldedValue)
+    return false;
+  return initial.getValue() == *foldedValue;
+}
+
 /// Return the single assignment to a Property value. It is assumed that the
 /// single assigment invariant is enforced elsewhere.
 PropAssignOp circt::firrtl::getPropertyAssignment(FIRRTLPropertyValue value) {

--- a/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/RegisterOptimizer.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "circt/Dialect/FIRRTL/FIRRTLOps.h"
+#include "circt/Dialect/FIRRTL/FIRRTLUtils.h"
 #include "circt/Dialect/FIRRTL/Passes.h"
 #include "circt/Support/Debug.h"
 #include "mlir/IR/Dominance.h"
@@ -62,18 +63,36 @@ void RegisterOptimizerPass::checkReg(mlir::DominanceInfo &dom,
   if (!con)
     return;
 
-  // Register is only written by itself, replace with invalid.
+  // Register is only written by itself.  Without a time-zero `initial` value
+  // its value is unspecified, so replace it with invalid.  With one, the
+  // register holds that constant forever, so replace it with the constant.
   if (con.getSrc() == reg.getResult()) {
     auto builder = OpBuilder(reg);
-    auto inv = InvalidValueOp::create(builder, reg.getLoc(),
-                                      reg.getResult().getType());
-    reg.getResult().replaceAllUsesWith(inv.getResult());
+    Value replacement;
+    if (auto initial = reg.getInitialAttr())
+      replacement =
+          ConstantOp::create(builder, reg.getLoc(),
+                             type_cast<IntType>(reg.getResult().getType()),
+                             initial.getValue())
+              .getResult();
+    else
+      replacement = InvalidValueOp::create(builder, reg.getLoc(),
+                                           reg.getResult().getType())
+                        .getResult();
+    reg.getResult().replaceAllUsesWith(replacement);
     toErase.push_back(reg);
     toErase.push_back(con);
     return;
   }
   // Register is only written by a constant
   if (isConstant(con.getSrc())) {
+    // Bail if replacing the register with the constant would change its
+    // time-zero simulation value.
+    auto cstOp = con.getSrc().getDefiningOp<ConstantOp>();
+    if (!preservesInitial(reg.getInitialAttr(),
+                          cstOp ? std::optional<APInt>(cstOp.getValue())
+                                : std::nullopt))
+      return;
     // constant may not dominate the register.  But it might be the next
     // operation, so we can't just move it.  Straight constants can be
     // rematerialized.  Derived constants are piped through wires.
@@ -117,6 +136,14 @@ void RegisterOptimizerPass::checkRegReset(mlir::DominanceInfo &dom,
     return;
   auto con = getSingleConnectUserOf(reg.getResult());
   if (!con)
+    return;
+
+  // Both folds below replace the register with its reset value, so bail if
+  // that would change the register's time-zero (`initial`) value.
+  auto resetCstOp = reg.getResetValue().getDefiningOp<ConstantOp>();
+  if (!preservesInitial(reg.getInitialAttr(),
+                        resetCstOp ? std::optional<APInt>(resetCstOp.getValue())
+                                   : std::nullopt))
     return;
 
   // Register is only written by itself, and reset with a constant.

--- a/test/Dialect/FIRRTL/canonicalization.mlir
+++ b/test/Dialect/FIRRTL/canonicalization.mlir
@@ -4228,4 +4228,31 @@ firrtl.module @ZeroResetForwardsInitial(in %clock: !firrtl.clock, out %q: !firrt
   %r = firrtl.regreset %clock, %zero, %c0 {initial = 4 : ui8} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<8>, !firrtl.uint<8>
   firrtl.matchingconnect %q, %r : !firrtl.uint<8>
 }
+
+// A register driven only by a constant is *not* that constant while it still
+// holds its time-zero `initial` value, so the single-set forward must bail.
+// This is the "has the clock ticked yet" flag shape: `initial = 0`, driven by a
+// constant 1.
+// CHECK-LABEL: firrtl.module @SingleSetConstantRegKeepsInitial
+firrtl.module @SingleSetConstantRegKeepsInitial(in %clock: !firrtl.clock, out %q: !firrtl.uint<1>, out %q2: !firrtl.uint<1>) {
+  // CHECK: %r = firrtl.reg %clock {initial = 0 : ui1}
+  // CHECK: firrtl.matchingconnect %r, %c1_ui1
+  %r = firrtl.reg %clock {initial = 0 : ui1} : !firrtl.clock, !firrtl.uint<1>
+  %c1 = firrtl.constant 1 : !firrtl.uint<1>
+  firrtl.matchingconnect %r, %c1 : !firrtl.uint<1>
+  firrtl.matchingconnect %q, %r : !firrtl.uint<1>
+  firrtl.matchingconnect %q2, %r : !firrtl.uint<1>
+}
+
+// The same forward is fine when `initial` agrees with the constant.
+// CHECK-LABEL: firrtl.module @SingleSetConstantRegMatchingInitial
+firrtl.module @SingleSetConstantRegMatchingInitial(in %clock: !firrtl.clock, out %q: !firrtl.uint<1>, out %q2: !firrtl.uint<1>) {
+  // CHECK-NOT: firrtl.reg
+  %r = firrtl.reg %clock {initial = 1 : ui1} : !firrtl.clock, !firrtl.uint<1>
+  %c1 = firrtl.constant 1 : !firrtl.uint<1>
+  firrtl.matchingconnect %r, %c1 : !firrtl.uint<1>
+  firrtl.matchingconnect %q, %r : !firrtl.uint<1>
+  firrtl.matchingconnect %q2, %r : !firrtl.uint<1>
+}
+
 }

--- a/test/Dialect/FIRRTL/register-optimizer.mlir
+++ b/test/Dialect/FIRRTL/register-optimizer.mlir
@@ -11,6 +11,73 @@ firrtl.circuit "invalidReg"   {
     firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
   }
 
+  // A self-driven register with a time-zero `initial` value holds that value
+  // forever, so it folds to the constant -- not to invalid.
+  // CHECK-LABEL: @invalidRegInitialOne
+  firrtl.module @invalidRegInitialOne(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
+    %foobar = firrtl.reg %clock {initial = 1 : ui1} : !firrtl.clock, !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %foobar : !firrtl.uint<1>
+    //CHECK-NOT: firrtl.invalidvalue
+    //CHECK: %[[const:.*]] = firrtl.constant 1
+    //CHECK: firrtl.matchingconnect %a, %[[const]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: @invalidRegInitialZero
+  firrtl.module @invalidRegInitialZero(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
+    %foobar = firrtl.reg %clock {initial = 0 : ui1} : !firrtl.clock, !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %foobar : !firrtl.uint<1>
+    //CHECK-NOT: firrtl.invalidvalue
+    //CHECK: %[[const:.*]] = firrtl.constant 0
+    //CHECK: firrtl.matchingconnect %a, %[[const]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+  }
+
+  // A constant-driven register whose `initial` value differs from that constant
+  // must not be folded: it is 1 at time zero and 0 afterwards.
+  // CHECK-LABEL: @constantRegWriteInitialMismatch
+  firrtl.module @constantRegWriteInitialMismatch(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %foobar = firrtl.reg %clock {initial = 1 : ui1} : !firrtl.clock, !firrtl.uint<1>
+    //CHECK: %[[reg:.*]] = firrtl.reg %clock {initial = 1 : ui1}
+    //CHECK: firrtl.matchingconnect %[[reg]], %c
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[reg]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+  }
+
+  // Matching `initial` and driver: folding is still allowed.
+  // CHECK-LABEL: @constantRegWriteInitialMatch
+  firrtl.module @constantRegWriteInitialMatch(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %foobar = firrtl.reg %clock {initial = 0 : ui1} : !firrtl.clock, !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
+    //CHECK-NOT: firrtl.reg
+    //CHECK: firrtl.matchingconnect %a, %c
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: @constantRegResetWriteInitialMismatch
+  firrtl.module @constantRegResetWriteInitialMismatch(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %foobar = firrtl.regreset %clock, %reset, %c {initial = 1 : ui1} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    //CHECK: %[[reg:.*]] = firrtl.regreset {{.*}} {initial = 1 : ui1}
+    //CHECK: firrtl.matchingconnect %[[reg]], %c
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
+    //CHECK: firrtl.matchingconnect %a, %[[reg]]
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+  }
+
+  // CHECK-LABEL: @constantRegResetWriteInitialMatch
+  firrtl.module @constantRegResetWriteInitialMatch(in %clock: !firrtl.clock, in %reset: !firrtl.uint<1>, out %a: !firrtl.uint<1>) {
+    %c = firrtl.constant 0 : !firrtl.uint<1>
+    %foobar = firrtl.regreset %clock, %reset, %c {initial = 0 : ui1} : !firrtl.clock, !firrtl.uint<1>, !firrtl.uint<1>, !firrtl.uint<1>
+    firrtl.matchingconnect %foobar, %c : !firrtl.uint<1>
+    //CHECK-NOT: firrtl.regreset
+    //CHECK: firrtl.matchingconnect %a, %c
+    firrtl.matchingconnect %a, %foobar : !firrtl.uint<1>
+  }
+
   // CHECK-LABEL: @constantRegWrite
   firrtl.module @constantRegWrite(in %clock: !firrtl.clock, out %a: !firrtl.uint<1>) {
     %c = firrtl.constant 0 : !firrtl.uint<1>


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
This PR ensures the register optimizers handle the time zero initial attribute correctly.
It Adds the check to ensure replacing a register with a folded value doesn't 
conflict with the time-zero initial value.

Assisted-by: Claude sonnet 4.6