### PR TITLE
[MoreToCore] Add lowering for string comparison and case conversion methods

### DIFF
--- a/include/circt/Dialect/Sim/SimOps.td
+++ b/include/circt/Dialect/Sim/SimOps.td
@@ -851,6 +851,52 @@ def StringCmpOp : SimOp<"string.cmp", [Pure]> {
   let assemblyFormat = "$predicate $lhs `,` $rhs attr-dict `:` type($lhs)";
 }
 
+def StringCompareOp: SimOp<"string.compare", [Pure]> {
+  let summary = "Compare two dynamic strings lexicographically";
+
+  let description = [{
+    Compares two strings lexicographically and returns the ASCII difference.
+    This corresponds to the behavior of the ANSI C `strcmp` function.
+  }];
+
+  let arguments = (ins
+    DynamicStringType:$lhs,
+    DynamicStringType:$rhs
+  );
+  let results = (outs I32:$result);
+
+  let assemblyFormat = "$lhs `,` $rhs attr-dict";
+}
+
+def StringToLowerOp: SimOp<"string.tolower", [Pure]> {
+  let summary = "Convert a string to lowercase"; 
+
+  let description = [{
+    Returns a new string with all characters in lowercase.
+  }];
+
+  let arguments = (ins
+    DynamicStringType:$input
+  );
+  let results = (outs DynamicStringType:$result);
+
+  let assemblyFormat = "$input attr-dict";
+}
+
+def StringToUpperOp: SimOp<"string.toupper", [Pure]> {
+  let summary = "Convert a string to uppercase"; 
+
+  let description = [{
+    Returns a new string with all characters in uppercase.
+  }];
+
+  let arguments = (ins
+    DynamicStringType:$input
+  );
+  let results = (outs DynamicStringType:$result);
+
+  let assemblyFormat = "$input attr-dict";
+}
 //===----------------------------------------------------------------------===//
 // Queues
 //===----------------------------------------------------------------------===//

--- a/lib/Conversion/MooreToCore/MooreToCore.cpp
+++ b/lib/Conversion/MooreToCore/MooreToCore.cpp
@@ -3437,6 +3437,57 @@ struct StringCmpOpConversion : public OpConversionPattern<StringCmpOp> {
   }
 };
 
+struct StringCompareOpConversion : public OpConversionPattern<StringCompareOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StringCompareOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::StringCompareOp>(op, adaptor.getLhs(),
+                                                      adaptor.getRhs());
+    return success();
+  }
+};
+
+struct StringICompareOpConversion
+    : public OpConversionPattern<StringICompareOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StringICompareOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    Value lowerLhs =
+        sim::StringToLowerOp::create(rewriter, loc, adaptor.getLhs());
+    Value lowerRhs =
+        sim::StringToLowerOp::create(rewriter, loc, adaptor.getRhs());
+    rewriter.replaceOpWithNewOp<sim::StringCompareOp>(op, lowerLhs, lowerRhs);
+    return success();
+  }
+};
+
+struct StringToLowerOpConversion : public OpConversionPattern<StringToLowerOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StringToLowerOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::StringToLowerOp>(op, adaptor.getStr());
+    return success();
+  }
+};
+
+struct StringToUpperOpConversion : public OpConversionPattern<StringToUpperOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(StringToUpperOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<sim::StringToUpperOp>(op, adaptor.getStr());
+    return success();
+  }
+};
+
 struct ReadMemBIOpConversion : public OpConversionPattern<ReadMemBIOp> {
   using OpConversionPattern::OpConversionPattern;
 
@@ -4085,7 +4136,10 @@ static void populateOpConversion(ConversionPatternSet &patterns,
     StringConcatOpConversion,
     StringGetOpConversion,
     StringCmpOpConversion,
-
+    StringCompareOpConversion,
+    StringICompareOpConversion,
+    StringToLowerOpConversion,
+    StringToUpperOpConversion,
     // Queue operations
     QueueSizeBIOpConversion,
     QueuePushBackOpConversion,

--- a/test/Conversion/MooreToCore/basic.mlir
+++ b/test/Conversion/MooreToCore/basic.mlir
@@ -1770,6 +1770,16 @@ func.func @StringOperations(%arg0: !moore.i32, %arg1: !moore.string, %arg2: !moo
   moore.string_cmp ge %arg1, %arg2 : string -> i1
   // CHECK: sim.string.cmp gt %arg1, %arg2 : !sim.dstring
   moore.string_cmp gt %arg1, %arg2 : string -> i1
+  // CHECK: sim.string.compare %arg1, %arg2
+  moore.string.compare %arg1, %arg2
+  // CHECK: [[LOWER_LHS:%.+]] = sim.string.tolower %arg1
+  // CHECK: [[LOWER_RHS:%.+]] = sim.string.tolower %arg2
+  // CHECK: sim.string.compare [[LOWER_LHS]], [[LOWER_RHS]]
+  moore.string.icompare %arg1, %arg2
+  // CHECK: sim.string.tolower %arg1
+  moore.string.tolower %arg1
+  // CHECK: sim.string.toupper %arg1
+  moore.string.toupper %arg1
   return
 }
 


### PR DESCRIPTION
This PR legalizes `moore.string.compare`, `moore.string.icompare`, `moore.string.tolower` and `moore.string.toupper`, fixing the following legalization errors that occured during lowering:

```
      1 error: failed to legalize operation moore.string.toupper
      1 error: failed to legalize operation moore.string.tolower
      1 error: failed to legalize operation moore.string.icompare
      1 error: failed to legalize operation moore.string.compare
```


`sim.string.compare`, `sim.string.tolower` and `sim.string.toupper` were added to the sim dialect. The MooreToCore pass lowers `moore.string.compare`, `moore.string.tolower`, and `moore.string.toupper` directly to their new respective sim operations. `moore.string.icompare` is lowered as a composition of the above operations.


<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
