### PR TITLE
[Arc] Remove i0 state types in RemoveI0Types

### DIFF
--- a/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
+++ b/lib/Dialect/Arc/Transforms/RemoveI0Types.cpp
@@ -290,10 +290,15 @@ void RemoveI0TypesPass::runOnOperation() {
       });
   converter.addConversion(
       [&converter](arc::StateType type, SmallVectorImpl<Type> &types) {
-        if (failed(converter.convertType(type.getType(), types)))
+        SmallVector<Type> innerTypes;
+        if (failed(converter.convertType(type.getType(), innerTypes)))
           return failure();
-        assert(types.size() == 1);
-        types[0] = arc::StateType::get(types[0]);
+        // A state of an i0 type holds no data. Remove the state type as well so
+        // that the ops allocating, reading, or writing it are erased.
+        if (innerTypes.empty())
+          return success();
+        assert(innerTypes.size() == 1);
+        types.push_back(arc::StateType::get(innerTypes[0]));
         return success();
       });
 

--- a/test/Dialect/Arc/remove-i0-types.mlir
+++ b/test/Dialect/Arc/remove-i0-types.mlir
@@ -214,3 +214,18 @@ func.func @AggregateConstantStaysAggregate() -> !hw.array<2x!hw.array<1xi32>> {
   %0 = hw.aggregate_constant [[0 : i32], [1 : i32]] : !hw.array<2x!hw.array<1xi32>>
   return %0 : !hw.array<2x!hw.array<1xi32>>
 }
+
+// A state of an i0 type holds no data. It is removed together with its reads and
+// writes, while states of other types are left untouched.
+// CHECK-LABEL: func.func @StateI0(%arg0: !arc.state<i32>)
+// CHECK-NEXT:    [[V:%.+]] = arc.state_read %arg0 : <i32>
+// CHECK-NEXT:    arc.state_write %arg0 = [[V]] : <i32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @StateI0(%a: !arc.state<i0>, %b: !arc.state<i32>) {
+  %0 = arc.state_read %a : <i0>
+  arc.state_write %a = %0 : <i0>
+  %1 = arc.state_read %b : <i32>
+  arc.state_write %b = %1 : <i32>
+  return
+}

--- a/test/arcilator/i0.mlir
+++ b/test/arcilator/i0.mlir
@@ -1,0 +1,14 @@
+// RUN: arcilator %s
+
+// Modules with i0 ports and i0 registers must make it through the pipeline:
+// the i0 values turn into i0 states, which must be removed like any other i0.
+
+hw.module @UnusedI0Input(in %clock: !seq.clock, in %a: i0, in %x: i8, out y: i8) {
+  %reg = seq.compreg %x, %clock : i8
+  hw.output %reg : i8
+}
+
+hw.module @I0Register(in %clock: !seq.clock, in %a: i0, out b: i0) {
+  %reg = seq.compreg %a, %clock : i0
+  hw.output %reg : i0
+}


### PR DESCRIPTION
`RemoveI0Types` converts `!arc.state<T>` by converting `T` and then asserting that exactly one type comes back. When `T` is `i0` the inner conversion correctly returns no types, so the assertion fires:

```
arcilator: .../lib/Dialect/Arc/Transforms/RemoveI0Types.cpp:295: ... Assertion `types.size() == 1' failed.
```

Any module with an `i0` port or an `i0` register reaches this path. A minimal reproducer is a single unused `i0` input:

```mlir
hw.module @top(in %clock : !seq.clock, in %d : i0, in %x : i8, out y : i8) {
  %s = seq.compreg %x, %clock : i8
  hw.output %s : i8
}
```

In practice this hits every design produced by `lower-handshake-to-hw` for control-only (`none`) channels, so such designs cannot be simulated with arcilator at all.

This change removes the state type as well when its inner type is removed. The ops that allocate, read, or write such a state then have an empty converted operand (or fewer results) and are erased by the existing `ConvertGeneric` pattern, the same way other `i0` values are handled.

Tests:
- `test/Dialect/Arc/remove-i0-types.mlir`: an `!arc.state<i0>` next to an `!arc.state<i32>`; the `i0` state and its read/write are removed, the `i32` ones are kept.
- `test/arcilator/i0.mlir`: pipeline test with an unused `i0` input port and an `i0` register.

Verified on an arm64 cross-build at eade0de61: `test/Dialect/Arc` and `test/arcilator` pass (63/63), and a handshake-lowered design that previously aborted now compiles and simulates with correct results.

