### PR TITLE
[PyCDE] Fix the nightly "Test PyCDE and the ESI runtime" workflow

### DIFF
--- a/frontends/PyCDE/python/requirements.txt
+++ b/frontends/PyCDE/python/requirements.txt
@@ -1,7 +1,10 @@
 numpy
 nanobind>=2.2.0,<3
 PyYAML
-cocotb>=1.6.2
+# cocotb 2.1 removed `cocotb_tools.config.lib_name`, which cocotb-test (the
+# runner we use in `pycde.testing`) still relies on. Cap the version until
+# cocotb-test supports cocotb 2.1 or we move off of cocotb-test.
+cocotb>=1.6.2,<2.1
 cocotb-test>=0.2.2
 jinja2
 executing>=2.2.0

--- a/frontends/PyCDE/test/test_fsm.py
+++ b/frontends/PyCDE/test/test_fsm.py
@@ -12,7 +12,7 @@ from pycde.testing import unittestmodule
 # CHECK-NEXT:    %0:4 = fsm.hw_instance "F0" @F0(%a, %b, %c), clock %clk, reset %rst : (i1, i1, i1) -> (i1, i1, i1, i1)
 # CHECK-NEXT:    hw.output %0#1, %0#2, %0#3 : i1, i1, i1
 # CHECK-NEXT:  }
-# CHECK-LABEL: fsm.machine @F0(%arg0: i1, %arg1: i1, %arg2: i1) -> (i1, i1, i1, i1) attributes {clock_name = "clk", in_names = ["a", "b", "c"], initialState = "idle", out_names = ["is_idle", "is_A", "is_B", "is_C"], reset_name = "rst"} {
+# CHECK-LABEL: fsm.machine @F0(%arg0: i1, %arg1: i1, %arg2: i1) -> (i1, i1, i1, i1) attributes {clock_name = "clk", in_names = ["a", "b", "c"], out_names = ["is_idle", "is_A", "is_B", "is_C"], reset_name = "rst", initialState = "idle"} {
 # CHECK-NEXT:    fsm.state @idle output {
 # CHECK-NEXT:      %true = hw.constant true
 # CHECK-NEXT:      %false = hw.constant false
@@ -128,7 +128,7 @@ system.print()
 # Test alternative clock / reset names.
 
 
-# CHECK-LABEL:  fsm.machine @FsmClockTest(%arg0: i1) -> (i1, i1) attributes {clock_name = "clock", in_names = ["a"], initialState = "A", out_names = ["is_A", "is_B"], reset_name = "reset"}
+# CHECK-LABEL:  fsm.machine @FsmClockTest(%arg0: i1) -> (i1, i1) attributes {clock_name = "clock", in_names = ["a"], out_names = ["is_A", "is_B"], reset_name = "reset", initialState = "A"}
 @unittestmodule()
 class FsmClockTest(fsm.Machine):
   clock = Clock()


### PR DESCRIPTION
The [Test PyCDE and the ESI runtime](https://github.com/llvm/circt/actions/workflows/testPycdeESI.yml) workflow has been failing on `main` every night since 2026-08-31 (last green run: 08-30). It also blocks the same job on any PR touching `frontends/PyCDE/**` or `lib/Dialect/ESI/runtime/**` (e.g. #11099). Two unrelated breakages landed within a day of each other, both in the `Test PyCDE` step:

### 1. `test_fsm.py`: MLIR attribute print order changed

The LLVM bump picked up the upstream change which splits the inherent/discardable attribute APIs. `function_interface_impl::printFunctionAttributes` now prints `getDiscardableAttrDictionary()` first and then appends the inherent attributes:

```c++
NamedAttrList attrs(op->getDiscardableAttrDictionary().getValue());
op->getName().walkInherentAttrs(
    op, [&](StringRef name, Attribute &attr) { attrs.append(name, attr); });
```

`fsm.machine`'s `initialState` is an inherent attribute, so it now prints *after* the discardable `clock_name`/`in_names`/`out_names`/`reset_name` attributes that PyCDE attaches:

```mlir
// before
fsm.machine @F0(...) attributes {clock_name = "clk", in_names = [...], initialState = "idle", out_names = [...], reset_name = "rst"}
// after
fsm.machine @F0(...) attributes {clock_name = "clk", in_names = [...], out_names = [...], reset_name = "rst", initialState = "idle"}
```

The in-tree FSM tests never have more than one attribute in the dictionary, so PyCDE is the only place that noticed. This just updates the expected output.

### 2. `test_cocotb_testbench.py`: cocotb 2.1 broke cocotb-test

cocotb 2.1.0 was released on 2026-08-30 (19:01 UTC), exactly between the last green and the first red run. It removed `cocotb_tools.config.lib_name`, which `cocotb-test` still calls, so every cocotb run dies with:

```
File "cocotb_test/simulator.py", line 447, in run_command
  ["vvp", "-M", self.lib_dir, "-m", cocotb_config.lib_name("vpi", "icarus")]
AttributeError: module 'cocotb_tools.config' has no attribute 'lib_name'
```

`cocotb-test` has had no release since Jan 2025, so cap cocotb at `<2.1` until it supports 2.1 or we move `pycde.testing` off of `cocotb-test` and onto cocotb's built-in `cocotb_tools.runner`. 2.0.1 is the version that was passing before. Note that `unifiedBuildTestAndInstall.yml` already pins `cocotb~=1.9`, which is why the nightly integration tests stayed green.

### Testing

Built locally with the Python bindings, PyCDE, and the ESI runtime + cosim (iverilog 11, verilator 5.042) and ran every step of the workflow that had been blocked:

| Step | Result |
| --- | --- |
| `check-pycde` | 32 passed, 1 XFAIL (previously 30 passed / 2 failed) |
| `check-pycde-integration` | 1 XFAIL — identical to the last green CI run |
| `ESIRuntimeCppTests` + ESI runtime pytest | 137 passed, 1 skipped |