### PR TITLE
DRAFT: [HW] Analyse clock domain crossings in CIRCT

### DIFF
--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -61,6 +61,23 @@ def ExternalizeClockGate: Pass<"externalize-clock-gate", "mlir::ModuleOp"> {
   ];
 }
 
+def PropagateClockDomains : Pass<"seq-propagate-clock-domains", "mlir::ModuleOp"> {
+  let summary = "Propagate may clock domains through a hardware hierarchy";
+  let description = [{
+    Propagate may clock domains through dataflow and `hw.instance` operations.
+    The `seq.clock_domains` port attribute is an array of string domain
+    identifiers which seeds a public module input. The pass writes the
+    resulting domain set to each operation result it reaches.
+
+    Results of operations implementing `seq::Clocked` are coherent to their
+    clock operand. Other results conservatively join the domains of their
+    operands. Module bodies are evaluated independently for each instance, so
+    propagation itself is not contaminated by domains from sibling instances.
+    The annotation on a multiply-instantiated operation is the union of its
+    instance-context results.
+  }];
+}
+
 def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
   let summary = "Implement FIRRTMMem memories nodes with simulation model";
   let description = [{

--- a/include/circt/Dialect/Seq/SeqPasses.td
+++ b/include/circt/Dialect/Seq/SeqPasses.td
@@ -78,6 +78,16 @@ def PropagateClockDomains : Pass<"seq-propagate-clock-domains", "mlir::ModuleOp"
   }];
 }
 
+def CheckMultipleClockSources : Pass<"seq-check-multiple-clock-sources",
+                                      "mlir::ModuleOp"> {
+  let summary = "Diagnose results with multiple possible clock sources";
+  let description = [{
+    Read `seq.clock_domains` result annotations and emit an informational
+    remark for every result that has more than one possible clock domain. This
+    pass does not modify the IR.
+  }];
+}
+
 def HWMemSimImpl : Pass<"hw-memory-sim", "ModuleOp"> {
   let summary = "Implement FIRRTMMem memories nodes with simulation model";
   let description = [{

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTSeqTransforms
   ExternalizeClockGate.cpp
   HWMemSimImpl.cpp
+  PropagateClockDomains.cpp
   RegOfVecToMem.cpp
   LowerSeqCompRegCE.cpp
   LowerSeqHLMem.cpp

--- a/lib/Dialect/Seq/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Seq/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_circt_dialect_library(CIRCTSeqTransforms
   ExternalizeClockGate.cpp
   HWMemSimImpl.cpp
+  CheckMultipleClockSources.cpp
   PropagateClockDomains.cpp
   RegOfVecToMem.cpp
   LowerSeqCompRegCE.cpp

--- a/lib/Dialect/Seq/Transforms/CheckMultipleClockSources.cpp
+++ b/lib/Dialect/Seq/Transforms/CheckMultipleClockSources.cpp
@@ -1,0 +1,59 @@
+//===- CheckMultipleClockSources.cpp - Diagnose multi-clock results -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/ADT/STLExtras.h"
+
+namespace circt {
+namespace seq {
+#define GEN_PASS_DEF_CHECKMULTIPLECLOCKSOURCES
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+} // namespace seq
+} // namespace circt
+
+using namespace circt;
+using namespace seq;
+using namespace mlir;
+
+namespace {
+
+static constexpr StringLiteral clockDomainsAttrName = "seq.clock_domains";
+
+struct CheckMultipleClockSourcesPass
+    : public seq::impl::CheckMultipleClockSourcesBase<
+          CheckMultipleClockSourcesPass> {
+  using CheckMultipleClockSourcesBase::CheckMultipleClockSourcesBase;
+
+  void runOnOperation() override {
+    getOperation()->walk([&](Operation *operation) {
+      auto domainSets =
+          dyn_cast_or_null<ArrayAttr>(operation->getAttr(clockDomainsAttrName));
+      if (!domainSets || domainSets.size() != operation->getNumResults())
+        return;
+
+      for (auto [index, domainSet] : llvm::enumerate(domainSets)) {
+        auto domains = dyn_cast<ArrayAttr>(domainSet);
+        if (!domains || domains.size() <= 1)
+          continue;
+
+        auto diagnostic = operation->emitRemark()
+                          << "result #" << index
+                          << " has multiple possible clock sources: ";
+        llvm::interleaveComma(domains, diagnostic, [&](Attribute domain) {
+          if (auto string = dyn_cast<StringAttr>(domain))
+            diagnostic << string.getValue();
+          else
+            diagnostic << domain;
+        });
+      }
+    });
+  }
+};
+
+} // namespace

--- a/lib/Dialect/Seq/Transforms/PropagateClockDomains.cpp
+++ b/lib/Dialect/Seq/Transforms/PropagateClockDomains.cpp
@@ -9,6 +9,7 @@
 #include "circt/Dialect/HW/HWOps.h"
 #include "circt/Dialect/Seq/SeqOps.h"
 #include "circt/Dialect/Seq/SeqPasses.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/IR/SymbolTable.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -134,38 +135,46 @@ private:
          llvm::zip(module.getBodyBlock()->getArguments(), inputDomains))
       instance.values[argument].join(domains);
 
+    SmallVector<Operation *> operations;
+    for (Operation &op : module.getBodyBlock()->without_terminator())
+      operations.push_back(&op);
+    if (!computeTopologicalSorting(operations)) {
+      activeModules.erase(operation);
+      return unknownOutputs(module);
+    }
+
     unsigned nextDerivedClock = 0;
-    for (Operation &op : module.getBodyBlock()->without_terminator()) {
-      if (auto child = dyn_cast<hw::InstanceOp>(op)) {
+    for (Operation *operation : operations) {
+      if (auto child = dyn_cast<hw::InstanceOp>(operation)) {
         propagateInstance(child, instance, path);
         continue;
       }
 
-      for (Value result : op.getResults()) {
-        if (!isa<ClockType>(result.getType()) || isa<hw::WireOp>(op))
+      for (Value result : operation->getResults()) {
+        if (!isa<ClockType>(result.getType()) || isa<hw::WireOp>(operation))
           continue;
         auto name = (Twine(path) + ".clock" + Twine(nextDerivedClock++)).str();
         instance.values[result].insert(StringAttr::get(context, name));
       }
 
-      if (auto clocked = dyn_cast<Clocked>(op)) {
-        for (Value result : op.getResults()) {
-          if (isa<ClockType>(result.getType()) && !isa<hw::WireOp>(op))
+      if (auto clocked = dyn_cast<Clocked>(operation)) {
+        for (Value result : operation->getResults()) {
+          if (isa<ClockType>(result.getType()) && !isa<hw::WireOp>(operation))
             continue;
           instance.values[result].join(get(instance, clocked.getClk()));
         }
       } else {
         DomainSet operandDomains;
-        for (Value operand : op.getOperands())
+        for (Value operand : operation->getOperands())
           operandDomains.join(get(instance, operand));
-        for (Value result : op.getResults()) {
-          if (isa<ClockType>(result.getType()) && !isa<hw::WireOp>(op))
+        for (Value result : operation->getResults()) {
+          if (isa<ClockType>(result.getType()) && !isa<hw::WireOp>(operation))
             continue;
           instance.values[result].join(operandDomains);
         }
       }
 
-      for (Value result : op.getResults())
+      for (Value result : operation->getResults())
         record(result, get(instance, result));
     }
 

--- a/lib/Dialect/Seq/Transforms/PropagateClockDomains.cpp
+++ b/lib/Dialect/Seq/Transforms/PropagateClockDomains.cpp
@@ -1,0 +1,248 @@
+//===- PropagateClockDomains.cpp - Propagate Seq clock domains --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Seq/SeqPasses.h"
+#include "mlir/IR/SymbolTable.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringExtras.h"
+
+namespace circt {
+namespace seq {
+#define GEN_PASS_DEF_PROPAGATECLOCKDOMAINS
+#include "circt/Dialect/Seq/SeqPasses.h.inc"
+} // namespace seq
+} // namespace circt
+
+using namespace circt;
+using namespace seq;
+using namespace mlir;
+
+namespace {
+
+static constexpr StringLiteral clockDomainsAttrName = "seq.clock_domains";
+
+/// A conservative set of clock-domain identifiers.
+class DomainSet {
+public:
+  bool join(const DomainSet &other) {
+    bool changed = false;
+    for (StringAttr domain : other.domains)
+      changed |= domains.insert(domain);
+    return changed;
+  }
+
+  bool insert(StringAttr domain) { return domains.insert(domain); }
+  bool empty() const { return domains.empty(); }
+
+  ArrayAttr asAttr(MLIRContext *context) const {
+    SmallVector<Attribute> attributes;
+    attributes.append(domains.begin(), domains.end());
+    return ArrayAttr::get(context, attributes);
+  }
+
+private:
+  SmallSetVector<StringAttr, 2> domains;
+};
+
+/// Forward may analysis over hardware *instances*. A module body is evaluated
+/// once for each instance context, keeping separately-instantiated copies of a
+/// module from contaminating each other's propagated domains.
+class DomainPropagator {
+public:
+  explicit DomainPropagator(ModuleOp top)
+      : top(top), context(top.getContext()),
+        unknown(StringAttr::get(context, "<unknown>")) {}
+
+  void run() {
+    for (hw::HWModuleOp module : top.getOps<hw::HWModuleOp>()) {
+      if (!module.isPublic())
+        continue;
+      SmallVector<DomainSet> inputDomains;
+      for (auto [index, argument] :
+           llvm::enumerate(module.getBodyBlock()->getArguments())) {
+        auto domains = getPortDomains(module, index);
+        if (domains.empty()) {
+          if (isa<ClockType>(argument.getType())) {
+            auto name = (Twine(module.getModuleName()) + "." +
+                         module.getInputName(index))
+                            .str();
+            domains.insert(StringAttr::get(context, name));
+          } else {
+            domains.insert(unknown);
+          }
+        }
+        inputDomains.push_back(std::move(domains));
+      }
+      propagateModule(module, inputDomains, module.getModuleName().str());
+    }
+    annotate();
+  }
+
+private:
+  /// State local to one particular instance of a module body.
+  struct InstanceContext {
+    DenseMap<Value, DomainSet> values;
+  };
+
+  DomainSet getPortDomains(hw::HWModuleOp module, size_t portIndex) const {
+    auto attr =
+        dyn_cast_or_null<DictionaryAttr>(module.getPortAttrs(portIndex));
+    if (!attr)
+      return {};
+    auto array = dyn_cast<ArrayAttr>(attr.get(clockDomainsAttrName));
+    if (!array)
+      return {};
+
+    DomainSet result;
+    for (Attribute domain : array)
+      if (auto string = dyn_cast<StringAttr>(domain))
+        result.insert(string);
+    return result;
+  }
+
+  const DomainSet &get(const InstanceContext &context, Value value) const {
+    auto it = context.values.find(value);
+    return it == context.values.end() ? empty : it->second;
+  }
+
+  void record(Value value, const DomainSet &domains) {
+    reportedDomains[value].join(domains);
+  }
+
+  SmallVector<DomainSet> propagateModule(hw::HWModuleOp module,
+                                         ArrayRef<DomainSet> inputDomains,
+                                         StringRef path) {
+    // Recursive instantiation does not have a finite instance tree. Preserve
+    // soundness by returning an unknown summary for this edge; structural
+    // verification can diagnose the recursion independently.
+    auto *operation = module.getOperation();
+    if (!activeModules.insert(operation).second)
+      return unknownOutputs(module);
+
+    InstanceContext instance;
+    for (auto [argument, domains] :
+         llvm::zip(module.getBodyBlock()->getArguments(), inputDomains))
+      instance.values[argument].join(domains);
+
+    unsigned nextDerivedClock = 0;
+    for (Operation &op : module.getBodyBlock()->without_terminator()) {
+      if (auto child = dyn_cast<hw::InstanceOp>(op)) {
+        propagateInstance(child, instance, path);
+        continue;
+      }
+
+      for (Value result : op.getResults()) {
+        if (!isa<ClockType>(result.getType()) || isa<hw::WireOp>(op))
+          continue;
+        auto name = (Twine(path) + ".clock" + Twine(nextDerivedClock++)).str();
+        instance.values[result].insert(StringAttr::get(context, name));
+      }
+
+      if (auto clocked = dyn_cast<Clocked>(op)) {
+        for (Value result : op.getResults()) {
+          if (isa<ClockType>(result.getType()) && !isa<hw::WireOp>(op))
+            continue;
+          instance.values[result].join(get(instance, clocked.getClk()));
+        }
+      } else {
+        DomainSet operandDomains;
+        for (Value operand : op.getOperands())
+          operandDomains.join(get(instance, operand));
+        for (Value result : op.getResults()) {
+          if (isa<ClockType>(result.getType()) && !isa<hw::WireOp>(op))
+            continue;
+          instance.values[result].join(operandDomains);
+        }
+      }
+
+      for (Value result : op.getResults())
+        record(result, get(instance, result));
+    }
+
+    auto output = cast<hw::OutputOp>(module.getBodyBlock()->getTerminator());
+    SmallVector<DomainSet> result;
+    for (Value value : output.getOperands())
+      result.push_back(get(instance, value));
+    activeModules.erase(operation);
+    return result;
+  }
+
+  void propagateInstance(hw::InstanceOp instance, InstanceContext &parent,
+                         StringRef parentPath) {
+    auto *target = SymbolTable::lookupNearestSymbolFrom(
+        instance, instance.getReferencedModuleNameAttr());
+    auto module = dyn_cast_or_null<hw::HWModuleOp>(target);
+    if (!module) {
+      for (Value result : instance.getResults())
+        parent.values[result].insert(unknown);
+    } else {
+      SmallVector<DomainSet> inputDomains;
+      for (Value input : instance.getInputs())
+        inputDomains.push_back(get(parent, input));
+      auto path = (Twine(parentPath) + "." + instance.getInstanceName()).str();
+      auto outputDomains = propagateModule(module, inputDomains, path);
+      for (auto [result, domains] :
+           llvm::zip(instance.getResults(), outputDomains))
+        parent.values[result].join(domains);
+    }
+
+    for (Value result : instance.getResults())
+      record(result, get(parent, result));
+  }
+
+  SmallVector<DomainSet> unknownOutputs(hw::HWModuleOp module) const {
+    auto output = cast<hw::OutputOp>(module.getBodyBlock()->getTerminator());
+    SmallVector<DomainSet> result(output.getOperands().size());
+    for (DomainSet &domains : result)
+      domains.insert(unknown);
+    return result;
+  }
+
+  void annotate() {
+    auto name = StringAttr::get(context, clockDomainsAttrName);
+    for (auto &entry : reportedDomains) {
+      Value value = entry.first;
+      auto *operation = value.getDefiningOp();
+      if (!operation)
+        continue;
+
+      SmallVector<Attribute> resultDomains;
+      bool hasDomains = false;
+      for (Value result : operation->getResults()) {
+        auto resultIt = reportedDomains.find(result);
+        const DomainSet &resultDomainSet =
+            resultIt == reportedDomains.end() ? empty : resultIt->second;
+        resultDomains.push_back(resultDomainSet.asAttr(context));
+        hasDomains |= !resultDomainSet.empty();
+      }
+      if (hasDomains)
+        operation->setAttr(name, ArrayAttr::get(context, resultDomains));
+    }
+  }
+
+  ModuleOp top;
+  MLIRContext *context;
+  DenseMap<Value, DomainSet> reportedDomains;
+  SmallPtrSet<Operation *, 4> activeModules;
+  DomainSet empty;
+  StringAttr unknown;
+};
+
+struct PropagateClockDomainsPass
+    : public seq::impl::PropagateClockDomainsBase<PropagateClockDomainsPass> {
+  using PropagateClockDomainsBase::PropagateClockDomainsBase;
+
+  void runOnOperation() override { DomainPropagator(getOperation()).run(); }
+};
+
+} // namespace

--- a/test/Dialect/Seq/propagate-clock-domains.mlir
+++ b/test/Dialect/Seq/propagate-clock-domains.mlir
@@ -1,11 +1,12 @@
 // RUN: circt-opt %s --seq-propagate-clock-domains | FileCheck %s
+// RUN: circt-opt %s --seq-propagate-clock-domains --seq-check-multiple-clock-sources 2>&1 | FileCheck %s --check-prefix=NOTE
 
 // A comb.mux joins the input domains. The register body is evaluated separately
 // for each instance: the annotation on the shared module operation is therefore
 // the union, while the two hw.instance results retain their individual domains.
 // CHECK-LABEL: hw.module private @Register
 hw.module private @Register(in %data: i1, in %clock: !seq.clock, out result: i1) {
-  // CHECK: seq.compreg %data, %clock {seq.clock_domains = {{\[\[("A", "B"|"B", "A")\]\]}}} : i1
+// CHECK: seq.compreg %data, %clock {seq.clock_domains = {{\[\[("A", "B"|"B", "A")\]\]}}} : i1
   %reg = seq.compreg %data, %clock : i1
   hw.output %reg : i1
 }
@@ -28,10 +29,13 @@ hw.module @Top(
   %resultA = hw.instance "registerA" @Register(data: %mixed : i1, clock: %clockA : !seq.clock) -> (result: i1)
   // CHECK: hw.instance "registerB" @Register(data: %{{.*}}: i1, clock: %clockB: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["B"\]\]}}}
   %resultB = hw.instance "registerB" @Register(data: %mixed : i1, clock: %clockB : !seq.clock) -> (result: i1)
-  // CHECK: comb.mux %dataA, %dataA, %dataB {seq.clock_domains = {{\[\[("A", "B"|"B", "A")\]\]}}} : i1
+// CHECK: comb.mux %dataA, %dataA, %dataB {seq.clock_domains = {{\[\[("A", "B"|"B", "A")\]\]}}} : i1
   %mixed = comb.mux %dataA, %dataA, %dataB : i1
   hw.output %resultA, %resultB : i1, i1
 }
+
+// NOTE: remark: result #0 has multiple possible clock sources: {{(A, B|B, A)}}
+// NOTE: remark: result #0 has multiple possible clock sources: {{(A, B|B, A)}}
 
 // Public clocks without an explicit annotation receive stable, distinct domain
 // names. Unannotated data instead conservatively starts in the unknown domain.

--- a/test/Dialect/Seq/propagate-clock-domains.mlir
+++ b/test/Dialect/Seq/propagate-clock-domains.mlir
@@ -1,0 +1,54 @@
+// RUN: circt-opt %s --seq-propagate-clock-domains | FileCheck %s
+
+// A comb.mux joins the input domains. The register body is evaluated separately
+// for each instance: the annotation on the shared module operation is therefore
+// the union, while the two hw.instance results retain their individual domains.
+// CHECK-LABEL: hw.module private @Register
+hw.module private @Register(in %data: i1, in %clock: !seq.clock, out result: i1) {
+  // CHECK: seq.compreg %data, %clock {seq.clock_domains = {{\[\["A", "B"\]\]}}} : i1
+  %reg = seq.compreg %data, %clock : i1
+  hw.output %reg : i1
+}
+
+// CHECK-LABEL: hw.module @Top(
+// CHECK-SAME: in %dataA : i1 {seq.clock_domains = ["A"]},
+// CHECK-SAME: in %dataB : i1 {seq.clock_domains = ["B"]},
+// CHECK-SAME: in %clockA : !seq.clock {seq.clock_domains = ["A"]},
+// CHECK-SAME: in %clockB : !seq.clock {seq.clock_domains = ["B"]},
+// CHECK-SAME: out resultA : i1,
+// CHECK-SAME: out resultB : i1)
+hw.module @Top(
+    in %dataA: i1 {seq.clock_domains = ["A"]},
+    in %dataB: i1 {seq.clock_domains = ["B"]},
+    in %clockA: !seq.clock {seq.clock_domains = ["A"]},
+    in %clockB: !seq.clock {seq.clock_domains = ["B"]},
+    out resultA: i1,
+    out resultB: i1) {
+  // CHECK: %[[MIXED:.*]] = comb.mux %dataA, %dataA, %dataB {seq.clock_domains = {{\[\["A", "B"\]\]}}} : i1
+  %mixed = comb.mux %dataA, %dataA, %dataB : i1
+  // CHECK: hw.instance "registerA" @Register(data: %[[MIXED]]: i1, clock: %clockA: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["A"\]\]}}}
+  %resultA = hw.instance "registerA" @Register(data: %mixed : i1, clock: %clockA : !seq.clock) -> (result: i1)
+  // CHECK: hw.instance "registerB" @Register(data: %[[MIXED]]: i1, clock: %clockB: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["B"\]\]}}}
+  %resultB = hw.instance "registerB" @Register(data: %mixed : i1, clock: %clockB : !seq.clock) -> (result: i1)
+  hw.output %resultA, %resultB : i1, i1
+}
+
+// Public clocks without an explicit annotation receive stable, distinct domain
+// names. Unannotated data instead conservatively starts in the unknown domain.
+// CHECK-LABEL: hw.module @Unannotated(
+// CHECK-SAME: in %data : i1,
+// CHECK-SAME: in %clockA : !seq.clock,
+// CHECK-SAME: in %clockB : !seq.clock,
+// CHECK-SAME: out resultA : i1,
+// CHECK-SAME: out resultB : i1)
+hw.module @Unannotated(in %data: i1, in %clockA: !seq.clock,
+                       in %clockB: !seq.clock, out resultA: i1,
+                       out resultB: i1) {
+  // CHECK: %[[UNKNOWN:.*]] = comb.and %data, %data {seq.clock_domains = {{\[\["<unknown>"\]\]}}} : i1
+  %unknown = comb.and %data, %data : i1
+  // CHECK: seq.compreg %[[UNKNOWN]], %clockA {seq.clock_domains = {{\[\["Unannotated.clockA"\]\]}}} : i1
+  %resultA = seq.compreg %unknown, %clockA : i1
+  // CHECK: seq.compreg %[[UNKNOWN]], %clockB {seq.clock_domains = {{\[\["Unannotated.clockB"\]\]}}} : i1
+  %resultB = seq.compreg %unknown, %clockB : i1
+  hw.output %resultA, %resultB : i1, i1
+}

--- a/test/Dialect/Seq/propagate-clock-domains.mlir
+++ b/test/Dialect/Seq/propagate-clock-domains.mlir
@@ -5,7 +5,7 @@
 // the union, while the two hw.instance results retain their individual domains.
 // CHECK-LABEL: hw.module private @Register
 hw.module private @Register(in %data: i1, in %clock: !seq.clock, out result: i1) {
-  // CHECK: seq.compreg %data, %clock {seq.clock_domains = {{\[\["A", "B"\]\]}}} : i1
+  // CHECK: seq.compreg %data, %clock {seq.clock_domains = {{\[\[("A", "B"|"B", "A")\]\]}}} : i1
   %reg = seq.compreg %data, %clock : i1
   hw.output %reg : i1
 }
@@ -24,12 +24,12 @@ hw.module @Top(
     in %clockB: !seq.clock {seq.clock_domains = ["B"]},
     out resultA: i1,
     out resultB: i1) {
-  // CHECK: %[[MIXED:.*]] = comb.mux %dataA, %dataA, %dataB {seq.clock_domains = {{\[\["A", "B"\]\]}}} : i1
-  %mixed = comb.mux %dataA, %dataA, %dataB : i1
-  // CHECK: hw.instance "registerA" @Register(data: %[[MIXED]]: i1, clock: %clockA: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["A"\]\]}}}
+  // CHECK: hw.instance "registerA" @Register(data: %{{.*}}: i1, clock: %clockA: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["A"\]\]}}}
   %resultA = hw.instance "registerA" @Register(data: %mixed : i1, clock: %clockA : !seq.clock) -> (result: i1)
-  // CHECK: hw.instance "registerB" @Register(data: %[[MIXED]]: i1, clock: %clockB: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["B"\]\]}}}
+  // CHECK: hw.instance "registerB" @Register(data: %{{.*}}: i1, clock: %clockB: !seq.clock) -> (result: i1) {seq.clock_domains = {{\[\["B"\]\]}}}
   %resultB = hw.instance "registerB" @Register(data: %mixed : i1, clock: %clockB : !seq.clock) -> (result: i1)
+  // CHECK: comb.mux %dataA, %dataA, %dataB {seq.clock_domains = {{\[\[("A", "B"|"B", "A")\]\]}}} : i1
+  %mixed = comb.mux %dataA, %dataA, %dataB : i1
   hw.output %resultA, %resultB : i1, i1
 }
 


### PR DESCRIPTION
This PR contains a first version of propagating clock domain information through he `hw` dialect.

The idea is to associated every signal with a clock domain and eventually check for consistent clock domain crossings as a linting pass. 

This first patch adds a forward pass to propagate information downwards, and a checking pass that emits a note on every signal that has been assigned multiple clocks. 


Assisted-by: Codex:Terra 5.6
