### PR TITLE
[LLHD] Preserve explicit register initializers through Deseq

### DIFF
--- a/integration_test/circt-bmc/initializers.sv
+++ b/integration_test/circt-bmc/initializers.sv
@@ -1,6 +1,7 @@
 // REQUIRES: slang
 // REQUIRES: libz3
 // REQUIRES: circt-bmc-jit
+// UNSUPPORTED: valgrind
 
 // Declaration initializers must reach the generated registers and constrain
 // the initial BMC state.

--- a/integration_test/circt-bmc/initializers.sv
+++ b/integration_test/circt-bmc/initializers.sv
@@ -1,0 +1,44 @@
+// REQUIRES: slang
+// REQUIRES: libz3
+// REQUIRES: circt-bmc-jit
+
+// Declaration initializers must reach the generated registers and constrain
+// the initial BMC state.
+// RUN: circt-verilog %s --top=Zero | FileCheck %s --check-prefix=ZERO-IR
+// RUN: circt-verilog %s --top=Nonzero | FileCheck %s --check-prefix=NONZERO-IR
+// RUN: circt-verilog %s --top=Uninitialized | FileCheck %s --check-prefix=UNINITIALIZED-IR
+// RUN: circt-verilog %s --top=Zero | circt-bmc - --module Zero -b 1 --shared-libs=%libz3 | FileCheck %s --check-prefix=SAFE
+// RUN: circt-verilog %s --top=Zero | circt-bmc - --module Zero -b 4 --shared-libs=%libz3 | FileCheck %s --check-prefix=FAIL
+// RUN: circt-verilog %s --top=Zero | circt-bmc - --module Zero -b 1 --rising-clocks-only --shared-libs=%libz3 | FileCheck %s --check-prefix=SAFE
+// RUN: circt-verilog %s --top=Nonzero | circt-bmc - --module Nonzero -b 1 --shared-libs=%libz3 | FileCheck %s --check-prefix=SAFE
+// RUN: circt-verilog %s --top=Nonzero | circt-bmc - --module Nonzero -b 1 --rising-clocks-only --shared-libs=%libz3 | FileCheck %s --check-prefix=SAFE
+
+// A variable without a declaration initializer must remain unconstrained.
+// RUN: circt-verilog %s --top=Uninitialized | circt-bmc - --module Uninitialized -b 1 --shared-libs=%libz3 | FileCheck %s --check-prefix=FAIL
+
+// SAFE: Bound reached with no violations!
+// FAIL: Assertion can be violated!
+// ZERO-IR: seq.firreg {{.*}} preset 0
+// NONZERO-IR: seq.firreg {{.*}} preset 7
+// UNINITIALIZED-IR: seq.firreg {{.*}} clock {{%[a-zA-Z0-9_]+}} : i4
+
+module Zero(input logic clk);
+  logic [3:0] count = 4'd0;
+  always_ff @(posedge clk)
+    count <= count + 4'd1;
+  assert property (@(posedge clk) count < 4'd3);
+endmodule
+
+module Nonzero(input logic clk);
+  logic [3:0] count = 4'd7;
+  always_ff @(posedge clk)
+    count <= count + 4'd1;
+  assert property (@(posedge clk) count >= 4'd7);
+endmodule
+
+module Uninitialized(input logic clk);
+  logic [3:0] count;
+  always_ff @(posedge clk)
+    count <= count + 4'd1;
+  assert property (@(posedge clk) count == 4'd0);
+endmodule

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -1142,14 +1142,21 @@ struct VariableOpConversion : public OpConversionPattern<VariableOp> {
 
     // Determine the initial value of the signal.
     Value init = adaptor.getInitial();
+    bool hasExplicitInit = !!init;
     if (!init) {
       init = createZeroValue(refType.getNestedType(), loc, rewriter);
       if (!init)
         return failure();
     }
 
-    rewriter.replaceOpWithNewOp<llhd::SignalOp>(op, resultType,
-                                                op.getNameAttr(), init);
+    auto signal = rewriter.replaceOpWithNewOp<llhd::SignalOp>(
+        op, resultType, op.getNameAttr(), init);
+    // LLHD signals also have a synthesized initial value for variables without
+    // a declaration initializer. Preserve this distinction so Deseq can carry
+    // explicit source initializers into registers without constraining
+    // uninitialized registers to zero.
+    if (hasExplicitInit)
+      signal->setAttr("llhd.explicit_init", rewriter.getUnitAttr());
     return success();
   }
 };

--- a/lib/Dialect/LLHD/Transforms/Deseq.cpp
+++ b/lib/Dialect/LLHD/Transforms/Deseq.cpp
@@ -1433,16 +1433,21 @@ void Deseq::implementRegister(DriveInfo &drive) {
 
   // Try to guess a name for the register.
   StringAttr name;
-  if (auto sigOp = drive.op.getSignal().getDefiningOp<llhd::SignalOp>())
+  IntegerAttr preset;
+  if (auto sigOp = drive.op.getSignal().getDefiningOp<llhd::SignalOp>()) {
     name = sigOp.getNameAttr();
+    if (sigOp->hasAttr("llhd.explicit_init"))
+      if (auto constant = sigOp.getInit().getDefiningOp<hw::ConstantOp>())
+        preset = constant.getValueAttr();
+  }
   if (!name)
     name = builder.getStringAttr("");
 
   // Create the register op.
-  auto reg = seq::FirRegOp::create(builder, loc, value, clock, name,
-                                   hw::InnerSymAttr{},
-                                   /*preset=*/IntegerAttr{}, reset, resetValue,
-                                   /*isAsync=*/reset != Value{});
+  auto reg =
+      seq::FirRegOp::create(builder, loc, value, clock, name,
+                            hw::InnerSymAttr{}, preset, reset, resetValue,
+                            /*isAsync=*/reset != Value{});
 
   // If the register has an enable, insert a self-mux in front of the register.
   // Set the `bin` flag on the mux specifically to make up for a subtle

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -553,12 +553,12 @@ moore.module @Variable() {
 
   // CHECK: [[PRB:%.+]] = llhd.prb %b1 : i8
   %0 = moore.read %b1 : <i8>
-  // CHECK: %b2 = llhd.sig [[PRB]] : i8
+  // CHECK: %b2 = llhd.sig [[PRB]] {llhd.explicit_init} : i8
   %b2 = moore.variable %0 : <i8>
 
   // CHECK: %true = hw.constant true
   %1 = moore.constant 1 : l1
-  // CHECK: %l = llhd.sig %true : i1
+  // CHECK: %l = llhd.sig %true {llhd.explicit_init} : i1
   %l = moore.variable %1 : <l1>
   // CHECK: [[TMP:%.+]] = hw.constant 0 : i19
   // CHECK: %m = llhd.sig [[TMP]] : i19
@@ -580,7 +580,7 @@ moore.module @Variable() {
   moore.variable : <!moore.time>
 
   // CHECK: [[TMP:%.+]] = llhd.constant_time
-  // CHECK: llhd.sig [[TMP]] : !llhd.time
+  // CHECK: llhd.sig [[TMP]] {llhd.explicit_init} : !llhd.time
   %c42_fs = moore.constant_time 42 fs
   moore.variable %c42_fs : <!moore.time>
 
@@ -688,7 +688,7 @@ moore.module @Struct(in %a : !moore.i32, in %b : !moore.i32, in %arg0 : !moore.s
 
   // CHECK: [[INIT:%.+]] = hw.aggregate_constant [0 : i32, 0 : i32] : !hw.struct<exp_bits: i32, man_bits: i32>
   // CHECK: llhd.sig [[INIT]] : !hw.struct<exp_bits: i32, man_bits: i32>
-  // CHECK: llhd.sig %arg0 : !hw.struct<exp_bits: i32, man_bits: i32>
+  // CHECK: llhd.sig %arg0 {llhd.explicit_init} : !hw.struct<exp_bits: i32, man_bits: i32>
   %1 = moore.variable : <struct<{exp_bits: i32, man_bits: i32}>>
   %2 = moore.variable %arg0 : <struct<{exp_bits: i32, man_bits: i32}>>
 

--- a/test/Dialect/LLHD/Transforms/deseq.mlir
+++ b/test/Dialect/LLHD/Transforms/deseq.mlir
@@ -23,6 +23,32 @@ hw.module @ClockPosEdge(in %clock: i1, in %d: i42) {
   llhd.drv %3, %1 after %0 if %2 : i42
 }
 
+// Explicit source initializers become register presets. The unmarked signal
+// in ClockPosEdge above must continue to produce a register without a preset.
+// CHECK-LABEL: @ClockPosEdgeExplicitInit(
+hw.module @ClockPosEdgeExplicitInit(in %clock: i1, in %d: i42) {
+  %zero = hw.constant 0 : i42
+  %init = hw.constant 7 : i42
+  %time = llhd.constant_time <0ns, 1d, 0e>
+  // CHECK-NOT: llhd.process
+  // CHECK: [[CLK:%.+]] = seq.to_clock %clock
+  // CHECK: [[REG:%.+]] = seq.firreg %d clock [[CLK]] preset 7 {name = "sig"} : i42
+  %value, %enable = llhd.process -> i42, i1 {
+    %true = hw.constant true
+    %false = hw.constant false
+    cf.br ^bb1(%zero, %false : i42, i1)
+  ^bb1(%data: i42, %en: i1):
+    llhd.wait yield (%data, %en : i42, i1), (%clock : i1), ^bb2(%clock : i1)
+  ^bb2(%prev: i1):
+    %notPrev = comb.xor bin %prev, %true : i1
+    %posedge = comb.and bin %notPrev, %clock : i1
+    cf.cond_br %posedge, ^bb1(%d, %true : i42, i1), ^bb1(%zero, %false : i42, i1)
+  }
+  %sig = llhd.sig %init {llhd.explicit_init} : i42
+  // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
+  llhd.drv %sig, %value after %time if %enable : i42
+}
+
 // CHECK-LABEL: @ClockNegEdge(
 hw.module @ClockNegEdge(in %clock: i1, in %d: i42) {
   %c0_i42 = hw.constant 0 : i42
@@ -1279,4 +1305,3 @@ hw.module @ClockExtractedFromAliasedStructExtractPosEdge(in %st: !hw.typealias<@
   // CHECK: llhd.drv {{%.+}}, [[REG]] after {{%.+}} :
   llhd.drv %sig, %out after %time if %en : i4
 }
-


### PR DESCRIPTION
This preserves explicit SystemVerilog register initializers when lowering LLHD processes to `seq.firreg`.

Before this change, the initializer reached `llhd.sig`, but was dropped when Deseq created the register. This left the initial BMC state unconstrained and could produce false counterexamples for initialized registers.

For example:

```systemverilog
logic [3:0] count = 4'd0;
always_ff @(posedge clk)
  count <= count + 4'd1;
```

The resulting register now has `preset 0`, so BMC starts `count` at zero.

MooreToCore marks explicit declaration initializers so Deseq can distinguish them from the zero values synthesized for variables without an initializer. Only explicit constant initializers become register presets.

Adds regression coverage for zero and nonzero initializers, and for registers that must remain unconstrained.

Tested with `check-circt` and the initializer integration test.

Assisted-by: Codex:gpt-6
