### PR TITLE
[FIRRTL] Add preserve-modules option for DropNamePass

### DIFF
--- a/include/circt/Dialect/FIRRTL/Passes.td
+++ b/include/circt/Dialect/FIRRTL/Passes.td
@@ -611,7 +611,9 @@ def DropName : Pass<"firrtl-drop-names", "firrtl::FModuleOp"> {
                 "Preserve values with meaningful names"),
               clEnumValN(PreserveValues::All, "all",
                 "Preserve all values"))
-           }]>
+           }]>,
+    ListOption<"preserveModules", "preserve-modules", "std::string",
+               "specify the modules in which all meaningful names are preserved">
   ];
   let statistics = [
     Statistic<"numNamesDropped", "num-names-dropped",

--- a/include/circt/Firtool/Firtool.h
+++ b/include/circt/Firtool/Firtool.h
@@ -99,6 +99,8 @@ public:
     llvm_unreachable("unknown build mode");
   }
 
+  ArrayRef<std::string> getPreserveModules() const { return preserveModules; }
+
   StringRef getOutputFilename() const { return outputFilename; }
   StringRef getBlackBoxRootPath() const { return blackBoxRootPath; }
   StringRef getReplaceSequentialMemoriesFile() const { return replSeqMemFile; }
@@ -223,6 +225,11 @@ public:
   FirtoolOptions &
   setPreserveValues(firrtl::PreserveValues::PreserveMode value) {
     preserveMode = value;
+    return *this;
+  }
+
+  FirtoolOptions &setPreserveModules(std::vector<std::string> value) {
+    preserveModules = value;
     return *this;
   }
 
@@ -443,6 +450,7 @@ private:
   bool probesToSignals;
   firrtl::PreserveAggregate::PreserveMode preserveAggregate;
   firrtl::PreserveValues::PreserveMode preserveMode;
+  std::vector<std::string> preserveModules;
   bool enableDebugInfo;
   BuildMode buildMode;
   bool disableLayerSink;

--- a/lib/Dialect/FIRRTL/Transforms/DropName.cpp
+++ b/lib/Dialect/FIRRTL/Transforms/DropName.cpp
@@ -32,20 +32,27 @@ struct DropNamesPass : public circt::firrtl::impl::DropNameBase<DropNamesPass> {
   enum ModAction { Drop, Keep, Demote };
 
   void runOnOperation() override {
+    auto moduleName = getOperation().getName();
+    bool isPreserved =
+        llvm::find_if(preserveModules, [moduleName](const std::string &name) {
+          return moduleName == name;
+        }) != preserveModules.end();
+    auto mode = isPreserved ? PreserveValues::Named : preserveMode;
+
     size_t namesDropped = 0;
     size_t namesChanged = 0;
-    if (preserveMode == PreserveValues::None) {
+    if (mode == PreserveValues::None) {
       // Drop all names.
       dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {
         if (isUselessName(op.getName()))
           return ModAction::Drop;
         return ModAction::Demote;
       });
-    } else if (preserveMode == PreserveValues::Strip) {
+    } else if (mode == PreserveValues::Strip) {
       // Strip all names.
       dropNamesIf(namesChanged, namesDropped,
                   [](FNamableOp op) { return ModAction::Drop; });
-    } else if (preserveMode == PreserveValues::Named) {
+    } else if (mode == PreserveValues::Named) {
       // Drop the name if it isn't considered meaningful.
       dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {
         auto name = op.getName();
@@ -55,7 +62,7 @@ struct DropNamesPass : public circt::firrtl::impl::DropNameBase<DropNamesPass> {
           return ModAction::Demote;
         return ModAction::Keep;
       });
-    } else if (preserveMode == PreserveValues::All) {
+    } else if (mode == PreserveValues::All) {
       // Drop the name if it isn't considered meaningful.
       dropNamesIf(namesChanged, namesDropped, [](FNamableOp op) {
         if (isUselessName(op.getName()))

--- a/lib/Firtool/Firtool.cpp
+++ b/lib/Firtool/Firtool.cpp
@@ -73,7 +73,9 @@ LogicalResult firtool::populateCHIRRTLToLowFIRRTL(mlir::PassManager &pm,
       firrtl::createPassiveWires());
 
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
-      firrtl::createDropName({/*preserveMode=*/opt.getPreserveMode()}));
+      firrtl::createDropName(
+          {/*preserveMode=*/opt.getPreserveMode(),
+           /*preserveModules=*/llvm::to_vector(opt.getPreserveModules())}));
 
   pm.nest<firrtl::CircuitOp>().nest<firrtl::FModuleOp>().addPass(
       firrtl::createLowerCHIRRTLPass());
@@ -543,6 +545,12 @@ public:
                      "Preserve all values")),
       llvm::cl::init(firrtl::PreserveValues::None)};
 
+  llvm::cl::list<std::string> preserveModules{
+      "preserve-modules",
+      llvm::cl::desc(
+          "Specify the modules in which all meaningful names are preserved"),
+      llvm::cl::ZeroOrMore};
+
   llvm::cl::opt<bool> enableDebugInfo{
       "g", llvm::cl::desc("Enable the generation of debug information"),
       llvm::cl::init(false)};
@@ -858,16 +866,16 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
       disableAnnotationsClassless(false), lowerAnnotationsNoRefTypePorts(false),
       probesToSignals(false),
       preserveAggregate(firrtl::PreserveAggregate::None),
-      preserveMode(firrtl::PreserveValues::None), enableDebugInfo(false),
-      buildMode(BuildModeRelease), disableLayerSink(false),
-      disableOptimization(false), vbToBV(false), noDedup(false),
-      dedupClasses(true), companionMode(firrtl::CompanionMode::Bind),
-      noViews(false), disableAggressiveMergeConnections(false),
-      lowerMemories(false), blackBoxRootPath(""), replSeqMem(false),
-      replSeqMemFile(""), ignoreReadEnableMem(false),
-      disableRandom(RandomKind::None), outputAnnotationFilename(""),
-      enableAnnotationWarning(false), warnOnTruncation(false),
-      lowerToCore(false), addMuxPragmas(false),
+      preserveMode(firrtl::PreserveValues::None), preserveModules({}),
+      enableDebugInfo(false), buildMode(BuildModeRelease),
+      disableLayerSink(false), disableOptimization(false), vbToBV(false),
+      noDedup(false), dedupClasses(true),
+      companionMode(firrtl::CompanionMode::Bind), noViews(false),
+      disableAggressiveMergeConnections(false), lowerMemories(false),
+      blackBoxRootPath(""), replSeqMem(false), replSeqMemFile(""),
+      ignoreReadEnableMem(false), disableRandom(RandomKind::None),
+      outputAnnotationFilename(""), enableAnnotationWarning(false),
+      warnOnTruncation(false), lowerToCore(false), addMuxPragmas(false),
       verificationFlavor(firrtl::VerificationFlavor::None),
       emitSeparateAlwaysBlocks(false),
       addVivadoRAMAddressConflictSynthesisBugWorkaround(false),
@@ -889,6 +897,7 @@ circt::firtool::FirtoolOptions::FirtoolOptions()
   probesToSignals = clOptions->probesToSignals;
   preserveAggregate = clOptions->preserveAggregate;
   preserveMode = clOptions->preserveMode;
+  preserveModules = clOptions->preserveModules;
   enableDebugInfo = clOptions->enableDebugInfo;
   buildMode = clOptions->buildMode;
   disableLayerSink = clOptions->disableLayerSink;


### PR DESCRIPTION
Add an option that preserves all meaningful names within selected modules.

Assisted-by: codex: gpt-5.6-terra

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
