### PR TITLE
Lists all hw, comb, seq components in verilog and sv files

### DIFF
--- a/tools/hw-estimate/CMakeLists.txt
+++ b/tools/hw-estimate/CMakeLists.txt
@@ -1,0 +1,16 @@
+# circt/tools/hw-estimate/CMakeLists.txt
+set(LLVM_LINK_COMPONENTS Support)
+
+add_circt_tool(hw-estimate
+  hw-estimate.cpp
+)
+
+target_link_libraries(hw-estimate
+  PRIVATE
+  CIRCTHW
+  CIRCTComb
+  CIRCTSeq
+  MLIRIR
+  MLIRParser
+  MLIRSupport
+)

--- a/tools/hw-estimate/cost-model.json
+++ b/tools/hw-estimate/cost-model.json
@@ -1,0 +1,23 @@
+{
+    "_comment" : "GE cost based on assumption that NAND = 1 GE"
+    "comb.and":     { "ge_per_bit": 1.5, "fixed_ge": 0, "scales_with_operands": true },
+    "comb.or":      { "ge_per_bit": 1.5, "fixed_ge": 0, "scales_with_operands": true },
+    "comb.xor":     { "ge_per_bit": 2.5, "fixed_ge": 0, "scales_with_operands": true },
+    "comb.mux":     { "ge_per_bit": 2.25, "fixed_ge": 0 },
+    "comb.add":     { "ge_per_bit": 9.5, "fixed_ge": 0 },
+    "comb.sub":     { "ge_per_bit": 10.0, "fixed_ge": 0 },
+    "comb.mul":     { "ge_quadratic_k": 11.0 },
+    "comb.divu":    { "ge_quadratic_k": 15.0 },
+    "comb.divs":    { "ge_quadratic_k": 16.0 },
+    "comb.icmp": {
+        "eq_predicates":  { "predicates": ["eq", "ceq", "ne", "cne"], "ge_per_bit": 4.0 },
+        "mag_predicates": { "predicates": ["ult","ule","ugt","uge","slt","sle","sgt","sge"], "ge_per_bit": 9.0 }
+    },
+    "comb.extract": { "ge_per_bit": 0.0, "fixed_ge": 0 },
+    "comb.concat":  { "ge_per_bit": 0.0, "fixed_ge": 0 },
+    "hw.constant":  { "ge_per_bit": 0.0, "fixed_ge": 0 }
+  },
+  "ff_ge_per_bit": 6.0,
+  "sram_ge_per_bit": 0.4
+  }
+}

--- a/tools/hw-estimate/hw-estimate.cpp
+++ b/tools/hw-estimate/hw-estimate.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file hw-estimate.cpp
+ * @author Terrence Cao
+ * @brief Lightweight tool to estimate the GE and FO4 of a potential hardware design
+ * @details current usage: build/bin/circt-verilog <verilog file> | build/bin/hw-estimate -
+ *
+ */
+
+
+
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/Parser/Parser.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
+
+using namespace mlir;
+
+static llvm::cl::opt<std::string> inputFileName(
+    llvm::cl::Positional, llvm::cl::desc("<input .mlir file>"),
+    llvm::cl::init("-")
+);
+
+int main(int argc, char** argv)
+{
+  llvm::InitLLVM y(argc, argv);
+  llvm::cl::ParseCommandLineOptions(argc, argv, "hw-estimate\n");
+
+  DialectRegistry registry;
+  registry.insert<circt::hw::HWDialect, circt::comb::CombDialect, circt::seq::SeqDialect>();
+
+  MLIRContext context(registry);
+
+  OwningOpRef<ModuleOp> module = parseSourceFile<ModuleOp>(inputFileName, &context);
+
+  if(!module)
+  {
+    llvm::errs() << "Failed to parse the input\n";
+    return 1;
+  }
+
+  module->walk([&](Operation *op)
+  {
+    llvm::outs() << op->getName().getStringRef() << "\n";
+  });
+
+  return 0;
+}

--- a/tools/hw-estimate/test/ALU.sv
+++ b/tools/hw-estimate/test/ALU.sv
@@ -1,0 +1,90 @@
+/* ALU Arithmetic and Logic Operations
+----------------------------------------------------------------------
+|ALU_Sel|   ALU Operation
+----------------------------------------------------------------------
+| 0000  |   ALU_Out = A + B;
+----------------------------------------------------------------------
+| 0001  |   ALU_Out = A - B;
+----------------------------------------------------------------------
+| 0010  |   ALU_Out = A * B;
+----------------------------------------------------------------------
+| 0011  |   ALU_Out = A / B;
+----------------------------------------------------------------------
+| 0100  |   ALU_Out = A << 1;
+----------------------------------------------------------------------
+| 0101  |   ALU_Out = A >> 1;
+----------------------------------------------------------------------
+| 0110  |   ALU_Out = A rotated left by 1;
+----------------------------------------------------------------------
+| 0111  |   ALU_Out = A rotated right by 1;
+----------------------------------------------------------------------
+| 1000  |   ALU_Out = A and B;
+----------------------------------------------------------------------
+| 1001  |   ALU_Out = A or B;
+----------------------------------------------------------------------
+| 1010  |   ALU_Out = A xor B;
+----------------------------------------------------------------------
+| 1011  |   ALU_Out = A nor B;
+----------------------------------------------------------------------
+| 1100  |   ALU_Out = A nand B;
+----------------------------------------------------------------------
+| 1101  |   ALU_Out = A xnor B;
+----------------------------------------------------------------------
+| 1110  |   ALU_Out = 1 if A>B else 0;
+----------------------------------------------------------------------
+| 1111  |   ALU_Out = 1 if A=B else 0;
+----------------------------------------------------------------------*/
+// fpga4student.com: FPGA projects, Verilog projects, VHDL projects
+// Verilog project: Verilog code for ALU
+// by FPGA4STUDENT
+module alu(
+           input [7:0] A,B,  // ALU 8-bit Inputs                 
+           input [3:0] ALU_Sel,// ALU Selection
+           output [7:0] ALU_Out, // ALU 8-bit Output
+           output CarryOut // Carry Out Flag
+    );
+    reg [7:0] ALU_Result;
+    wire [8:0] tmp;
+    assign ALU_Out = ALU_Result; // ALU out
+    assign tmp = {1'b0,A} + {1'b0,B};
+    assign CarryOut = tmp[8]; // Carryout flag
+    always @(*)
+    begin
+        case(ALU_Sel)
+        4'b0000: // Addition
+           ALU_Result = A + B ; 
+        4'b0001: // Subtraction
+           ALU_Result = A - B ;
+        4'b0010: // Multiplication
+           ALU_Result = A * B;
+        4'b0011: // Division
+           ALU_Result = A/B;
+        4'b0100: // Logical shift left
+           ALU_Result = A<<1;
+         4'b0101: // Logical shift right
+           ALU_Result = A>>1;
+         4'b0110: // Rotate left
+           ALU_Result = {A[6:0],A[7]};
+         4'b0111: // Rotate right
+           ALU_Result = {A[0],A[7:1]};
+          4'b1000: //  Logical and 
+           ALU_Result = A & B;
+          4'b1001: //  Logical or
+           ALU_Result = A | B;
+          4'b1010: //  Logical xor 
+           ALU_Result = A ^ B;
+          4'b1011: //  Logical nor
+           ALU_Result = ~(A | B);
+          4'b1100: // Logical nand 
+           ALU_Result = ~(A & B);
+          4'b1101: // Logical xnor
+           ALU_Result = ~(A ^ B);
+          4'b1110: // Greater comparison
+           ALU_Result = (A>B)?8'd1:8'd0 ;
+          4'b1111: // Equal comparison   
+            ALU_Result = (A==B)?8'd1:8'd0 ;
+          default: ALU_Result = A + B ; 
+        endcase
+    end
+
+endmodule


### PR DESCRIPTION

Version 0 of hw-estimate, a lightweight tool used to quickly estimate GE and FO4 (area and rough speed) of a potential hardware design, without having to go through lengthy synthesis processes.