### PR TITLE
[ImportVerilog] Support fixed-size aggregates in streaming operators

### DIFF
--- a/lib/Conversion/ImportVerilog/Expressions.cpp
+++ b/lib/Conversion/ImportVerilog/Expressions.cpp
@@ -921,6 +921,64 @@ struct ExprVisitor {
 
 // NOLINTBEGIN(misc-no-recursion)
 namespace {
+
+/// Takes one streaming operand and appends its packed pieces to `leaves`,
+/// in the order defined in IEEE 1800-2023 § 11.4.14.1.
+static LogicalResult flattenStreamingValue(Context &context, Location loc,
+                                           Value value,
+                                           SmallVectorImpl<Value> &leaves) {
+  auto &builder = context.builder;
+
+  // Convert packed values to a simple bit vector.
+  if (isa<moore::PackedType>(value.getType())) {
+    value = context.convertToSimpleBitVector(value);
+    if (!value)
+      return failure();
+    leaves.push_back(value);
+    return success();
+  }
+
+  // Fixed-size unpacked arrays are traversed in foreach order.
+  if (auto type = dyn_cast<moore::UnpackedArrayType>(value.getType())) {
+    for (unsigned i = type.getSize(); i > 0; --i) {
+      auto element = moore::ExtractOp::create(
+          builder, loc, type.getElementType(), value, i - 1);
+      if (failed(flattenStreamingValue(context, loc, element, leaves)))
+        return failure();
+    }
+    return success();
+  }
+
+  // Struct members are traversed in declaration order.
+  if (auto type = dyn_cast<moore::UnpackedStructType>(value.getType())) {
+    for (auto member : type.getMembers()) {
+      auto field = moore::StructExtractOp::create(builder, loc, member.type,
+                                                  member.name, value);
+      if (failed(flattenStreamingValue(context, loc, field, leaves)))
+        return failure();
+    }
+    return success();
+  }
+
+  // Untagged unions are traversed through their first-declared member.
+  if (auto type = dyn_cast<moore::UnpackedUnionType>(value.getType())) {
+    if (type.getMembers().empty())
+      return failure();
+    auto member = type.getMembers().front();
+    auto field = moore::UnionExtractOp::create(builder, loc, member.type,
+                                               member.name, value);
+    return flattenStreamingValue(context, loc, field, leaves);
+  }
+
+  // Dynamic arrays, queues, associative arrays, strings, and class handles
+  // are not streamed yet and remain unsupported.
+  value = context.convertToSimpleBitVector(value);
+  if (!value)
+    return failure();
+  leaves.push_back(value);
+  return success();
+}
+
 struct RvalueExprVisitor : public ExprVisitor {
   RvalueExprVisitor(Context &context, Location loc)
       : ExprVisitor(context, loc, /*isLvalue=*/false) {}
@@ -1152,10 +1210,44 @@ struct RvalueExprVisitor : public ExprVisitor {
     if (!lhs)
       return {};
 
-    // Determine the right-hand side value of the assignment.
     context.lvalueStack.push_back(lhs);
-    auto rhs = context.convertRvalueExpression(
-        expr.right(), cast<moore::RefType>(lhs.getType()).getNestedType());
+    Value rhs;
+    auto rhsType = context.convertType(*expr.right().type);
+    // Flatten a fixed-size aggregate RHS for a streaming assignment target.
+    // See IEEE 1800-2023 § 11.4.14.3.
+    bool flattenRhs =
+        expr.left().as_if<slang::ast::StreamingConcatenationExpression>() &&
+        isa_and_nonnull<moore::UnpackedArrayType, moore::UnpackedStructType,
+                        moore::UnpackedUnionType>(rhsType);
+    if (flattenRhs) {
+      rhs = context.convertRvalueExpression(expr.right());
+      SmallVector<Value> leaves;
+      if (rhs && failed(flattenStreamingValue(context, loc, rhs, leaves)))
+        rhs = {};
+      if (rhs) {
+        if (leaves.size() == 1)
+          rhs = leaves.front();
+        else
+          rhs = moore::ConcatOp::create(builder, loc, leaves);
+      }
+
+      if (rhs) {
+        auto targetType = cast<moore::RefType>(lhs.getType()).getNestedType();
+        auto sourceType = cast<moore::IntType>(rhs.getType());
+        auto targetWidth = targetType.getBitSize().value();
+        if (sourceType.getWidth() > targetWidth) {
+          auto truncatedType = moore::IntType::get(
+              context.getContext(), targetWidth, sourceType.getDomain());
+          rhs = moore::ExtractOp::create(builder, loc, truncatedType, rhs,
+                                         sourceType.getWidth() - targetWidth);
+        }
+        rhs = context.materializeConversion(targetType, rhs,
+                                            expr.right().type->isSigned(), loc);
+      }
+    } else {
+      rhs = context.convertRvalueExpression(
+          expr.right(), cast<moore::RefType>(lhs.getType()).getNestedType());
+    }
     context.lvalueStack.pop_back();
     if (!rhs)
       return {};
@@ -2411,21 +2503,14 @@ struct RvalueExprVisitor : public ExprVisitor {
         return {};
       }
       Value value;
-      if (stream.constantWithWidth.has_value()) {
+      if (stream.constantWithWidth.has_value())
         value = context.convertRvalueExpression(*stream.withExpr);
-        auto type = cast<moore::UnpackedType>(value.getType());
-        auto intType = moore::IntType::get(
-            context.getContext(), type.getBitSize().value(), type.getDomain());
-        // Do not care if it's signed, because we will not do expansion.
-        value = context.materializeConversion(intType, value, false, loc);
-      } else {
+      else
         value = context.convertRvalueExpression(*stream.operand);
-      }
 
-      value = context.convertToSimpleBitVector(value);
-      if (!value)
+      if (!value ||
+          failed(flattenStreamingValue(context, operandLoc, value, operands)))
         return {};
-      operands.push_back(value);
     }
     Value value;
 
@@ -2569,6 +2654,104 @@ struct RvalueExprVisitor : public ExprVisitor {
 //===----------------------------------------------------------------------===//
 
 namespace {
+
+/// Takes one streaming assignment target and appends its packed references to
+/// `leaves`, in the order defined in IEEE 1800-2023 § 11.4.14.1.
+static LogicalResult flattenStreamingRef(Context &context, Location loc,
+                                         Value value,
+                                         SmallVectorImpl<Value> &leaves) {
+  auto &builder = context.builder;
+  auto refType = dyn_cast<moore::RefType>(value.getType());
+  if (!refType)
+    return failure();
+
+  // If already packed, we are done.
+  if (isa<moore::PackedType>(refType.getNestedType())) {
+    leaves.push_back(value);
+    return success();
+  }
+
+  // Fixed-size unpacked arrays are traversed in foreach order.
+  if (auto type = dyn_cast<moore::UnpackedArrayType>(refType.getNestedType())) {
+    auto elementRefType = moore::RefType::get(type.getElementType());
+    for (unsigned i = type.getSize(); i > 0; --i) {
+      auto element = moore::ExtractRefOp::create(builder, loc, elementRefType,
+                                                 value, i - 1);
+      if (failed(flattenStreamingRef(context, loc, element, leaves)))
+        return failure();
+    }
+    return success();
+  }
+
+  // Struct members are traversed in declaration order.
+  if (auto type =
+          dyn_cast<moore::UnpackedStructType>(refType.getNestedType())) {
+    for (auto member : type.getMembers()) {
+      auto field = moore::StructExtractRefOp::create(
+          builder, loc, moore::RefType::get(member.type), member.name, value);
+      if (failed(flattenStreamingRef(context, loc, field, leaves)))
+        return failure();
+    }
+    return success();
+  }
+
+  // Untagged unions are traversed through their first-declared member.
+  if (auto type = dyn_cast<moore::UnpackedUnionType>(refType.getNestedType())) {
+    if (type.getMembers().empty())
+      return failure();
+    auto member = type.getMembers().front();
+    auto field = moore::UnionExtractRefOp::create(
+        builder, loc, moore::RefType::get(member.type), member.name, value);
+    return flattenStreamingRef(context, loc, field, leaves);
+  }
+
+  // Dynamic arrays, queues, associative arrays, strings, and class handles
+  // are not streamed yet and remain unsupported.
+  return failure();
+}
+
+/// Extract a range [lowBit, lowBit + width) without creating
+/// extract_ref(concat_ref), which SimplifyRefs cannot decompose.
+static Value sliceStreamingRefs(Context &context, Location loc,
+                                ArrayRef<Value> leaves, unsigned lowBit,
+                                unsigned width) {
+  auto &builder = context.builder;
+  SmallVector<Value> pieces;
+  unsigned highBit = lowBit + width;
+  unsigned leafLow = 0;
+
+  // The last concat operand contains the least-significant bits.
+  for (Value leaf : llvm::reverse(leaves)) {
+    auto refType = cast<moore::RefType>(leaf.getType());
+    auto type = cast<moore::PackedType>(refType.getNestedType());
+    auto leafWidth = type.getBitSize();
+    if (!leafWidth)
+      return {};
+    unsigned leafHigh = leafLow + *leafWidth;
+
+    // Find the intersection of this leaf with the requested range.
+    unsigned begin = std::max(lowBit, leafLow);
+    unsigned end = std::min(highBit, leafHigh);
+    if (begin < end) {
+      unsigned pieceWidth = end - begin;
+      auto pieceType = moore::RefType::get(moore::IntType::get(
+          context.getContext(), pieceWidth, type.getDomain()));
+      pieces.push_back(moore::ExtractRefOp::create(builder, loc, pieceType,
+                                                   leaf, begin - leafLow));
+    }
+    leafLow = leafHigh;
+  }
+
+  if (pieces.empty())
+    return {};
+  // `moore.concat_ref` expects operands from most-significant to
+  // least-significant.
+  std::reverse(pieces.begin(), pieces.end());
+  if (pieces.size() == 1)
+    return pieces.front();
+  return moore::ConcatRefOp::create(builder, loc, pieces);
+}
+
 struct LvalueExprVisitor : public ExprVisitor {
   LvalueExprVisitor(Context &context, Location loc)
       : ExprVisitor(context, loc, /*isLvalue=*/true) {}
@@ -2686,63 +2869,48 @@ struct LvalueExprVisitor : public ExprVisitor {
         return {};
       }
       Value value;
-      if (stream.constantWithWidth.has_value()) {
+      if (stream.constantWithWidth.has_value())
         value = context.convertLvalueExpression(*stream.withExpr);
-        auto type = cast<moore::UnpackedType>(
-            cast<moore::RefType>(value.getType()).getNestedType());
-        auto intType = moore::RefType::get(moore::IntType::get(
-            context.getContext(), type.getBitSize().value(), type.getDomain()));
-        // Do not care if it's signed, because we will not do expansion.
-        value = context.materializeConversion(intType, value, false, loc);
-      } else {
+      else
         value = context.convertLvalueExpression(*stream.operand);
-      }
-
-      if (!value)
+      if (!value ||
+          failed(flattenStreamingRef(context, operandLoc, value, operands)))
         return {};
-      operands.push_back(value);
-    }
-    Value value;
-    if (operands.size() == 1) {
-      // There must be at least one element, otherwise slang will report an
-      // error.
-      value = operands.front();
-    } else {
-      value = moore::ConcatRefOp::create(builder, loc, operands).getResult();
     }
 
     if (expr.getSliceSize() == 0) {
-      return value;
+      if (operands.size() == 1)
+        return operands.front();
+      return moore::ConcatRefOp::create(builder, loc, operands);
     }
 
-    auto type = cast<moore::IntType>(
-        cast<moore::RefType>(value.getType()).getNestedType());
-    SmallVector<Value> slicedOperands;
-    auto widthSum = type.getWidth();
-    auto domain = type.getDomain();
-    auto iterMax = widthSum / expr.getSliceSize();
-    auto remainSize = widthSum % expr.getSliceSize();
-
-    for (size_t i = 0; i < iterMax; i++) {
-      auto extractResultType = moore::RefType::get(moore::IntType::get(
-          context.getContext(), expr.getSliceSize(), domain));
-
-      auto extracted = moore::ExtractRefOp::create(
-          builder, loc, extractResultType, value, i * expr.getSliceSize());
-      slicedOperands.push_back(extracted);
-    }
-    // Handle other wire
-    if (remainSize) {
-      auto extractResultType = moore::RefType::get(
-          moore::IntType::get(context.getContext(), remainSize, domain));
-
-      auto extracted =
-          moore::ExtractRefOp::create(builder, loc, extractResultType, value,
-                                      iterMax * expr.getSliceSize());
-      slicedOperands.push_back(extracted);
+    unsigned width = 0;
+    for (Value operand : operands) {
+      auto operandWidth =
+          cast<moore::RefType>(operand.getType()).getNestedType().getBitSize();
+      if (!operandWidth)
+        return {};
+      width += *operandWidth;
     }
 
-    return moore::ConcatRefOp::create(builder, loc, slicedOperands);
+    SmallVector<Value> slices;
+    unsigned numSlices = width / expr.getSliceSize();
+    unsigned remainder = width % expr.getSliceSize();
+    for (unsigned i = 0; i < numSlices; ++i) {
+      auto slice = sliceStreamingRefs(
+          context, loc, operands, i * expr.getSliceSize(), expr.getSliceSize());
+      if (!slice)
+        return {};
+      slices.push_back(slice);
+    }
+    if (remainder) {
+      auto slice = sliceStreamingRefs(
+          context, loc, operands, numSlices * expr.getSliceSize(), remainder);
+      if (!slice)
+        return {};
+      slices.push_back(slice);
+    }
+    return moore::ConcatRefOp::create(builder, loc, slices);
   }
 
   /// Emit an error for all other expressions.

--- a/test/Conversion/ImportVerilog/basic.sv
+++ b/test/Conversion/ImportVerilog/basic.sv
@@ -801,6 +801,8 @@ module Expressions;
   int a, b, c;
   // CHECK: %j = moore.variable : <i32>
   int j;
+  // CHECK: %up = moore.variable : <uarray<4 x l11>>
+  logic [10:0] up [3:0];
   // CHECK: %p1 = moore.variable : <l11>
   // CHECK: %p2 = moore.variable : <l11>
   // CHECK: %p3 = moore.variable : <l11>
@@ -832,12 +834,20 @@ module Expressions;
   logic [-31:0] vec_1b;
   // CHECK: %vec_2 = moore.variable : <l32>
   logic [0:31] vec_2;
+  // CHECK: %vec_3 = moore.variable : <l16>
+  logic [15:0] vec_3;
   // CHECK: %vec_4 = moore.variable : <l32>
   logic [31:0] vec_4;
   // CHECK: %vec_5 = moore.variable : <l48>
   logic [47:0] vec_5;
   // CHECK: %arr = moore.variable : <uarray<3 x uarray<6 x i4>>>
   bit [4:1] arr [1:3][2:7];
+  // CHECK: %arr_1 = moore.variable : <uarray<64 x l1>>
+  logic arr_1 [63:0];
+  // CHECK: %ascending_arr = moore.variable : <uarray<4 x l8>>
+  logic [7:0] ascending_arr [0:3];
+  // CHECK: %ascending_vec = moore.variable : <l32>
+  logic [31:0] ascending_vec;
 
   // CHECK: %struct0 = moore.variable : <struct<{a: i32, b: i32}>>
   struct packed {
@@ -847,6 +857,10 @@ module Expressions;
   struct {
     int a, b;
   } ustruct0;
+  // CHECK: %uunion0 = moore.variable : <uunion<{a: i32, b: i32}>>
+  union {
+    int a, b;
+  } uunion0;
   // CHECK: %struct1 = moore.variable : <struct<{c: struct<{a: i32, b: i32}>, d: struct<{a: i32, b: i32}>}>>
   struct packed {
     struct packed {
@@ -1026,6 +1040,15 @@ module Expressions;
     // CHECK: [[TMP2:%.+]] = moore.constant 31 : i96
     // CHECK: moore.blocking_assign [[TMP1]], [[TMP2]] : i96
     {>>{ a, b, c }} = 100'b11111;
+    // CHECK: [[TMP1:%.+]] = moore.concat_ref %p1, %p2, %p3, %p4 : (!moore.ref<l11>, !moore.ref<l11>, !moore.ref<l11>, !moore.ref<l11>) -> <l44>
+    // CHECK: [[TMP2:%.+]] = moore.read %up : <uarray<4 x l11>>
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP2]] from 3 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP4:%.+]] = moore.extract [[TMP2]] from 2 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP5:%.+]] = moore.extract [[TMP2]] from 1 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP6:%.+]] = moore.extract [[TMP2]] from 0 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP7:%.+]] = moore.concat [[TMP3]], [[TMP4]], [[TMP5]], [[TMP6]] : (!moore.l11, !moore.l11, !moore.l11, !moore.l11) -> l44
+    // CHECK: moore.blocking_assign [[TMP1]], [[TMP7]] : l44
+    {>>{p1, p2, p3, p4}} = up;
     // CHECK: [[TMP1:%.+]] = moore.extract_ref %a from 0 : <i32> -> <i8>
     // CHECK: [[TMP2:%.+]] = moore.extract_ref %a from 8 : <i32> -> <i8>
     // CHECK: [[TMP3:%.+]] = moore.extract_ref %a from 16 : <i32> -> <i8>
@@ -1034,6 +1057,71 @@ module Expressions;
     // CHECK: [[TMP6:%.+]] = moore.constant 1 : i32
     // CHECK: moore.blocking_assign [[TMP5]], [[TMP6]] : i32
     {<< byte {a}} = 32'b1;
+    // CHECK: [[TMP1:%.+]] = moore.read %vec_3 : <l16>
+    // CHECK: [[TMP2:%.+]] = moore.read %arr_1 : <uarray<64 x l1>>
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP2]] from 0 : uarray<64 x l1> -> uarray<16 x l1>
+    // CHECK: [[TMP4:%.+]] = moore.extract [[TMP3]] from 15 : uarray<16 x l1> -> l1
+    // CHECK: [[TMP5:%.+]] = moore.extract [[TMP3]] from 14 : uarray<16 x l1> -> l1
+    // CHECK: moore.concat [[TMP1]], [[TMP4]], [[TMP5]],
+    // CHECK: [[TMP6:%.+]] = moore.concat %{{.+}} : (!moore.l8, !moore.l8, !moore.l8, !moore.l8) -> l32
+    // CHECK: moore.blocking_assign %vec_1, [[TMP6]] : l32
+    vec_1 = {<<byte{vec_3, arr_1 with [15:0]}};
+    // CHECK: [[TMP1:%.+]] = moore.extract_ref %arr_1 from 0 : <uarray<64 x l1>> -> <uarray<16 x l1>>
+    // CHECK: [[TMP2:%.+]] = moore.extract_ref [[TMP1]] from 15 : <uarray<16 x l1>> -> <l1>
+    // CHECK: [[TMP3:%.+]] = moore.extract_ref [[TMP1]] from 14 : <uarray<16 x l1>> -> <l1>
+    // CHECK: [[STREAM_REF:%.+]] = moore.concat_ref %{{.+}} : (!moore.ref<l8>, !moore.ref<l8>, !moore.ref<l8>, !moore.ref<l8>) -> <l32>
+    // CHECK: [[RHS:%.+]] = moore.read %vec_1 : <l32>
+    // CHECK: moore.blocking_assign [[STREAM_REF]], [[RHS]] : l32
+    {<<byte{vec_3, arr_1 with [15:0]}} = vec_1;
+    // CHECK: [[TMP1:%.+]] = moore.read %ascending_arr : <uarray<4 x l8>>
+    // CHECK: [[TMP2:%.+]] = moore.extract [[TMP1]] from 3 : uarray<4 x l8> -> l8
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP1]] from 2 : uarray<4 x l8> -> l8
+    // CHECK: [[TMP4:%.+]] = moore.extract [[TMP1]] from 1 : uarray<4 x l8> -> l8
+    // CHECK: [[TMP5:%.+]] = moore.extract [[TMP1]] from 0 : uarray<4 x l8> -> l8
+    // CHECK: [[TMP6:%.+]] = moore.concat [[TMP2]], [[TMP3]], [[TMP4]], [[TMP5]] : (!moore.l8, !moore.l8, !moore.l8, !moore.l8) -> l32
+    // CHECK: moore.blocking_assign %ascending_vec, [[TMP6]] : l32
+    ascending_vec = {>>{ascending_arr}};
+    // CHECK: [[TMP1:%.+]] = moore.extract_ref %ascending_arr from 3 : <uarray<4 x l8>> -> <l8>
+    // CHECK: [[TMP2:%.+]] = moore.extract_ref %ascending_arr from 0 : <uarray<4 x l8>> -> <l8>
+    // CHECK: [[TMP3:%.+]] = moore.extract_ref [[TMP2]] from 0 : <l8> -> <l8>
+    // CHECK: [[TMP4:%.+]] = moore.extract_ref [[TMP1]] from 0 : <l8> -> <l8>
+    // CHECK: [[TMP5:%.+]] = moore.concat_ref %{{.+}} : (!moore.ref<l8>, !moore.ref<l8>, !moore.ref<l8>, !moore.ref<l8>) -> <l32>
+    // CHECK: [[TMP6:%.+]] = moore.read %ascending_vec : <l32>
+    // CHECK: moore.blocking_assign [[TMP5]], [[TMP6]] : l32
+    {<<byte{ascending_arr}} = ascending_vec;
+    // CHECK: [[TMP1:%.+]] = moore.concat_ref %{{.+}} : (!moore.ref<l8>, !moore.ref<l8>, !moore.ref<l8>, !moore.ref<l8>) -> <l32>
+    // CHECK: [[TMP2:%.+]] = moore.read %up : <uarray<4 x l11>>
+    // CHECK: [[TMP3:%.+]] = moore.extract [[TMP2]] from 3 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP4:%.+]] = moore.extract [[TMP2]] from 2 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP5:%.+]] = moore.extract [[TMP2]] from 1 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP6:%.+]] = moore.extract [[TMP2]] from 0 : uarray<4 x l11> -> l11
+    // CHECK: [[TMP7:%.+]] = moore.concat [[TMP3]], [[TMP4]], [[TMP5]], [[TMP6]] : (!moore.l11, !moore.l11, !moore.l11, !moore.l11) -> l44
+    // CHECK: [[TMP8:%.+]] = moore.extract [[TMP7]] from 12 : l44 -> l32
+    // CHECK: moore.blocking_assign [[TMP1]], [[TMP8]] : l32
+    {>>{ascending_arr}} = up;
+    // CHECK: [[TMP1:%.+]] = moore.read %ustruct0 : <ustruct<{a: i32, b: i32}>>
+    // CHECK: [[TMP2:%.+]] = moore.struct_extract [[TMP1]], "a" : ustruct<{a: i32, b: i32}> -> i32
+    // CHECK: [[TMP3:%.+]] = moore.struct_extract [[TMP1]], "b" : ustruct<{a: i32, b: i32}> -> i32
+    // CHECK: [[TMP4:%.+]] = moore.read %a : <i32>
+    // CHECK: [[TMP5:%.+]] = moore.concat [[TMP2]], [[TMP3]], [[TMP4]] : (!moore.i32, !moore.i32, !moore.i32) -> i96
+    // CHECK: moore.blocking_assign %yy, [[TMP5]] : i96
+    yy = {>>{ustruct0, a}};
+    // CHECK: [[TMP1:%.+]] = moore.struct_extract_ref %ustruct0, "a" : <ustruct<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[TMP2:%.+]] = moore.struct_extract_ref %ustruct0, "b" : <ustruct<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[TMP3:%.+]] = moore.concat_ref [[TMP1]], [[TMP2]], %a : (!moore.ref<i32>, !moore.ref<i32>, !moore.ref<i32>) -> <i96>
+    // CHECK: [[TMP4:%.+]] = moore.read %yy : <i96>
+    // CHECK: moore.blocking_assign [[TMP3]], [[TMP4]] : i96
+    {>>{ustruct0, a}} = yy;
+    // CHECK: [[TMP1:%.+]] = moore.read %uunion0 : <uunion<{a: i32, b: i32}>>
+    // CHECK: [[TMP2:%.+]] = moore.union_extract [[TMP1]], "a" : uunion<{a: i32, b: i32}> -> i32
+    // CHECK: [[TMP3:%.+]] = moore.int_to_logic [[TMP2]] : i32
+    // CHECK: moore.blocking_assign %vec_1, [[TMP3]] : l32
+    vec_1 = {>>{uunion0}};
+    // CHECK: [[TMP1:%.+]] = moore.union_extract_ref %uunion0, "a" : <uunion<{a: i32, b: i32}>> -> <i32>
+    // CHECK: [[TMP2:%.+]] = moore.read %vec_1 : <l32>
+    // CHECK: [[TMP3:%.+]] = moore.logic_to_int [[TMP2]] : l32
+    // CHECK: moore.blocking_assign [[TMP1]], [[TMP3]] : i32
+    {>>{uunion0}} = vec_1;
     // CHECK: [[TMP1:%.+]] = moore.constant 0 : i1
     // CHECK: [[TMP2:%.+]] = moore.concat [[TMP1]] : (!moore.i1) -> i1
     // CHECK: moore.replicate [[TMP2]] : i1 -> i32


### PR DESCRIPTION
This addresses issue #11028 by adding support for streaming fixed-size aggregates as specified by IEEE 1800-2023 section 11.4.14.

This adds support for:

- Fixed-size unpacked arrays
- Unpacked structs
- Untagged unpacked unions

Packed types remain supported.

The following remain unsupported:

- Dynamic arrays
- Queues
- Associative arrays
- Strings
- Class handles
- Tagged unions

When a streaming operator is used on the RHS:
Recursively flatten its aggregate operands into packed leaves and concatenate them in streaming order.

When a streaming operator is used on the LHS:
Recursively flatten aggregate references into packed references. Construct streaming slices from these references while avoiding `extract_ref` on `concat_ref` results.

Add/restore tests to `basic.sv` covering:

- Fixed-size unpacked arrays, structs, and unions
- Ascending array ranges
- Width truncation
- Slices spanning multiple elements

Fixes #11028

<!--

If AI tools were used, ensure this pull request complies with the
[CIRCT AI Tool Use Policy](https://github.com/llvm/circt/blob/main/docs/AIToolPolicy.md),
including the requirements for human review, transparency, and accountability.

Using an LLM is allowed, but copy-pasting an LLM-generated PR description is heavily discouraged.

Include the following message trailer in commits and Pull Requests when AI tools were used:
Assisted-by: <tool>:<model>

-->
