### PR TITLE
[NFC][Slang] Export BOOST_REGEX_STANDALONE when Slang is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,6 +587,14 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     set(SLANG_USE_THREADS OFF)  # avoid race condition in BS::thread_pool
     FetchContent_MakeAvailable(slang)
 
+    # The vendored Boost.Regex headers can otherwise discover an unrelated
+    # system Boost installation through the global include paths.  Force the
+    # header-only fallback into standalone mode so it does not require a
+    # Boost.Regex library at link time.
+    if(TARGET boost_unordered)
+      target_compile_definitions(boost_unordered INTERFACE BOOST_REGEX_STANDALONE)
+    endif()
+
     if(LLVM_ENABLE_ASSERTIONS)
       target_compile_definitions(slang_slang PUBLIC SLANG_ASSERT_ENABLED=1)
     endif()


### PR DESCRIPTION
Previously the CMake buildflow with `SLANG_FRONTEND_ENABLED=ON` would build a vendored Boost version. However, on systems where another system-wide version of boost is installed, this could lead to link-time errors when trying to link `Boost.Regex`.

This patch exports `BOOST_REGEX_STANDALONE` on `boost_unordered` as an INTERFACE compile def to use the vendored header-only regex implementation and avoid pulling in incompatible system-wide boost implementations.

No tokens were burnt in the making of this PR.