### PR TITLE
[FIRRTL][NFC] Replace "sym_name" lookup with OpInterface

### DIFF
--- a/include/circt/Dialect/FIRRTL/Namespace.h
+++ b/include/circt/Dialect/FIRRTL/Namespace.h
@@ -30,9 +30,8 @@ struct CircuitNamespace : public Namespace {
   /// a symbol.
   void add(CircuitOp circuit) {
     for (auto &op : *circuit.getBodyBlock())
-      if (auto symbol = op.getAttrOfType<mlir::StringAttr>(
-              SymbolTable::getSymbolAttrName()))
-        nextIndex.insert({symbol.getValue(), 0});
+      if (auto symbol = mlir::dyn_cast<mlir::SymbolOpInterface>(&op))
+        nextIndex.insert({symbol.getName(), 0});
   }
 };
 

--- a/lib/Dialect/FIRRTL/Import/FIRParser.cpp
+++ b/lib/Dialect/FIRRTL/Import/FIRParser.cpp
@@ -6754,10 +6754,11 @@ DoneParsing:
     DenseMap<Attribute, Location> nameToOrigLoc;
     for (auto &op : *circuit.getBodyBlock()) {
       // Check for a symbol name attribute.
-      auto nameAttr =
-          op.getAttrOfType<StringAttr>(mlir::SymbolTable::getSymbolAttrName());
-      if (!nameAttr)
+      auto symbol = dyn_cast<mlir::SymbolOpInterface>(&op);
+      if (!symbol)
         continue;
+
+      auto nameAttr = symbol.getNameAttr();
 
       // Try to insert this symbol into the table.
       auto it = nameToOrigLoc.try_emplace(nameAttr, op.getLoc());

--- a/lib/Dialect/FIRRTL/NLATable.cpp
+++ b/lib/Dialect/FIRRTL/NLATable.cpp
@@ -39,10 +39,9 @@ ArrayRef<hw::HierPathOp> NLATable::lookup(StringAttr name) {
 }
 
 ArrayRef<hw::HierPathOp> NLATable::lookup(Operation *op) {
-  auto name = op->getAttrOfType<StringAttr>("sym_name");
-  if (!name)
-    return {};
-  return lookup(name);
+  if (auto symOp = dyn_cast<mlir::SymbolOpInterface>(op))
+    return lookup(symOp.getNameAttr());
+  return {};
 }
 
 hw::HierPathOp NLATable::getNLA(StringAttr name) {


### PR DESCRIPTION
Replaces direct attribute string lookups for sym_name and SymbolTable::getSymbolAttrName() with mlir::SymbolOpInterface in FIRRTL namespace handling, parser, and NLA table lookup.

Assisted-by: codex: gpt 5.6luna