### PR TITLE
[Calyx] Reject invoke ops passing ref cells to local instances

### DIFF
--- a/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
+++ b/lib/Conversion/SCFToCalyx/SCFToCalyx.cpp
@@ -1990,7 +1990,8 @@ struct FuncOpConversion : public calyx::FuncOpPartialLoweringPattern {
         auto memOp = calyx::SeqMemoryOp::create(
             rewriter, funcOp.getLoc(), memName,
             memtype.getElementType().getIntOrFloatBitWidth(), sizes, addrSizes);
-        // we don't set the memory to "external", which implies it's a reference
+        // Explicitly set "is_ref" to mark this memory as a reference interface.
+        memOp->setAttr("is_ref", rewriter.getUnitAttr());
 
         compState->registerMemoryInterface(arg.value(),
                                            calyx::MemoryInterface(memOp));

--- a/lib/Dialect/Calyx/CalyxOps.cpp
+++ b/lib/Dialect/Calyx/CalyxOps.cpp
@@ -2960,6 +2960,50 @@ LogicalResult InvokeOp::verify() {
            << "'@" << callee << "'"
            << " is a combinational component and cannot be invoked, which must "
               "have single go port and single done port.";
+  if (auto instanceOp = dyn_cast<InstanceOp>(operation)) {
+    if (auto compInterface = instanceOp.getReferencedComponent()) {
+      if (auto calleeComp =
+              dyn_cast<ComponentOp>(compInterface.getOperation())) {
+        if (auto refCells = getRefCellsMap()) {
+          for (Attribute attr : refCells) {
+            auto dictAttr = cast<DictionaryAttr>(attr);
+            for (NamedAttribute namedAttr : dictAttr) {
+              StringRef calleeRefCellName = namedAttr.getName().getValue();
+
+              Operation *calleeCell = lookupCell(calleeComp, calleeRefCellName);
+
+              if (!calleeCell) {
+                return emitOpError()
+                       << "references cell '" << calleeRefCellName
+                       << "' which does not exist in callee component '"
+                       << instanceOp.getComponentName() << "'.";
+              }
+
+              auto isRefBoolAttr =
+                  calleeCell->getAttrOfType<BoolAttr>("is_ref");
+              bool isUnitAttr = calleeCell->hasAttr("is_ref");
+              bool isRef = false;
+
+              if (isRefBoolAttr) {
+                isRef = isRefBoolAttr.getValue();
+              } else if (isUnitAttr) {
+                isRef = true;
+              }
+
+              if (!isRef) {
+                return emitOpError()
+                       << "attempts to pass a reference to cell '"
+                       << calleeRefCellName << "' in component '"
+                       << instanceOp.getComponentName()
+                       << "', but the target is a localized instance, not a "
+                          "reference cell (missing 'is_ref' attribute).";
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
   auto ports = getPorts();
   auto inputs = getInputs();

--- a/test/Conversion/SCFToCalyx/convert_controlflow.mlir
+++ b/test/Conversion/SCFToCalyx/convert_controlflow.mlir
@@ -775,7 +775,7 @@ module {
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]] = calyx.std_slice @std_slice_0 : i32, i1
 // CHECK:           %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_slt @std_slt_0 : i32, i32, i1
-// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] {is_ref} : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.comb_group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_15]] = %[[VAL_0]] : i32
@@ -846,8 +846,8 @@ module {
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]] = calyx.std_eq @std_eq_0 : i32, i32, i1
 // CHECK:           %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]] = calyx.register @remui_0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]] = calyx.std_remu_pipe @std_remu_pipe_0 : i1, i1, i1, i32, i32, i32, i1
-// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.seq_mem @arg_mem_1 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]], %[[VAL_46:.*]], %[[VAL_47:.*]], %[[VAL_48:.*]], %[[VAL_49:.*]] = calyx.seq_mem @arg_mem_0 <[120] x 32> [7] : i7, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]], %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]] = calyx.seq_mem @arg_mem_1 <[120] x 32> [7] {is_ref} : i7, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]], %[[VAL_46:.*]], %[[VAL_47:.*]], %[[VAL_48:.*]], %[[VAL_49:.*]] = calyx.seq_mem @arg_mem_0 <[120] x 32> [7] {is_ref} : i7, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_30]] = %[[VAL_0]] : i32

--- a/test/Conversion/SCFToCalyx/convert_memory.mlir
+++ b/test/Conversion/SCFToCalyx/convert_memory.mlir
@@ -401,7 +401,7 @@ module {
 // CHECK-SAME:                          %[[VAL_5:.*]]: i1 {done}) {
 // CHECK:           %[[VAL_6:.*]] = hw.constant true
 // CHECK:           %[[VAL_7:.*]], %[[VAL_8:.*]] = calyx.std_slice @std_slice_0 : i32, i3
-// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_9:.*]], %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]], %[[VAL_16:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.group @bb0_0 {
 // CHECK:               calyx.assign %[[VAL_7]] = %[[VAL_1]] : i32
@@ -457,7 +457,7 @@ module {
 // CHECK:           %[[VAL_7:.*]] = hw.constant true
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i3
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.assign %[[VAL_4]] = %[[VAL_14]] : i32
 // CHECK:             calyx.group @bb0_0 {
@@ -526,7 +526,7 @@ module {
 // CHECK:           %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]], %[[VAL_24:.*]], %[[VAL_25:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]], %[[VAL_30:.*]], %[[VAL_31:.*]] = calyx.register @ret_arg1_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.assign %[[VAL_6]] = %[[VAL_30]] : i32
 // CHECK:             calyx.assign %[[VAL_5]] = %[[VAL_36]] : i32
@@ -666,7 +666,7 @@ module {
 // CHECK:           %[[VAL_7:.*]] = hw.constant 0 : i32
 // CHECK:           %[[VAL_8:.*]], %[[VAL_9:.*]] = calyx.std_slice @std_slice_0 : i32, i6
 // CHECK:           %[[VAL_10:.*]], %[[VAL_11:.*]], %[[VAL_12:.*]], %[[VAL_13:.*]], %[[VAL_14:.*]], %[[VAL_15:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[33] x 32> [6] : i6, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_16:.*]], %[[VAL_17:.*]], %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.seq_mem @arg_mem_0 <[33] x 32> [6] {is_ref} : i6, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_14]] : i32
 // CHECK:             calyx.group @bb0_0 {
@@ -821,8 +821,8 @@ module {
 // CHECK:           %[[VAL_15:.*]], %[[VAL_16:.*]], %[[VAL_17:.*]] = calyx.std_add @std_add_0 : i32, i32, i32
 // CHECK:           %[[VAL_18:.*]], %[[VAL_19:.*]], %[[VAL_20:.*]], %[[VAL_21:.*]], %[[VAL_22:.*]], %[[VAL_23:.*]] = calyx.register @load_0_reg : i32, i1, i1, i1, i32, i1
 // CHECK:           %[[VAL_24:.*]], %[[VAL_25:.*]], %[[VAL_26:.*]], %[[VAL_27:.*]], %[[VAL_28:.*]], %[[VAL_29:.*]] = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
-// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.seq_mem @arg_mem_1 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
-// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_30:.*]], %[[VAL_31:.*]], %[[VAL_32:.*]], %[[VAL_33:.*]], %[[VAL_34:.*]], %[[VAL_35:.*]], %[[VAL_36:.*]], %[[VAL_37:.*]] = calyx.seq_mem @arg_mem_1 <[1] x 32> [1] {is_ref} : i1, i1, i1, i1, i1, i32, i32, i1
+// CHECK:           %[[VAL_38:.*]], %[[VAL_39:.*]], %[[VAL_40:.*]], %[[VAL_41:.*]], %[[VAL_42:.*]], %[[VAL_43:.*]], %[[VAL_44:.*]], %[[VAL_45:.*]] = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] {is_ref} : i1, i1, i1, i1, i1, i32, i32, i1
 // CHECK:           calyx.wires {
 // CHECK:             calyx.assign %[[VAL_3]] = %[[VAL_28]] : i32
 // CHECK:             calyx.group @bb0_0 {

--- a/test/Dialect/Calyx/emit-invoke-with-ref.mlir
+++ b/test/Dialect/Calyx/emit-invoke-with-ref.mlir
@@ -9,7 +9,7 @@ module attributes {calyx.entrypoint = "main"} {
     %std_add_0.left, %std_add_0.right, %std_add_0.out = calyx.std_add @std_add_0 : i32, i32, i32
     %ret_arg0_reg.in, %ret_arg0_reg.write_en, %ret_arg0_reg.clk, %ret_arg0_reg.reset, %ret_arg0_reg.out, %ret_arg0_reg.done = calyx.register @ret_arg0_reg : i32, i1, i1, i1, i32, i1
     // CHECK: ref arg_mem_0 = seq_mem_d1(32, 1, 1);
-    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] : i1, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[1] x 32> [1] {is_ref} : i1, i1, i1, i1, i1, i32, i32, i1
     calyx.wires {
       calyx.assign %out0 = %ret_arg0_reg.out : i32
       calyx.group @bb0_0 {

--- a/test/Dialect/Calyx/round-trip.mlir
+++ b/test/Dialect/Calyx/round-trip.mlir
@@ -476,8 +476,8 @@ module attributes {calyx.entrypoint = "main"} {
     %true = hw.constant true
     %c1_i32 = hw.constant 1 : i32
     %func_1_instance.in0, %func_1_instance.in2, %func_1_instance.clk, %func_1_instance.reset, %func_1_instance.go, %func_1_instance.done = calyx.instance @func_1_instance of @func_1 : i32, i32, i1, i1, i1, i1
-    %arg_mem_1.addr0, %arg_mem_1.clk, %arg_mem_1.reset, %arg_mem_1.content_en, %arg_mem_1.write_en, %arg_mem_1.write_data, %arg_mem_1.read_data, %arg_mem_1.done = calyx.seq_mem @arg_mem_1 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
-    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_1.addr0, %arg_mem_1.clk, %arg_mem_1.reset, %arg_mem_1.content_en, %arg_mem_1.write_en, %arg_mem_1.write_data, %arg_mem_1.read_data, %arg_mem_1.done = calyx.seq_mem @arg_mem_1 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
     calyx.wires {
       calyx.group @init_func_1_instance {
         calyx.assign %func_1_instance.reset = %true : i1
@@ -500,8 +500,8 @@ module attributes {calyx.entrypoint = "main"} {
     %true = hw.constant true
     %std_slice_1.in, %std_slice_1.out = calyx.std_slice @std_slice_1 : i32, i3
     %std_slice_0.in, %std_slice_0.out = calyx.std_slice @std_slice_0 : i32, i3
-    %arg_mem_1.addr0, %arg_mem_1.clk, %arg_mem_1.reset, %arg_mem_1.content_en, %arg_mem_1.write_en, %arg_mem_1.write_data, %arg_mem_1.read_data, %arg_mem_1.done = calyx.seq_mem @arg_mem_1 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
-    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] : i3, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_1.addr0, %arg_mem_1.clk, %arg_mem_1.reset, %arg_mem_1.content_en, %arg_mem_1.write_en, %arg_mem_1.write_data, %arg_mem_1.read_data, %arg_mem_1.done = calyx.seq_mem @arg_mem_1 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
+    %arg_mem_0.addr0, %arg_mem_0.clk, %arg_mem_0.reset, %arg_mem_0.content_en, %arg_mem_0.write_en, %arg_mem_0.write_data, %arg_mem_0.read_data, %arg_mem_0.done = calyx.seq_mem @arg_mem_0 <[8] x 32> [3] {is_ref} : i3, i1, i1, i1, i1, i32, i32, i1
     calyx.wires {
       calyx.group @bb0_0 {
         calyx.assign %std_slice_1.in = %in2 : i32


### PR DESCRIPTION
Previously, when a `calyx.invoke` operation used `refCellsMap` to pass a memory reference to a callee component, the compiler assumed the target cell was a valid reference cell. If the callee actually instantiated that cell locally (e.g., via `calyx.instance` without the `is_ref` attribute), the `lower-calyx-to-hw` pass would encounter a null pointer dereference and crash with a Segmentation fault.

This patch adds semantic verification to `InvokeOp::verify()`. It ensures that every cell referenced in `refCellsMap`:
1. Exists within the callee component.
2. Possesses the `is_ref` attribute.

If the target is a localized instance rather than a reference cell, the verifier now properly emits a diagnostic error, preventing invalid IR from crashing the lowering pipeline.

### Note to Reviewers:

The new verification logic works perfectly, but it causes 5 existing tests to fail (e.g., in `SCFToCalyx`). This reveals that the current `SCFToCalyx` pass is generating invalid Calyx IR (missing the `is_ref` attribute on instances that are meant to be passed by reference).

Fixes #11087

Assisted-by: Google:Gemini 3.1 pro
