### PR TITLE
[circt-bmc] Print only first counterexample by default

### DIFF
--- a/include/circt/Conversion/Passes.td
+++ b/include/circt/Conversion/Passes.td
@@ -801,7 +801,7 @@ def LowerSMTToZ3LLVM : Pass<"lower-smt-to-z3-llvm", "mlir::ModuleOp"> {
            "Insert additional printf calls printing the solver's state to "
            "stdout (e.g. at check-sat operations) for debugging purposes">,
     Option<"printOnlyFirstCounterexample", "print-only-first-counterexample",
-           "bool", "false",
+           "bool", "true",
            "Suppress counterexample printing after the first successfully "
            "printed model in each solver invocation">,
   ];

--- a/integration_test/circt-bmc/counterexample.mlir
+++ b/integration_test/circt-bmc/counterexample.mlir
@@ -1,7 +1,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit
-// RUN: circt-bmc %s -b 3 --module FormalTop --shared-libs=%libz3 | FileCheck %s --check-prefix=MULTI
-// RUN: circt-bmc %s -b 3 --module FormalTop --shared-libs=%libz3 --print-only-first-counterexample | FileCheck %s --check-prefix=ONE
+// RUN: circt-bmc %s -b 3 --module FormalTop --shared-libs=%libz3 --print-only-first-counterexample=false | FileCheck %s --check-prefix=MULTI
+// RUN: circt-bmc %s -b 3 --module FormalTop --shared-libs=%libz3 --print-only-first-counterexample=true | FileCheck %s --check-prefix=ONE
 
 // MULTI: counterexample for FormalTop:
 // MULTI: counterexample for FormalTop:

--- a/integration_test/circt-bmc/system-verilog.sv
+++ b/integration_test/circt-bmc/system-verilog.sv
@@ -2,7 +2,7 @@
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit
 // UNSUPPORTED: valgrind
-// RUN: circt-verilog %s --top=Top | circt-bmc - --module Top -b 1 --shared-libs=%libz3 --print-only-first-counterexample | FileCheck %s
+// RUN: circt-verilog %s --top=Top | circt-bmc - --module Top -b 1 --shared-libs=%libz3 | FileCheck %s
 
 // CHECK: counterexample for Top:
 // CHECK: cycle 0:

--- a/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
+++ b/test/Conversion/SMTToZ3LLVM/smt-to-z3-llvm.mlir
@@ -1,6 +1,6 @@
-// RUN: circt-opt %s --lower-smt-to-z3-llvm="print-only-first-counterexample=true" | FileCheck %s
-// RUN: circt-opt %s --lower-smt-to-z3-llvm="debug=true print-only-first-counterexample=true" | FileCheck %s --check-prefix=CHECK-DEBUG
-// RUN: circt-opt %s --lower-smt-to-z3-llvm | FileCheck %s --check-prefix=CHECK-MULTI
+// RUN: circt-opt %s --lower-smt-to-z3-llvm | FileCheck %s
+// RUN: circt-opt %s --lower-smt-to-z3-llvm="debug=true" | FileCheck %s --check-prefix=CHECK-DEBUG
+// RUN: circt-opt %s --lower-smt-to-z3-llvm="print-only-first-counterexample=false" | FileCheck %s --check-prefix=CHECK-MULTI
 
 // CHECK-LABEL: llvm.mlir.global internal @ctx_0()
 // CHECK-NEXT:   llvm.mlir.zero : !llvm.ptr

--- a/tools/circt-bmc/circt-bmc.cpp
+++ b/tools/circt-bmc/circt-bmc.cpp
@@ -124,7 +124,7 @@ static cl::opt<bool> printOnlyFirstCounterexample(
     "print-only-first-counterexample",
     cl::desc("Print only the first successfully generated counterexample for "
              "each solver invocation"),
-    cl::init(false), cl::cat(mainCategory));
+    cl::init(true), cl::cat(mainCategory));
 
 static cl::opt<bool>
     verbosePassExecutions("verbose-pass-executions",


### PR DESCRIPTION
I reckon the vast majority of the time people are only going to want to see the first counterexample, so this just sets that as the default behaviour in circt-bmc and LowerSMTToZ3LLVM.

CC @5iri (I can't request a review from you on GitHub because you're not in the LLVM org but a review would be appreciated!)

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
