### PR TITLE
[HandshakeRunner] Fix memref CLI arguments and add missing integer arith ops

### DIFF
--- a/integration_test/handshake-runner/arith_ops.mlir
+++ b/integration_test/handshake-runner/arith_ops.mlir
@@ -1,0 +1,33 @@
+// RUN: handshake-runner %s 6 3 | FileCheck %s
+// RUN: circt-opt -lower-cf-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner - 6 3 | FileCheck %s
+// CHECK: 74
+
+module {
+  func.func @main(%a: i32, %b: i32) -> i32 {
+    %and = arith.andi %a, %b : i32
+    %or = arith.ori %a, %b : i32
+    %shl = arith.shli %a, %b : i32
+    %shrs = arith.shrsi %a, %b : i32
+    %shru = arith.shrui %a, %b : i32
+    %rems = arith.remsi %a, %b : i32
+    %remu = arith.remui %a, %b : i32
+    %max = arith.maxsi %a, %b : i32
+    %min = arith.minsi %a, %b : i32
+    %gt = arith.cmpi sgt, %a, %b : i32
+    %sel = arith.select %gt, %and, %or : i32
+    %tr = arith.trunci %a : i32 to i8
+    %ex = arith.extsi %tr : i8 to i32
+
+    %0 = arith.addi %and, %or : i32
+    %1 = arith.addi %0, %shl : i32
+    %2 = arith.addi %1, %shrs : i32
+    %3 = arith.addi %2, %shru : i32
+    %4 = arith.addi %3, %rems : i32
+    %5 = arith.addi %4, %remu : i32
+    %6 = arith.addi %5, %max : i32
+    %7 = arith.addi %6, %min : i32
+    %8 = arith.addi %7, %sel : i32
+    %9 = arith.addi %8, %ex : i32
+    return %9 : i32
+  }
+}

--- a/integration_test/handshake-runner/memref_args.mlir
+++ b/integration_test/handshake-runner/memref_args.mlir
@@ -1,0 +1,16 @@
+// RUN: handshake-runner %s "1,2" "3,4" | FileCheck %s
+// RUN: circt-opt -lower-cf-to-handshake -handshake-materialize-forks-sinks %s | handshake-runner - "1,2" "3,4" | FileCheck %s
+// CHECK: 3 1,2 3,4
+
+// Each memref argument must be initialized from its own positional argument.
+// The returned value is %b[0], so binding %b to the first argument (as the
+// runner used to do) would print 1 instead of 3, and the second memref would
+// come back as "1,2".
+
+module {
+  func.func @main(%a: memref<2xi32>, %b: memref<2xi32>) -> i32 {
+    %c0 = arith.constant 0 : index
+    %0 = memref.load %b[%c0] : memref<2xi32>
+    return %0 : i32
+  }
+}

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -1000,11 +1000,12 @@ bool simulate(StringRef toplevelFunction, ArrayRef<std::string> inputArgs,
       unsigned buffer = allocateMemRef(memreftype, nothing, store, storeTimes);
       valueMap[blockArgs[i]] = buffer;
       timeMap[blockArgs[i]] = 0.0;
-      int64_t i = 0;
+      int64_t elem = 0;
       std::stringstream arg(inputArgs[i]);
       while (!arg.eof()) {
         getline(arg, x, ',');
-        store[buffer][i++] = readValueWithType(memreftype.getElementType(), x);
+        store[buffer][elem++] =
+            readValueWithType(memreftype.getElementType(), x);
       }
     } else {
       Any value = readValueWithType(type, inputArgs[i]);

--- a/tools/handshake-runner/Simulation.cpp
+++ b/tools/handshake-runner/Simulation.cpp
@@ -243,6 +243,28 @@ private:
                         std::vector<Any> &);
   LogicalResult execute(mlir::arith::AddIOp, std::vector<Any> &,
                         std::vector<Any> &);
+  LogicalResult execute(mlir::arith::SelectOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::AndIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::OrIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::TruncIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::ShLIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::ShRSIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::ShRUIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::RemSIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::RemUIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::MaxSIOp, std::vector<Any> &,
+                        std::vector<Any> &);
+  LogicalResult execute(mlir::arith::MinSIOp, std::vector<Any> &,
+                        std::vector<Any> &);
   LogicalResult execute(mlir::arith::XOrIOp, std::vector<Any> &,
                         std::vector<Any> &);
   LogicalResult execute(mlir::arith::AddFOp, std::vector<Any> &,
@@ -319,6 +341,84 @@ LogicalResult HandshakeExecuter::execute(mlir::arith::ConstantIntOp op,
                                          std::vector<Any> &out) {
   auto attr = op->getAttrOfType<mlir::IntegerAttr>("value");
   out[0] = attr.getValue();
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::SelectOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).getBoolValue() ? in[1] : in[2];
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::AndIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]) & any_cast<APInt>(in[1]);
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::OrIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]) | any_cast<APInt>(in[1]);
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::ShLIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).shl(any_cast<APInt>(in[1]));
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::ShRSIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).ashr(any_cast<APInt>(in[1]));
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::ShRUIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).lshr(any_cast<APInt>(in[1]));
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::RemSIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).srem(any_cast<APInt>(in[1]));
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::RemUIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).urem(any_cast<APInt>(in[1]));
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::MaxSIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).sgt(any_cast<APInt>(in[1])) ? in[0] : in[1];
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::MinSIOp,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  out[0] = any_cast<APInt>(in[0]).slt(any_cast<APInt>(in[1])) ? in[0] : in[1];
+  return success();
+}
+
+LogicalResult HandshakeExecuter::execute(mlir::arith::TruncIOp op,
+                                         std::vector<Any> &in,
+                                         std::vector<Any> &out) {
+  int64_t width = op.getType().getIntOrFloatBitWidth();
+  out[0] = any_cast<APInt>(in[0]).trunc(width);
   return success();
 }
 
@@ -720,6 +820,11 @@ HandshakeExecuter::HandshakeExecuter(
     auto res =
         llvm::TypeSwitch<Operation *, LogicalResult>(&op)
             .Case<mlir::arith::ConstantIndexOp, mlir::arith::ConstantIntOp,
+                  mlir::arith::SelectOp, mlir::arith::AndIOp, mlir::arith::OrIOp,
+                  mlir::arith::TruncIOp, mlir::arith::ShLIOp,
+                  mlir::arith::ShRSIOp, mlir::arith::ShRUIOp,
+                  mlir::arith::RemSIOp, mlir::arith::RemUIOp,
+                  mlir::arith::MaxSIOp, mlir::arith::MinSIOp,
                   mlir::arith::AddIOp, mlir::arith::AddFOp, mlir::arith::CmpIOp,
                   mlir::arith::CmpFOp, mlir::arith::SubIOp, mlir::arith::SubFOp,
                   mlir::arith::MulIOp, mlir::arith::MulFOp,
@@ -871,6 +976,11 @@ HandshakeExecuter::HandshakeExecuter(
     LogicalResult res =
         llvm::TypeSwitch<Operation *, LogicalResult>(&op)
             .Case<mlir::arith::ConstantIndexOp, mlir::arith::ConstantIntOp,
+                  mlir::arith::SelectOp, mlir::arith::AndIOp, mlir::arith::OrIOp,
+                  mlir::arith::TruncIOp, mlir::arith::ShLIOp,
+                  mlir::arith::ShRSIOp, mlir::arith::ShRUIOp,
+                  mlir::arith::RemSIOp, mlir::arith::RemUIOp,
+                  mlir::arith::MaxSIOp, mlir::arith::MinSIOp,
                   mlir::arith::AddIOp, mlir::arith::AddFOp, mlir::arith::CmpIOp,
                   mlir::arith::CmpFOp, mlir::arith::SubIOp, mlir::arith::SubFOp,
                   mlir::arith::MulIOp, mlir::arith::MulFOp,


### PR DESCRIPTION
Two independent fixes to `handshake-runner`, each with an integration test.

### 1. Every memref argument reads `argv[0]`

`simulate()` binds each memref block argument from the positional input
arguments, but the inner element counter shadows the outer loop induction
variable:

```c++
for (unsigned i = 0; i < realInputs; ++i) {
  ...
  int64_t i = 0;                        // shadows the outer `i`
  std::stringstream arg(inputArgs[i]);  // always inputArgs[0]
```

so every memref is initialized from the *first* positional argument.

```mlir
func.func @main(%a: memref<2xi32>, %b: memref<2xi32>) -> i32 {
  %c0 = arith.constant 0 : index
  %0 = memref.load %b[%c0] : memref<2xi32>
  return %0 : i32
}
```

```
$ handshake-runner memref_args.mlir "1,2" "3,4"
1 1,2 1,2          # before: %b bound to argv[0]
3 1,2 3,4          # after
```

The existing integration tests never hit this — they all allocate their
memrefs with `memref.alloc()` inside the function and pass only scalar
arguments, so the documented "Memref types are specified as a
comma-separated list of values" path had no coverage. The new test passes
two memrefs with distinct contents and returns an element of the second
one, so it fails loudly both in the scalar result and in the dumped
memref contents.

### 2. Missing integer arith ops

The op dispatch covers add/sub/mul/div/cmp/ext but not the rest of the
integer arith ops, so a module using them dies with
`'arith.andi' op Unknown operation!`. These appear routinely in lowered
code: `select` from predication, `and`/`or` from short-circuit control,
shifts and remainders from index arithmetic, `min`/`max` from loop
bounds, `trunci` from narrowing.

Added: `select`, `andi`, `ori`, `trunci`, `shli`, `shrsi`, `shrui`,
`remsi`, `remui`, `maxsi`, `minsi`.

### How this was found

Trying to use `handshake-runner` as the reference interpreter for the
dataflow level of an accelerator DSE flow. Both issues blocked running a
lowered matmul whose weights/activations/accumulators are three separate
memref arguments.

One more thing worth noting for anyone hitting a *silent hang* rather than
an error: `handshake-runner` deadlocks without diagnostics when a value
has more than one consumer and forks have not been materialized. Running
`-handshake-materialize-forks-sinks` first fixes it (the existing tests do
this in their RUN lines). Not changed here, just recording it.