### PR TITLE
[FIRRTL] Handle forceable registers in comb loop analysis

### DIFF
--- a/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/CheckCombLoops.cpp
@@ -100,19 +100,17 @@ public:
             // destination and the second is the source.
             for (auto [dest, source] : df.computeDataFlow())
               addDrivenBy(dest, source);
+            // RegOp/RegResetOp implement CombDataFlow *and* Forceable. Without
+            // this, probe recording is skipped and addToPortPathsIfRWProbe
+            // asserts on a missing equivalence class.
+            if (auto forceableOp = dyn_cast<Forceable>(op))
+              recordForceableProbe(forceableOp);
           })
           .Case<Forceable>([&](Forceable forceableOp) {
             // Any declaration that can be forced.
             if (auto node = dyn_cast<NodeOp>(op))
               recordDataflow(node.getData(), node.getInput());
-            if (!forceableOp.isForceable() ||
-                forceableOp.getDataRef().use_empty())
-              return;
-            auto data = forceableOp.getData();
-            auto ref = forceableOp.getDataRef();
-            // Record dataflow from data to the probe.
-            recordDataflow(ref, data);
-            recordProbe(data, ref);
+            recordForceableProbe(forceableOp);
           })
           .Case<RefSendOp>([&](RefSendOp send) {
             recordDataflow(send.getResult(), send.getBase());
@@ -325,9 +323,16 @@ public:
     if (iter == rwProbeRefersTo.end())
       return;
 
-    assert(iter != rwProbeRefersTo.end());
-    if (iter->second != dstNode)
-      drivenBy[iter->second].second.push_back(getOrAddNode(srcVal));
+    auto dataNode = iter->second;
+    if (dataNode == dstNode)
+      return;
+    // Force of a register is sequential, so do not add a combinational edge
+    // into the register data.
+    auto dataVal = drivenBy[dataNode].first.getValue();
+    if (auto *def = dataVal.getDefiningOp())
+      if (isa<RegOp, RegResetOp>(def))
+        return;
+    drivenBy[dataNode].second.push_back(getOrAddNode(srcVal));
   }
 
   // Helper to process instance ports for a given module and instance results.
@@ -648,6 +653,16 @@ public:
     });
   }
 
+  void recordForceableProbe(Forceable forceableOp) {
+    if (!forceableOp.isForceable() || forceableOp.getDataRef().use_empty())
+      return;
+    auto data = forceableOp.getData();
+    auto ref = forceableOp.getDataRef();
+    // Record dataflow from data to the probe.
+    recordDataflow(ref, data);
+    recordProbe(data, ref);
+  }
+
   void recordProbe(Value data, Value ref) {
     auto refNode = getOrAddNode(ref);
     auto dataNode = getOrAddNode(data);
@@ -668,12 +683,13 @@ public:
     auto baseFieldRef = drivenBy[srcNode].first;
     if (auto defOp = dyn_cast_or_null<Forceable>(baseFieldRef.getDefiningOp()))
       if (defOp.isForceable() && !defOp.getDataRef().use_empty()) {
-        // Assumption, the probe must exist in the equivalence classes.
-        auto rwProbeNode =
-            rwProbeClasses.getLeaderValue(getOrAddNode(defOp.getDataRef()));
+        auto probeNode = getOrAddNode(defOp.getDataRef());
+        auto leader = rwProbeClasses.findLeader(probeNode);
+        if (leader == rwProbeClasses.member_end())
+          return;
         // For all the probes, that are in the same eqv class, i.e., refer to
         // the same value.
-        for (auto probe : rwProbeClasses.members(rwProbeNode)) {
+        for (auto probe : rwProbeClasses.members(*leader)) {
           auto probeVal = drivenBy[probe].first;
           // If the probe is a port, then record the path from the probe to the
           // input port.

--- a/test/Dialect/FIRRTL/check-comb-loops.mlir
+++ b/test/Dialect/FIRRTL/check-comb-loops.mlir
@@ -1214,3 +1214,55 @@ firrtl.circuit "InstanceChoiceLoopAlt" {
     firrtl.matchingconnect %y, %inst_out : !firrtl.uint<8>
   }
 }
+
+// -----
+
+// Forceable registers implement CombDataFlow, so their RWProbes must still be
+// recorded.
+// CHECK: firrtl.circuit "ForceableRegInChild"
+firrtl.circuit "ForceableRegInChild" {
+  firrtl.module @Child(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
+                       in %v: !firrtl.uint<8>, in %d: !firrtl.uint<8>,
+                       out %o: !firrtl.uint<8>) {
+    %r, %r_ref = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+    firrtl.matchingconnect %o, %r : !firrtl.uint<8>
+    firrtl.ref.force %clock, %en, %r_ref, %v : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>, !firrtl.uint<8>
+  }
+  firrtl.module @ForceableRegInChild(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                     in %v: !firrtl.uint<8>, in %d: !firrtl.uint<8>,
+                                     out %o: !firrtl.uint<8>) {
+    %c_clock, %c_en, %c_v, %c_d, %c_o = firrtl.instance c @Child(in clock: !firrtl.clock, in en: !firrtl.uint<1>, in v: !firrtl.uint<8>, in d: !firrtl.uint<8>, out o: !firrtl.uint<8>)
+    firrtl.matchingconnect %c_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %c_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %c_v, %v : !firrtl.uint<8>
+    firrtl.matchingconnect %c_d, %d : !firrtl.uint<8>
+    firrtl.matchingconnect %o, %c_o : !firrtl.uint<8>
+  }
+}
+
+// -----
+
+// Exporting the RWProbe of a forceable register.
+// CHECK: firrtl.circuit "ForceableRegExportedRWProbe"
+firrtl.circuit "ForceableRegExportedRWProbe" {
+  firrtl.module @Child(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
+                       in %v: !firrtl.uint<8>, in %d: !firrtl.uint<8>,
+                       out %o: !firrtl.uint<8>, out %p: !firrtl.rwprobe<uint<8>>) {
+    %r, %r_ref = firrtl.reg %clock forceable : !firrtl.clock, !firrtl.uint<8>, !firrtl.rwprobe<uint<8>>
+    firrtl.matchingconnect %r, %d : !firrtl.uint<8>
+    firrtl.matchingconnect %o, %r : !firrtl.uint<8>
+    firrtl.ref.define %p, %r_ref : !firrtl.rwprobe<uint<8>>
+    firrtl.ref.force %clock, %en, %r_ref, %v : !firrtl.clock, !firrtl.uint<1>, !firrtl.rwprobe<uint<8>>, !firrtl.uint<8>
+  }
+  firrtl.module @ForceableRegExportedRWProbe(in %clock: !firrtl.clock, in %en: !firrtl.uint<1>,
+                                             in %v: !firrtl.uint<8>, in %d: !firrtl.uint<8>,
+                                             out %o: !firrtl.uint<8>) {
+    %c_clock, %c_en, %c_v, %c_d, %c_o, %c_p = firrtl.instance c @Child(in clock: !firrtl.clock, in en: !firrtl.uint<1>, in v: !firrtl.uint<8>, in d: !firrtl.uint<8>, out o: !firrtl.uint<8>, out p: !firrtl.rwprobe<uint<8>>)
+    firrtl.matchingconnect %c_clock, %clock : !firrtl.clock
+    firrtl.matchingconnect %c_en, %en : !firrtl.uint<1>
+    firrtl.matchingconnect %c_v, %v : !firrtl.uint<8>
+    firrtl.matchingconnect %c_d, %d : !firrtl.uint<8>
+    firrtl.matchingconnect %o, %c_o : !firrtl.uint<8>
+  }
+}


### PR DESCRIPTION
<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
This PR fixes `firrtl-check-comb-loops` a bug with the handling of forceable registers and reset registers.
`RegOp` and `RegResetOp` implement both `CombDataFlow` and `Forceable`. Because the pass previously handled these operations only through the CombDataFlow case, their RWProbe metadata was not recorded. This could leave the probe out of the equivalence classes and cause an assertion failure while tracing module port paths.

Assisted-by:Opus 5
