### PR TITLE
[ExportVerilog][NFC] Use SymbolOpInterface instead of looking for "sym_name" attribute

### DIFF
--- a/lib/Conversion/ExportVerilog/ExportVerilog.cpp
+++ b/lib/Conversion/ExportVerilog/ExportVerilog.cpp
@@ -209,6 +209,7 @@ StringRef ExportVerilog::getSymOpName(Operation *symOp) {
           [&](InterfaceSignalOp op) { return op.getSymName(); })
       .Case<InterfaceModportOp>(
           [&](InterfaceModportOp op) { return op.getSymName(); })
+      .Case<GenerateOp>([](GenerateOp op) { return op.getSymName(); })
       .Default([&](Operation *op) {
         if (auto attr = op->getAttrOfType<StringAttr>("name"))
           return attr.getValue();
@@ -216,9 +217,8 @@ StringRef ExportVerilog::getSymOpName(Operation *symOp) {
           return attr.getValue();
         if (auto attr = op->getAttrOfType<StringAttr>("sv.namehint"))
           return attr.getValue();
-        if (auto attr =
-                op->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName()))
-          return attr.getValue();
+        if (auto symbol = dyn_cast<mlir::SymbolOpInterface>(op))
+          return symbol.getName();
         return StringRef("");
       });
 }


### PR DESCRIPTION
Refactor `getSymOpName` in `ExportVerilog.cpp` to use `mlir::SymbolOpInterface` via `dyn_cast` instead of directly looking up the `sym_name` attribute via `SymbolTable::getSymbolAttrName()`. Also add explicit support for `GenerateOp` because it doesn't have `SymbolOpInterface` (see https://github.com/llvm/circt/issues/11079). 